### PR TITLE
Popula o campo `id` das entradas do changelog

### DIFF
--- a/Resources/Changelog/GabyChangelog.yml
+++ b/Resources/Changelog/GabyChangelog.yml
@@ -101,11 +101,9 @@ Entries:
   changes:
     - type: Add
       message: Changelog automatica!
-  id: .nan
   time: '2025-01-08T01:17:03.0000000+00:00'
 - author: AgentePanela
   changes:
     - type: Add
       message: Revert "Reativar o cog"
-  id: .nan
   time: '2025-01-08T01:30:48.0000000+00:00'

--- a/Resources/Changelog/GabyChangelog.yml
+++ b/Resources/Changelog/GabyChangelog.yml
@@ -1,5 +1,3 @@
-Name: GabyStation
-Order: -2
 Entries:
 - author: Dreykor
   time: '2024-11-6T12:01:00.0000000+00:00'
@@ -7,52 +5,62 @@ Entries:
   changes:
     - type: Add
       message: Adiciona o changelog do Gaby Station!
+  id: 0
 - author: cosmosgc
   time: '2024-11-18T12:01:00.0000000+00:00'
   url: https://github.com/Scomossor/Gaby-Station/pull/4
   changes:
     - type: Add
       message: Adiciona canvas para desenho
+  id: 1
 - author: AgentePanela
   time: '2024-11-18T12:01:00.0000000+00:00'
   changes:
     - type: Add
       message: Tradução ao lobby
+  id: 2
 - author: AgentePanela
   time: '2024-11-18T12:01:00.0000000+00:00'
   changes:
     - type: Add
       message: Console de energia portatil
+  id: 3
 - author: AgentePanela
   time: '2024-11-18T12:01:00.0000000+00:00'
   changes:
     - type: Tweak
       message: Revenant
+  id: 4
 - author: AgentePanela
   time: '2024-11-18T12:01:00.0000000+00:00'
   changes:
     - type: Add
       message: Melhorias no console de comunicações
+  id: 5
 - author: Zeroblacck
   time: '2024-11-18T12:01:00.0000000+00:00'
   changes:
     - type: Add
       message: Mais tradução para o jogo
+  id: 6
 - author: JoseFernando-TZ
   time: '2024-11-18T12:01:00.0000000+00:00'
   changes:
     - type: Add
       message: Mais tradução para o jogo
+  id: 7
 - author: Dreykor
   time: '2024-11-18T20:15:00.0000000+00:00'
   changes:
     - type: Add
       message: Adiciona Cabelo e Barba para a raça Moth!
+  id: 8
 - author: Dreykor
   time: '2024-11-20T10:26:00.0000000+00:00'
   changes:
     - type: Fix
       message: Corrige a falta de cabelo e barba para Moth!
+  id: 9
 - author: Day-OS
   time: '2024-11-21T12:01:00.0000000+00:00'
   url: >-
@@ -60,6 +68,7 @@ Entries:
   changes:
     - type: Add
       message: Cartas! 🃏 (cherry-picked)
+  id: 10
 - author: Day-OS
   time: '2024-11-21T12:01:00.0000000+00:00'
   url: >-
@@ -67,43 +76,52 @@ Entries:
   changes:
     - type: Add
       message: Vestidos e Ternos! (cherry-picked)
+  id: 11
 - author: Day-OS
   time: '2024-11-21T12:01:00.0000000+00:00'
   changes:
     - type: Add
       message: Muitas roupas novas (cherry-picked)
+  id: 12
 - author: AgentePanela
   time: '2024-12-08T12:01:00.0000000+00:00'
   changes:
     - type: Add
       message: Impressora de documentos (cherry-picked)
+  id: 13
 - author: Lenhare
   time: '2024-12-22T21:30:00.0000000+00:00'
   changes:
     - type: Add
       message: Tradução inicial do "Guide Book".
+  id: 14
 - author: Zequin
   time: '2024-12-22T21:30:00.0000000+00:00'
   changes:
     - type: Add
       message: Tradução inicial do "Guide Book".
+  id: 15
 - author: AgentePanela
   time: '2025-01-02T21:30:00.0000000+00:00'
   changes:
     - type: Tweak
       message: Sotaquee Ohio agora é Xique-Xique.
+  id: 16
 - author: AgentePanela
   time: '2025-01-02T21:30:00.0000000+00:00'
   changes:
     - type: Add
       message: Pronome neutro.
+  id: 17
 - author: Piras314
   changes:
     - type: Add
       message: Changelog automatica!
   time: '2025-01-08T01:17:03.0000000+00:00'
+  id: 18
 - author: AgentePanela
   changes:
     - type: Add
       message: Revert "Reativar o cog"
   time: '2025-01-08T01:30:48.0000000+00:00'
+  id: 19

--- a/Tools/changelog/generate_ids.js
+++ b/Tools/changelog/generate_ids.js
@@ -1,0 +1,24 @@
+const fs = require("fs");
+const yaml = require("js-yaml");
+
+const filePath = "../../Resources/Changelog/GabyChangelog.yml"
+
+function main() {
+    const file = fs.readFileSync(filePath, "utf-8");
+
+    const data = yaml.load(file);
+    const entries = data && data.Entries ? Array.from(data.Entries) : [];
+
+    // entries.sort((a, b) => (new Date(b.time)) - (new Date(a.time)));
+
+    for (const i in entries) {
+        entries[i].id = Number(i);
+    }
+
+    fs.writeFileSync(
+        filePath,
+        "Entries:\n" + yaml.dump(data.Entries, { indent: 2 }).replace(/^---/, "")
+    )
+}
+
+main()


### PR DESCRIPTION
## Sobre o PR
Resolve o crash no cliente:

```
Unhandled exception. System.FormatException: The input string '.nan' was not in a correct format.
   at System.Number.ThrowFormatException[TChar](ReadOnlySpan`1 value)
   at System.Int32.Parse(ReadOnlySpan`1 s, NumberStyles style, IFormatProvider provider)
   at Robust.Shared.Utility.Parse.Int32(ReadOnlySpan`1 text, NumberStyles style) in /media/felipe25f/Storage/developer/Gaby-Station/RobustToolbox/Robust.Shared/Utility/Parse.cs:line 64
   at Robust.Shared.Serialization.TypeSerializers.Implementations.Primitive.IntSerializer.Read(ISerializationManager serializationManager, ValueDataNode node, IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext context, InstantiationDelegate`1 instanceProvider) in /media/felipe25f/Storage/developer/Gaby-Station/RobustToolbox/Robust.Shared/Serialization/TypeSerializers/Implementations/Primitive/IntSerializer.cs:line 28
   at Robust.Shared.Serialization.Manager.SerializationManager.Read[T,TNode](ITypeReader`2 reader, TNode node, SerializationHookContext hookCtx, ISerializationContext context, InstantiationDelegate`1 instanceProvider, Boolean notNullableOverride) in /media/felipe25f/Storage/developer/Gaby-Station/RobustToolbox/Robust.Shared/Serialization/Manager/SerializationManager.Reading.cs:line 109
   at lambda_method12446(Closure, DataNode, SerializationHookContext, ISerializationContext, InstantiationDelegate`1)
   at Robust.Shared.Serialization.Manager.SerializationManager.Read[T](DataNode node, SerializationHookContext hookCtx, ISerializationContext context, InstantiationDelegate`1 instanceProvider, Boolean notNullableOverride) in /media/felipe25f/Storage/developer/Gaby-Station/RobustToolbox/Robust.Shared/Serialization/Manager/SerializationManager.Reading.cs:line 82
<bem maior, to omitindo o resto>
```

## Detalhes técnicos

O crash ocorre por que onde deveria ter um número, em `Resources/Changelog/GabyChangelog.yml` no campo `id`, tem um `.nan`. Os `id`'s são um incremento do anterior, então, ele tentou incrementar o anterior, que não existe, e resultou em `NaN`.

A solução que, eu e Panela, pensamos é adicionar o campo `id` em cada entrada do changelog.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
Não há mudanças para os jogadores.