### PR TITLE
Rebalança os gamemodes e remove revs

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,16 +1,16 @@
 - type: weightedRandom # All dual antag gamemodes are goobstation
   id: Secret
   weights:
-    Traitor: 0.40 # Goobstation
-    Changeling: 0.11 # Goobstation unique antag
+    Traitor: 0.35 # Goobstation
+    Changeling: 0.30 # Goobstation unique antag
     Traitorling: 0.05 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
     Nukeops: 0.20 # Goobstation
     NukeTraitor: 0.01
     NukeLing: 0.01
-    Revolutionary: 0.10 # Maybe 0.04 after wiz/cult? Goobstation
-    RevTraitor: 0.02
-    RevLing: 0.01
-    Zombie: 0.04 # Maybe 0.03 after wiz/cult? Goobstation
+  #  Revolutionary: 0.10 # Maybe 0.04 after wiz/cult? Goobstation
+  #  RevTraitor: 0.02
+  #  RevLing: 0.01
+    Zombie: 0.10 # Maybe 0.03 after wiz/cult? Goobstation
     Survival: 0.05 # Maybe 0.03 after wiz/cult? aGoobstation
   #  KesslerSyndrome: 0.01 # Goobstation - remove kessler
   # Wizard: 0.05


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Remove revs como gamemode aleatório do secret.
Os gamemodes agora acontecem:

Traidores: levemente mais que 3 vezes a cada 10 rounds.
Changeling: 3 vezes a cada 10 rounds.
Nukies: 2 vezes a cada 10 rounds.
Zombies: 1 vez a cada 10 rounds.
Traidor com changeling: 1 vez a cada 20 rounds.
Sobrevivência: 1 vez a cada 20 rounds.
Nukes com traidor ou changeling: 1 vez a cada 100 rounds.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: joshepvodka
- remove: Revolucionários foram removidos do modo Secret.
- tweak: Modo de traidores é levemente menos frequente. Todos os outros modos são levemente mais frequentes.