### PR TITLE
Diminui a quantidade de eventos no secret

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -188,7 +188,7 @@
     - Nukeops
     - SubGamemodesRule
     - BasicStationEventScheduler
-    #- MeteorSwarmScheduler #gabystation edit
+    - MeteorSwarmScheduler
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
 

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -86,7 +86,7 @@
   description: extended-description
   rules:
   - BasicStationEventScheduler
-  #- MeteorSwarmScheduler #gabystation edit
+  - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
 

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -6,7 +6,7 @@
   showInVote: true # Gabystation - melhor que dynamic
   description: survival-description
   rules:
-    - MeteorSwarmScheduler
+    #- MeteorSwarmScheduler #gabystation edit
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
 
@@ -69,7 +69,7 @@
     - BasicStationEventScheduler
     - KesslerSyndromeScheduler
     - MeteorSwarmMildScheduler
-    - MeteorSwarmScheduler
+    #- MeteorSwarmScheduler #gabystation edit
     - RampingStationEventScheduler
     - SpaceTrafficControlEventScheduler
     - SpaceTrafficControlFriendlyEventScheduler
@@ -86,7 +86,7 @@
   description: extended-description
   rules:
   - BasicStationEventScheduler
-  - MeteorSwarmScheduler
+  #- MeteorSwarmScheduler #gabystation edit
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
 
@@ -112,7 +112,6 @@
   description: secret-description
   rules:
     - Secret
-    - BasicStationEventScheduler
 
 - type: gamePreset
   id: SecretExtended #For Admin Use: Runs Extended but shows "Secret" in lobby.
@@ -123,7 +122,7 @@
   description: secret-description
   rules:
     - BasicStationEventScheduler
-    - MeteorSwarmScheduler
+    #- MeteorSwarmScheduler #gabystation edit
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
 
@@ -161,7 +160,7 @@
     - Traitor
     - SubGamemodesRule
     - BasicStationEventScheduler
-    - MeteorSwarmScheduler
+    #- MeteorSwarmScheduler #gabystation edit
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
 
@@ -189,7 +188,7 @@
     - Nukeops
     - SubGamemodesRule
     - BasicStationEventScheduler
-    - MeteorSwarmScheduler
+    #- MeteorSwarmScheduler #gabystation edit
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
 
@@ -206,7 +205,7 @@
     - Revolutionary
     - SubGamemodesRule
     - BasicStationEventScheduler
-    - MeteorSwarmScheduler
+    #- MeteorSwarmScheduler #gabystation edit
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
 
@@ -224,7 +223,7 @@
   rules:
   - Zombie
   - BasicStationEventScheduler
-  - MeteorSwarmScheduler
+  #- MeteorSwarmScheduler #gabystation edit
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
 

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -69,7 +69,7 @@
     - BasicStationEventScheduler
     - KesslerSyndromeScheduler
     - MeteorSwarmMildScheduler
-    #- MeteorSwarmScheduler #gabystation edit
+    - MeteorSwarmScheduler
     - RampingStationEventScheduler
     - SpaceTrafficControlEventScheduler
     - SpaceTrafficControlFriendlyEventScheduler

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -6,7 +6,7 @@
   showInVote: true # Gabystation - melhor que dynamic
   description: survival-description
   rules:
-    #- MeteorSwarmScheduler #gabystation edit
+    - MeteorSwarmScheduler
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
 

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -160,7 +160,7 @@
     - Traitor
     - SubGamemodesRule
     - BasicStationEventScheduler
-    #- MeteorSwarmScheduler #gabystation edit
+    - MeteorSwarmScheduler
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
 

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -205,7 +205,7 @@
     - Revolutionary
     - SubGamemodesRule
     - BasicStationEventScheduler
-    #- MeteorSwarmScheduler #gabystation edit
+    - MeteorSwarmScheduler
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
 

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -122,7 +122,7 @@
   description: secret-description
   rules:
     - BasicStationEventScheduler
-    #- MeteorSwarmScheduler #gabystation edit
+    - MeteorSwarmScheduler
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
 

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -223,7 +223,7 @@
   rules:
   - Zombie
   - BasicStationEventScheduler
-  #- MeteorSwarmScheduler #gabystation edit
+  - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
 

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -14,7 +14,7 @@
     # RevTraitor: 0.02 # Gabystation - Nerfa chances de rev
     # RevLing: 0.01 # Gabystation - Nerfa chances de rev
     Zombie: 0.08 # Gabystation - Aumenta zumbi
-    #Survival: 0.01 # Gabystation - Aumenta survival
+    #Survival: 0.01 # Gabystation - Desativa survival
     Blob: 0.05 # Gabystation - Adiciona blob ao secreto
     Abductor: 0.04
     #KesslerSyndrome: 0.01 # Goobstation - remove kessler

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -14,13 +14,13 @@
     # RevTraitor: 0.02 # Gabystation - Nerfa chances de rev
     # RevLing: 0.01 # Gabystation - Nerfa chances de rev
     Zombie: 0.08 # Gabystation - Aumenta zumbi
-    Survival: 0.01 # Gabystation - Aumenta survival
+    #Survival: 0.01 # Gabystation - Aumenta survival
     Blob: 0.05 # Gabystation - Adiciona blob ao secreto
     Abductor: 0.04
-    Honkops: 0.02
     #KesslerSyndrome: 0.01 # Goobstation - remove kessler
     #Wizard: 0.05 # Esperando ser jogavel
     #Cult: 0.05 # Esperando o port
+    Extended: 0.01 #arruma o fallback sempre ser survival
 
 
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
O que o titulo diz. No secret tem tanto eventos por causa que se nenhum antagonista é escolhido, o jogo sempre escolhia Survival. Agora ele escolhe extended em vez de survival se não tiver player o suficiente na partida.
Adicionalmente o jogo agora só roda 1 instancia de BasicStationEventScheaduler em vez de duas.

P.S.: Também tira os meteoros.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Disabled the `MeteorSwarmScheduler` rule across several game presets.
  - Adjusted game mode selections by deactivating the `Survival` option and introducing an `Extended` option for fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->