### PR TITLE
Remove o implante de blueshield que te deleta do jogo da mochila dele

### DIFF
--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -57,5 +57,5 @@
     back:
     - BoxSurvivalSlots
     - Flash
-    - BluespaceLifelineImplanter
+  # - BluespaceLifelineImplanter //gabystation: blueshields keep deleting themselves
     - SecHypo


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Um admin ainda pode spawnar, mas o blueshield não spawna mais com ele.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl: joshepvodka
- remove: Remove o implante do Blueshield.

