### PR TITLE
Corrige plasma cutter e adiciona canos ao acesso da IA

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -5,6 +5,7 @@
   placement:
     mode: SnapgridCenter
   components:
+  - type: StationAiWhitelist #Gabystation
   - type: AtmosDevice
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -5,6 +5,7 @@
   placement:
     mode: SnapgridCenter
   components:
+    - type: StationAiWhitelist #Gabystation
     - type: AtmosDevice
     - type: Tag
       tags:

--- a/Resources/Prototypes/_Gabystation/Entities/Objects/Weapons/Guns/Pistol/PlasmaCutter.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Objects/Weapons/Guns/Pistol/PlasmaCutter.yml
@@ -96,7 +96,7 @@
       collection: WelderOff
   - type: Item
     sprite: _Gabystation/Objects/Weapons/Guns/Pistol/PlasmaCutter.rsi
-    size: 10
+    size: Normal
   - type: Gun
     fireRate: 2
     selectedMode: SemiAuto


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Esse PR faz exatamente o que está escrito no titulo.

O plasma cutter estava bugado devido o modo como o size estava escrito.

Permitir que a IA consiga mexer nos canos da atmos foi sugestão da Ichai, vai ser util em turnos em que a atmos estiver meio incompetente ou ausente. 
