### PR TITLE
dado do caos PR

### DIFF
--- a/Content.Server/Dice/FateDice/FateDiceComponent.cs
+++ b/Content.Server/Dice/FateDice/FateDiceComponent.cs
@@ -1,0 +1,65 @@
+using Content.Shared.Xenoarchaeology.XenoArtifacts;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
+
+namespace Content.Server.Dice.FateDice;
+
+[RegisterComponent, Access(typeof(FateDiceSystem))]
+public sealed partial class FateDiceComponent : Component
+{
+    /// <summary>
+    /// Last user that interacted with this dice
+    /// </summary>
+    [ViewVariables]
+    public EntityUid LastUser;
+
+    /// <summary>
+    /// List of the effects that this Dice of Fate can trigger.
+    /// </summary>
+    [DataField("effects", customTypeSerializer: typeof(PrototypeIdListSerializer<ArtifactEffectPrototype>), required: true), ViewVariables]
+    public List<string> Effects = new();
+
+    /// <summary>
+    /// The radius of the area for the boo event
+    /// </summary>
+    [DataField]
+    public float BooRadius = 4f;
+
+    /// <summary>
+    /// The time of the entity to be deleted in seconds
+    /// after it is completely been used.
+    /// </summary>
+    [DataField]
+    public float TimeToDelete = 2f;
+
+    /// <summary>
+    /// The time in seconds to the entity effect be activated
+    // after the dice is rolled.
+    /// </summary>
+    [DataField]
+    public float TimeToActivate = 1f;
+
+    /// <summary>
+    /// How many times the dice can be rolled,
+    /// if <= 0 the dice is replaced with
+    /// prototype specified by ´´toReplace´´.
+    /// </summary>
+    [DataField]
+    public int RemainingUses = 1;
+
+    /// <summary>
+    /// Prototype to replace the
+    /// dice of fate when used
+    /// up.
+    /// </summary>
+    [DataField("toReplace")]
+    public string ToReplace = "Ash";
+
+    [DataField]
+    public string DeletedSound = "/Audio/Magic/blink.ogg";
+
+    // component state variables
+    public TimeSpan? DelTime = null; // delay to delete the dice
+    public TimeSpan? ActTime = null; // delay to activate the dice
+    public int? LastRolledNumber = null;
+    public bool IsOnCooldown = false;
+}

--- a/Content.Server/Dice/FateDice/FateDiceSystem.cs
+++ b/Content.Server/Dice/FateDice/FateDiceSystem.cs
@@ -1,0 +1,212 @@
+using System.Linq;
+using Content.Server.Ghost;
+using Content.Server.Light.Components;
+using Content.Server.Xenoarchaeology.XenoArtifacts.Events;
+using Content.Shared.Coordinates;
+using Content.Shared.Dice;
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Item;
+using Content.Shared.Xenoarchaeology.XenoArtifacts;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Timing;
+
+namespace Content.Server.Dice.FateDice;
+
+public sealed class FateDiceSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly IComponentFactory _componentFactory = default!;
+    [Dependency] private readonly ISerializationManager _serialization = default!;
+    [Dependency] private readonly IEntityManager _entity = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly GhostSystem _ghost = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<FateDiceComponent, DiceRollEvent>(OnDiceRoll);
+        SubscribeLocalEvent<FateDiceComponent, GettingPickedUpAttemptEvent>(OnPickupAttempt);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = _entity.EntityQueryEnumerator<FateDiceComponent>();
+        while (query.MoveNext(out var uid, out var dice))
+        {
+            if (dice.ActTime <= _timing.CurTime)
+                ActivateEffect(uid, dice);
+            if (dice.DelTime <= _timing.CurTime)
+                RemoveDice(uid, dice);
+        }
+    }
+
+    // Removes the dice and replaces it with some other entity.
+    private void RemoveDice(EntityUid uid, FateDiceComponent dice)
+    {
+        try
+        {
+            var replaced = SpawnAtPosition(dice.ToReplace, uid.ToCoordinates());
+            _audio.PlayPvs(dice.DeletedSound, replaced);
+        }
+        catch
+        {
+            Log.Error(string.Format("'{0}' is not a valid entity", dice.ToReplace));
+        }
+
+        QueueDel(uid);
+    }
+
+    // Does the activation of the effect.
+    private void ActivateEffect(EntityUid uid, FateDiceComponent dice)
+    {
+        // do ghost boo
+        var lights = GetEntityQuery<PoweredLightComponent>();
+        foreach (var light in _lookup.GetEntitiesInRange(uid, dice.BooRadius, LookupFlags.StaticSundries))
+        {
+            if (!lights.HasComponent(light))
+                continue;
+
+            if (!_random.Prob(0.75f))
+                continue;
+
+            _ghost.DoGhostBooEvent(light);
+        }
+
+        // do the artifact activation
+        var ev = new ArtifactActivatedEvent
+        {
+            Activator = dice.LastUser
+        };
+        RaiseLocalEvent(uid, ev, true);
+        dice.ActTime = null;
+
+        RemoveEffectComponentsFromDice(uid, dice);
+        dice.IsOnCooldown = false;
+    }
+
+
+    // This is unshamefully yanked from EnterNode function from ArtifactSystem
+    private void AddEffectComponentsToDice(EntityUid uid, FateDiceComponent dice)
+    {
+        if (dice.LastRolledNumber is null
+            || dice.LastRolledNumber > dice.Effects.Count)
+            return;
+
+        var effectProto = _prototype.Index<ArtifactEffectPrototype>(dice.Effects[(int) dice.LastRolledNumber - 1]);
+        foreach (var (name, entry) in effectProto.Components.Concat(effectProto.PermanentComponents))
+        {
+            var reg = _componentFactory.GetRegistration(name);
+
+            if (EntityManager.HasComponent(uid, reg.Type))
+            {
+                // Don't re-add permanent components unless this is the first time you've entered this node
+                if (effectProto.PermanentComponents.ContainsKey(name))
+                    continue;
+
+                EntityManager.RemoveComponent(uid, reg.Type);
+            }
+
+            var comp = (Component) _componentFactory.GetComponent(reg);
+
+            // TODO: Fix obsolete.
+            comp.Owner = uid;
+
+            var temp = (object) comp;
+            _serialization.CopyTo(entry.Component, ref temp);
+            EntityManager.RemoveComponent(uid, temp!.GetType());
+            EntityManager.AddComponent(uid, (Component) temp!);
+        }
+    }
+
+
+    // This is unshamefully yanked from ExitNode function from ArtifactSystem
+    private void RemoveEffectComponentsFromDice(EntityUid uid, FateDiceComponent dice)
+    {
+        if (dice.LastRolledNumber is null
+        || dice.LastRolledNumber > dice.Effects.Count)
+            return;
+
+        var effect = _prototype.Index<ArtifactEffectPrototype>(dice.Effects[(int) dice.LastRolledNumber - 1]);
+
+        var entityPrototype = MetaData(uid).EntityPrototype;
+        var toRemove = effect.Components.Keys;
+
+        foreach (var name in toRemove)
+        {
+            // if the entity prototype contained the component originally
+            if (entityPrototype?.Components.TryGetComponent(name, out var entry) ?? false)
+            {
+                var comp = (Component) _componentFactory.GetComponent(name);
+
+                // TODO: Fix obsolete.
+                comp.Owner = uid;
+
+                var temp = (object) comp;
+                _serialization.CopyTo(entry, ref temp);
+                EntityManager.RemoveComponent(uid, temp!.GetType());
+                EntityManager.AddComponent(uid, (Component) temp);
+                continue;
+            }
+
+            EntityManager.RemoveComponentDeferred(uid, _componentFactory.GetRegistration(name).Type);
+        }
+    }
+
+    // basically select all components from the effect prototype and apply them directly to the dice.
+    public void OnDiceRoll(EntityUid uid, FateDiceComponent fateDice, DiceRollEvent args)
+    {
+        if (fateDice.RemainingUses <= 0)
+            return;
+
+        fateDice.ActTime = _timing.CurTime + TimeSpan.FromSeconds(fateDice.TimeToActivate);
+        fateDice.LastRolledNumber = args.RolledNumber;
+
+        AddEffectComponentsToDice(uid, fateDice);
+
+        // This is needed for some artifact effects properly work.
+        try
+        {
+            RaiseLocalEvent(uid, new ArtifactNodeEnteredEvent(_random.Next()));
+        }
+        catch { }
+
+        // If the dice is still in the hand of some entity, drop it.
+        if (
+            EntityManager.HasComponent<HandsComponent>(fateDice.LastUser)
+            && _hands.IsHolding(fateDice.LastUser, uid)
+        )
+        {
+            _hands.TryDrop(fateDice.LastUser);
+        }
+
+        fateDice.IsOnCooldown = true;
+
+        fateDice.RemainingUses--;
+
+        // Mark the dice to be deleted if it has no remaining uses
+        if (fateDice.RemainingUses <= 0)
+            fateDice.DelTime = _timing.CurTime + TimeSpan.FromSeconds(fateDice.TimeToDelete);
+    }
+
+    public void OnPickupAttempt(EntityUid uid, FateDiceComponent fateDice, GettingPickedUpAttemptEvent args)
+    {
+        // Prevent entities from picking up the dice while it can't be used.
+        if (fateDice.RemainingUses <= 0 || fateDice.IsOnCooldown)
+        {
+            args.Cancel();
+            return;
+        }
+        fateDice.LastUser = args.User;
+    }
+}

--- a/Content.Server/EntityEffects/Effects/RemoveCogchampAccent.cs
+++ b/Content.Server/EntityEffects/Effects/RemoveCogchampAccent.cs
@@ -1,0 +1,24 @@
+using Content.Server.Atmos.EntitySystems;
+using Content.Shared.Database;
+using Content.Shared.EntityEffects;
+using Content.Shared.Speech.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.EntityEffects.Effects;
+
+/// <summary>
+///     Removes cogchamp's accent from mob.
+/// </summary>
+public sealed partial class RemoveCogchampAccent : EntityEffect
+{
+    public override bool ShouldLog => false;
+
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+        => Loc.GetString("reagent-effect-guidebook-remove-cogchamp-accent", ("chance", Probability));
+
+    public override void Effect(EntityEffectBaseArgs args)
+    {
+        if (args.EntityManager.HasComponent<RatvarianLanguageComponent>(args.TargetEntity))
+            args.EntityManager.RemoveComponent<RatvarianLanguageComponent>(args.TargetEntity);
+    }
+}

--- a/Content.Server/StationEvents/Components/BabelTowerRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/BabelTowerRuleComponent.cs
@@ -1,0 +1,12 @@
+using Content.Server.StationEvents.Events;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Server.StationEvents.Components;
+
+/// <summary>
+/// Make everyone speak in tongues.
+/// (Cogchamp's accent)
+/// </summary>
+[RegisterComponent, Access(typeof(BabelTowerRule))]
+public sealed partial class BabelTowerRuleComponent : Component { }

--- a/Content.Server/StationEvents/Events/BabelTowerRule.cs
+++ b/Content.Server/StationEvents/Events/BabelTowerRule.cs
@@ -1,0 +1,62 @@
+
+using System.Numerics;
+using Content.Server.GameTicking.Rules.Components;
+using Content.Server.Station.Systems;
+using Content.Server.StationEvents.Components;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Humanoid;
+using Content.Shared.Speech.Components;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Spawners;
+using Robust.Shared.Timing;
+
+namespace Content.Server.StationEvents.Events
+{
+
+    public sealed class BabelTowerRule : StationEventSystem<BabelTowerRuleComponent>
+    {
+        [Dependency] private readonly EntityLookupSystem _lookup = default!;
+
+        private readonly HashSet<Entity<HumanoidAppearanceComponent>> _humans = new();
+
+        protected override void Started(EntityUid uid, BabelTowerRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
+        {
+            base.Started(uid, component, gameRule, args);
+
+            // get each and every speaking thing on the station's grid's map
+            // we can only replace humanoids
+            _humans.Clear();
+            _lookup.GetEntitiesOnMap(GameTicker.DefaultMap, _humans);
+
+            // add the Cogchamp accent to them
+            foreach (var (hUid, _) in _humans)
+            {
+                try
+                {
+                    if (!EntityManager.HasComponent<RatvarianLanguageComponent>(hUid))
+                    {
+                        EntityManager.AddComponent<RatvarianLanguageComponent>(hUid);
+                    }
+                } catch { }
+            }
+        }
+
+        protected override void Ended(EntityUid uid, BabelTowerRuleComponent component, GameRuleComponent gameRule, GameRuleEndedEvent args)
+        {
+            // remove the Cogchamp accent from them
+            foreach (var (hUid, _) in _humans)
+            {
+                try
+                {
+                    if (EntityManager.HasComponent<RatvarianLanguageComponent>(hUid))
+                    {
+                        EntityManager.RemoveComponent<RatvarianLanguageComponent>(hUid);
+                    }
+                } catch { }
+            }
+        }
+    }
+}

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.Nodes.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.Nodes.cs
@@ -99,7 +99,8 @@ public sealed partial class ArtifactSystem
         var allEffects = _prototype.EnumeratePrototypes<ArtifactEffectPrototype>()
             .Where(x => _whitelistSystem.IsWhitelistPassOrNull(x.Whitelist, artifact) &&
             _whitelistSystem.IsBlacklistFailOrNull(x.Blacklist, artifact)).ToList();
-        var validDepth = allEffects.Select(x => x.TargetDepth).Distinct().ToList();
+
+        var validDepth = allEffects.Select(x => x.TargetDepth).Where(x => x >= 0).Distinct().ToList();
 
         var weights = GetDepthWeights(validDepth, node.Depth);
         var selectedRandomTargetDepth = GetRandomTargetDepth(weights);

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/GameRuleArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/GameRuleArtifactComponent.cs
@@ -1,0 +1,12 @@
+namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+
+/// <summary>
+/// Artifact that adds a game rule/
+/// does a station event when activated.
+/// </summary>
+[RegisterComponent]
+public sealed partial class GameRuleArtifactComponent : Component
+{
+    [DataField]
+    public List<string> Rules = new();
+}

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/GibArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/GibArtifactComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+
+/// <summary>
+/// Artifact that gibs the entity that activated it.
+/// </summary>
+[RegisterComponent]
+public sealed partial class GibArtifactComponent : Component { }

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/TurnIntoBlobArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/TurnIntoBlobArtifactComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+
+/// <summary>
+/// Artifact that turns person into zombie.
+/// </summary>
+[RegisterComponent]
+public sealed partial class TurnIntoBlobArtifactComponent : Component { }

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/TurnIntoHereticArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/TurnIntoHereticArtifactComponent.cs
@@ -1,10 +1,10 @@
 namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
 
 /// <summary>
-/// Artifact that turns person into traitor.
+/// Artifact that turns person into heretic.
 /// </summary>
 [RegisterComponent]
-public sealed partial class TurnIntoTraitorArtifactComponent : Component
+public sealed partial class TurnIntoHereticArtifactComponent : Component
 {
     [DataField]
     public string? Rule;

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/TurnIntoLingArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/TurnIntoLingArtifactComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+
+/// <summary>
+/// Artifact that turns person into zombie.
+/// </summary>
+[RegisterComponent]
+public sealed partial class TurnIntoLingArtifactComponent : Component { }

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/TurnIntoRevLeaderArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/TurnIntoRevLeaderArtifactComponent.cs
@@ -1,0 +1,11 @@
+namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+
+/// <summary>
+/// Artifact that turns person into a head rev.
+/// </summary>
+[RegisterComponent]
+public sealed partial class TurnIntoRevLeaderArtifactComponent : Component
+{
+    [DataField]
+    public string? Rule;
+}

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/TurnIntoThiefArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/TurnIntoThiefArtifactComponent.cs
@@ -1,0 +1,11 @@
+namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+
+/// <summary>
+/// Artifact that turns person into traitor.
+/// </summary>
+[RegisterComponent]
+public sealed partial class TurnIntoThiefArtifactComponent : Component
+{
+    [DataField]
+    public string? Rule;
+}

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/TurnIntoTraitorArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/TurnIntoTraitorArtifactComponent.cs
@@ -1,0 +1,11 @@
+namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+
+/// <summary>
+/// Artifact that turns person into traitor.
+/// </summary>
+[RegisterComponent]
+public sealed partial class TurnIntoTraitorArtifactComponent : Component
+{
+    [DataField]
+    public string? Rule;
+}

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/TurnIntoZombieArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/TurnIntoZombieArtifactComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+
+/// <summary>
+/// Artifact that turns person into zombie.
+/// </summary>
+[RegisterComponent]
+public sealed partial class TurnIntoZombieArtifactComponent : Component { }

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/GameRuleArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/GameRuleArtifactSystem.cs
@@ -1,0 +1,29 @@
+using Content.Server.GameTicking;
+using Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+using Content.Server.Xenoarchaeology.XenoArtifacts.Events;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Systems;
+using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+
+namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems;
+
+public sealed class GameRuleArtifactSystem : EntitySystem
+{
+    [Dependency] private readonly SharedBodySystem _body = default!;
+    [Dependency] private readonly DamageableSystem _damageableSystem = default!;
+    [Dependency] private readonly GameTicker _ticker = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<GameRuleArtifactComponent, ArtifactActivatedEvent>(OnActivate);
+    }
+
+    private void OnActivate(EntityUid uid, GameRuleArtifactComponent component, ArtifactActivatedEvent args)
+    {
+        foreach (var rule in component.Rules)
+            // TODO: Check if this is a valid game rule.
+            _ticker.AddGameRule(rule);
+    }
+}

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/GibArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/GibArtifactSystem.cs
@@ -1,0 +1,35 @@
+using Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+using Content.Server.Xenoarchaeology.XenoArtifacts.Events;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Systems;
+using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+
+namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems;
+
+public sealed class GibArtifactSystem : EntitySystem
+{
+    [Dependency] private readonly SharedBodySystem _body = default!;
+    [Dependency] private readonly DamageableSystem _damageableSystem = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<GibArtifactComponent, ArtifactActivatedEvent>(OnActivate);
+    }
+
+    private void OnActivate(EntityUid uid, GibArtifactComponent component, ArtifactActivatedEvent args)
+    {
+        if (args.Activator is null)
+            return;
+
+        if (TryComp<BodyComponent>(args.Activator, out var _)
+        && TryComp<DamageableComponent>(args.Activator, out var damageable))
+        {
+            // it's gibbing time
+            _damageableSystem.SetAllDamage((EntityUid) args.Activator, damageable, (FixedPoint2) 10000f);
+            // the one bellow crashes the server when the activator is a skeleton
+            //_body.GibBody((EntityUid) args.Activator, gibOrgans: true, body, launchGibs: true);
+        }
+    }
+}

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/SpawnArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/SpawnArtifactSystem.cs
@@ -23,10 +23,15 @@ public sealed class SpawnArtifactSystem : EntitySystem
 
     private void OnActivate(EntityUid uid, SpawnArtifactComponent component, ArtifactActivatedEvent args)
     {
-        if (!_artifact.TryGetNodeData(uid, NodeDataSpawnAmount, out int amount))
-            amount = 0;
+        // if it is a artifact or not
+        var isArtifact = EntityManager.HasComponent<ArtifactComponent>(uid);
+        int? amount = null;
 
-        if (amount >= component.MaxSpawns)
+        if (isArtifact)
+            if (!_artifact.TryGetNodeData(uid, NodeDataSpawnAmount, out amount))
+                amount = 0;
+
+        if (amount is not null && amount >= component.MaxSpawns)
             return;
 
         if (component.Spawns is not {} spawns)
@@ -41,6 +46,8 @@ public sealed class SpawnArtifactSystem : EntitySystem
             var ent = Spawn(spawn, spawnCord);
             _transform.AttachToGridOrMap(ent);
         }
-        _artifact.SetNodeData(uid, NodeDataSpawnAmount, amount + 1);
+
+        if (amount is not null)
+            _artifact.SetNodeData(uid, NodeDataSpawnAmount, amount + 1);
     }
 }

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/TurnIntoBlobArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/TurnIntoBlobArtifactSystem.cs
@@ -1,0 +1,33 @@
+using Content.Server.Antag;
+using Content.Server.GameTicking.Rules.Components;
+using Content.Server.Roles;
+using Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+using Content.Server.Xenoarchaeology.XenoArtifacts.Events;
+using Content.Shared.Mind.Components;
+using Content.Shared._EinsteinEngines.Silicon.Components;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems;
+
+public sealed class TurnIntoBlobArtifactSystem : EntitySystem
+{
+    [Dependency] private readonly AntagSelectionSystem _antag = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<TurnIntoBlobArtifactComponent, ArtifactActivatedEvent>(OnActivate);
+    }
+
+    private void OnActivate(EntityUid uid, TurnIntoBlobArtifactComponent comp, ArtifactActivatedEvent args)
+    {
+        if (!HasComp<MindContainerComponent>(args.Activator) || !TryComp<ActorComponent>(args.Activator, out var target))
+            return;
+
+        var player = target.PlayerSession;
+
+        EnsureComp<Shared._Goobstation.Blob.Components.BlobCarrierComponent>((EntityUid) args.Activator).HasMind = HasComp<ActorComponent>((EntityUid) args.Activator);
+    }
+}

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/TurnIntoHereticArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/TurnIntoHereticArtifactSystem.cs
@@ -5,29 +5,32 @@ using Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
 using Content.Server.Xenoarchaeology.XenoArtifacts.Events;
 using Content.Shared.Mind.Components;
 using Robust.Shared.Player;
+using Content.Server.Roles;
+using Content.Shared.Heretic;
 
 namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems;
 
-public sealed class TurnIntoTraitorArtifactSystem : EntitySystem
+public sealed class TurnIntoHereticArtifactSystem : EntitySystem
 {
     [Dependency] private readonly AntagSelectionSystem _antag = default!;
 
-    const string DefaultTraitorRule = "Traitor";
     /// <inheritdoc/>
     public override void Initialize()
     {
-        SubscribeLocalEvent<TurnIntoTraitorArtifactComponent, ArtifactActivatedEvent>(OnActivate);
+        SubscribeLocalEvent<TurnIntoHereticArtifactComponent, ArtifactActivatedEvent>(OnActivate);
     }
 
-    private void OnActivate(EntityUid uid, TurnIntoTraitorArtifactComponent comp, ArtifactActivatedEvent args)
+    private void OnActivate(EntityUid uid, TurnIntoHereticArtifactComponent comp, ArtifactActivatedEvent args)
     {
         if (!HasComp<MindContainerComponent>(args.Activator) || !TryComp<ActorComponent>(args.Activator, out var target))
-            return;        if (HasComp<TraitorRoleComponent>(args.Activator))
             return;
 
         var player = target.PlayerSession;
 
-        _antag.ForceMakeAntag<TraitorRuleComponent>(player, comp.Rule ?? DefaultTraitorRule);
+        if(HasComp<HereticComponent>(args.Activator))
+            return;
+
+        _antag.ForceMakeAntag<HereticRuleComponent>(player, "Heretic");
     }
 }
 

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/TurnIntoLingArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/TurnIntoLingArtifactSystem.cs
@@ -1,0 +1,37 @@
+using Content.Server.Antag;
+using Content.Server.GameTicking.Rules.Components;
+using Content.Server.Roles;
+using Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+using Content.Server.Xenoarchaeology.XenoArtifacts.Events;
+using Content.Shared.Mind.Components;
+using Robust.Shared.Player;
+using Content.Shared._EinsteinEngines.Silicon.Components;
+using Content.Shared.Changeling;
+
+namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems;
+
+public sealed class TurnIntoLingArtifactSystem : EntitySystem
+{
+    [Dependency] private readonly AntagSelectionSystem _antag = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<TurnIntoLingArtifactComponent, ArtifactActivatedEvent>(OnActivate);
+    }
+
+    private void OnActivate(EntityUid uid, TurnIntoLingArtifactComponent comp, ArtifactActivatedEvent args)
+    {
+        if (!HasComp<MindContainerComponent>(args.Activator) || !TryComp<ActorComponent>(args.Activator, out var target))
+            return;
+
+        if (HasComp<ChangelingComponent>(args.Activator))
+            return;
+
+        var player = target.PlayerSession;
+
+        if (!HasComp<SiliconComponent>(args.Activator))
+            _antag.ForceMakeAntag<ChangelingRuleComponent>(player, "Changeling");
+    }
+}
+

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/TurnIntoRevLeaderArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/TurnIntoRevLeaderArtifactComponent.cs
@@ -1,0 +1,34 @@
+using Content.Server.Antag;
+using Content.Server.GameTicking.Rules.Components;
+using Content.Server.Roles;
+using Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+using Content.Server.Xenoarchaeology.XenoArtifacts.Events;
+using Content.Shared.Mind.Components;
+using Robust.Shared.Player;
+
+namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems;
+
+public sealed class TurnIntoRevLeaderArtifactSystem : EntitySystem
+{
+    [Dependency] private readonly AntagSelectionSystem _antag = default!;
+
+    const string DefaultRevleaderRule = "Revolutionary";
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<TurnIntoRevLeaderArtifactComponent, ArtifactActivatedEvent>(OnActivate);
+    }
+
+    private void OnActivate(EntityUid uid, TurnIntoRevLeaderArtifactComponent comp, ArtifactActivatedEvent args)
+    {
+        if (!HasComp<MindContainerComponent>(args.Activator) || !TryComp<ActorComponent>(args.Activator, out var target))
+            return;
+
+        if (HasComp<RevolutionaryRoleComponent>(args.Activator))
+            return;
+
+        var player = target.PlayerSession;
+
+        _antag.ForceMakeAntag<RevolutionaryRuleComponent>(player, comp.Rule ?? DefaultRevleaderRule);
+    }
+}

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/TurnIntoThiefArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/TurnIntoThiefArtifactSystem.cs
@@ -1,0 +1,34 @@
+using Content.Server.Antag;
+using Content.Server.GameTicking.Rules.Components;
+using Content.Server.Roles;
+using Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+using Content.Server.Xenoarchaeology.XenoArtifacts.Events;
+using Content.Shared.Mind.Components;
+using Robust.Shared.Player;
+
+namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems;
+
+public sealed class TurnIntoThiefArtifactSystem : EntitySystem
+{
+    [Dependency] private readonly AntagSelectionSystem _antag = default!;
+
+    const string DefaultTraitorRule = "Thief";
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<TurnIntoThiefArtifactComponent, ArtifactActivatedEvent>(OnActivate);
+    }
+
+    private void OnActivate(EntityUid uid, TurnIntoThiefArtifactComponent comp, ArtifactActivatedEvent args)
+    {
+        if (!HasComp<MindContainerComponent>(args.Activator) || !TryComp<ActorComponent>(args.Activator, out var target))
+            return;
+        if (HasComp<ThiefRoleComponent>(args.Activator))
+            return;
+
+        var player = target.PlayerSession;
+
+        _antag.ForceMakeAntag<ThiefRuleComponent>(player, comp.Rule ?? DefaultTraitorRule);
+    }
+}

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/TurnIntoThiefArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/TurnIntoThiefArtifactSystem.cs
@@ -24,8 +24,6 @@ public sealed class TurnIntoThiefArtifactSystem : EntitySystem
     {
         if (!HasComp<MindContainerComponent>(args.Activator) || !TryComp<ActorComponent>(args.Activator, out var target))
             return;
-        if (HasComp<ThiefRoleComponent>(args.Activator))
-            return;
 
         var player = target.PlayerSession;
 

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/TurnIntoTraitorArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/TurnIntoTraitorArtifactSystem.cs
@@ -1,0 +1,33 @@
+using Content.Server.Antag;
+using Content.Server.GameTicking.Rules.Components;
+using Content.Server.Roles;
+using Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+using Content.Server.Xenoarchaeology.XenoArtifacts.Events;
+using Content.Shared.Mind.Components;
+using Robust.Shared.Player;
+
+namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems;
+
+public sealed class TurnIntoTraitorArtifactSystem : EntitySystem
+{
+    [Dependency] private readonly AntagSelectionSystem _antag = default!;
+
+    const string DefaultTraitorRule = "Traitor";
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<TurnIntoTraitorArtifactComponent, ArtifactActivatedEvent>(OnActivate);
+    }
+
+    private void OnActivate(EntityUid uid, TurnIntoTraitorArtifactComponent comp, ArtifactActivatedEvent args)
+    {
+        if (!HasComp<MindContainerComponent>(args.Activator) || !TryComp<ActorComponent>(args.Activator, out var target))
+            return;        if (HasComp<TraitorRoleComponent>(args.Activator))
+            return;
+
+        var player = target.PlayerSession;
+
+        _antag.ForceMakeAntag<TraitorRuleComponent>(player, comp.Rule ?? DefaultTraitorRule);
+    }
+}
+

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/TurnIntoZombieArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/TurnIntoZombieArtifactSystem.cs
@@ -1,0 +1,33 @@
+using Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Components;
+using Content.Server.Xenoarchaeology.XenoArtifacts.Events;
+using Content.Server.Zombies;
+using Content.Shared.Mind.Components;
+using Content.Shared.Zombies;
+using Robust.Shared.Player;
+
+namespace Content.Server.Xenoarchaeology.XenoArtifacts.Effects.Systems;
+
+public sealed class TurnIntoZombieArtifactSystem : EntitySystem
+{
+    [Dependency] private readonly ZombieSystem _zombie = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<TurnIntoZombieArtifactComponent, ArtifactActivatedEvent>(OnActivate);
+    }
+
+    private void OnActivate(EntityUid uid, TurnIntoZombieArtifactComponent comp, ArtifactActivatedEvent args)
+    {
+        if (args.Activator is null)
+            return;
+
+        if (!HasComp<MindContainerComponent>(args.Activator) || !TryComp<ActorComponent>(args.Activator, out var target))
+            return;
+
+        if (HasComp<ZombieComponent>(uid))
+            return;
+
+        _zombie.ZombifyEntity((EntityUid) args.Activator);
+    }
+}

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/TurnIntoZombieArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/TurnIntoZombieArtifactSystem.cs
@@ -25,7 +25,10 @@ public sealed class TurnIntoZombieArtifactSystem : EntitySystem
         if (!HasComp<MindContainerComponent>(args.Activator) || !TryComp<ActorComponent>(args.Activator, out var target))
             return;
 
-        if (HasComp<ZombieComponent>(uid))
+        if (HasComp<ZombieImmuneComponent>(args.Activator))
+            return;
+
+        if (HasComp<ZombieComponent>(args.Activator))
             return;
 
         _zombie.ZombifyEntity((EntityUid) args.Activator);

--- a/Content.Shared/Dice/DiceRollEvent.cs
+++ b/Content.Shared/Dice/DiceRollEvent.cs
@@ -1,0 +1,11 @@
+namespace Content.Shared.Dice;
+
+public sealed class DiceRollEvent : EntityEventArgs
+{
+    public readonly int RolledNumber;
+
+    public DiceRollEvent(int rolledNumber)
+    {
+        RolledNumber = rolledNumber;
+    }
+}

--- a/Content.Shared/Dice/SharedDiceSystem.cs
+++ b/Content.Shared/Dice/SharedDiceSystem.cs
@@ -77,6 +77,9 @@ public abstract class SharedDiceSystem : EntitySystem
         var roll = rand.Next(1, entity.Comp.Sides + 1);
         SetCurrentSide(entity, roll);
 
+        var ev = new DiceRollEvent(roll);
+        RaiseLocalEvent((EntityUid) entity, ev, true);
+
         var popupString = Loc.GetString("dice-component-on-roll-land",
             ("die", entity),
             ("currentSide", entity.Comp.CurrentValue));

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -426,3 +426,9 @@ reagent-effect-guidebook-add-to-chemicals =
         [1] to
         *[-1] from
     } the solution
+
+reagent-effect-guidebook-remove-cogchamp-accent =
+    { $chance ->
+        [1] Removes the
+        *[other] remove the
+    } cogchamp accent of the user

--- a/Resources/Locale/pt-BR/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/pt-BR/guidebook/chemistry/effects.ftl
@@ -350,3 +350,9 @@ reagent-effect-guidebook-missing =
         [1] Causes
         *[other] cause
     } an unknown effect as nobody has written this effect yet
+
+reagent-effect-guidebook-remove-cogchamp-accent =
+    { $chance ->
+        [1] Remove
+        *[other] remove o
+    } sotaque cogchamp indivíduo

--- a/Resources/Prototypes/Entities/Objects/Fun/dice.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/dice.yml
@@ -160,7 +160,7 @@
     - EffectSpawnDoubleEnergySword
     - EffectTurnIntoRevLeader
     - EffectTurnIntoThief
-    - EffectTurnIntoTraitor
+    - EffectTurnIntoHeretic
     - EffectTurnIntoBlob
     - EffectTurnIntoLing
     remainingUses: 1

--- a/Resources/Prototypes/Entities/Objects/Fun/dice.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/dice.yml
@@ -134,3 +134,40 @@
       types:
         Piercing: 5
     # I love this
+
+- type: entity
+  parent: d20Dice
+  id: d20FateDice
+  name: dado do caos
+  description: Esse dado parece que veio do capiroto, devo brincar com ele?
+  components:
+  - type: FateDice
+    effects:
+    - EffectGib
+    - EffectTurnIntoZombie
+    - EffectZombieOutbreak
+    - EffectBabelTower
+    - EffectDragon
+    - EffectMassHallucinations
+    - EffectAngryCarpSpawn
+    - EffectEmp
+    - EffectPolyLuminous
+    - EffectMonkeySpawn
+    - EffectChargeBatteries
+    - EffectHealAll
+    - EffectSpawnBagOfHolding
+    - EffectGreytideVirus
+    - EffectSpawnDoubleEnergySword
+    - EffectTurnIntoRevLeader
+    - EffectTurnIntoThief
+    - EffectTurnIntoTraitor
+    - EffectTurnIntoBlob
+    - EffectTurnIntoLing
+    remainingUses: 1
+    toReplace: d20Dice
+  - type: PointLight
+    energy: 20
+    radius: 1.2
+  - type: RgbLightController
+    cycleRate: 0.2
+  - type: ActiveReagentGrinder

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -656,3 +656,16 @@
       min: 1
       max: 1
       pickPlayer: false
+
+# game rule that makes everyone speak with the cogchamp accent for a certain amount of time
+- type: entity
+  id: BabelTower
+  parent: BaseGameRule
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: StationEvent
+      minimumPlayers: 5
+      duration: 60 # duration is in seconds by the way
+      maxDuration: 180
+      weight: 0
+    - type: BabelTowerRule

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1178,6 +1178,7 @@
         factor: 3
     Medicine:
       effects:
+      - !type:RemoveCogchampAccent
       - !type:HealthChange
         conditions:
         - !type:TotalDamage

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -724,7 +724,7 @@
 - type: artifactEffect
   id: EffectGreytideVirus
   targetDepth: -1
-  effectHint: artifact-hint-rod
+  effectHint: artifact-hint-greytide-virus
   components:
   - type: GameRuleArtifact
     rules:
@@ -763,11 +763,11 @@
     - BabelTower
 
 - type: artifactEffect
-  id: EffectTurnIntoTraitor
+  id: EffectTurnIntoHeretic
   targetDepth: -1
-  effectHint: artifact-hint-traitor
+  effectHint: artifact-hint-heretic
   components:
-  - type: TurnIntoTraitorArtifact
+  - type: TurnIntoHereticArtifact
 
 - type: artifactEffect
   id: EffectTurnIntoThief

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -693,3 +693,119 @@
     maxSpawns: 1
     spawns:
     - id: TeslaEnergyBall
+
+## Dice of fate update ##
+
+- type: artifactEffect
+  id: EffectGib
+  targetDepth: -1
+  effectHint: artifact-hint-gib
+  components:
+  - type: GibArtifact
+
+- type: artifactEffect
+  id: EffectDragon
+  targetDepth: -1
+  effectHint: artifact-hint-dragon
+  components:
+  - type: GameRuleArtifact
+    rules:
+    - DragonSpawn
+
+- type: artifactEffect
+  id: EffectZombieOutbreak
+  targetDepth: -1
+  effectHint: artifact-hint-zombie-outbreak
+  components:
+  - type: GameRuleArtifact
+    rules:
+    - ZombieOutbreak
+
+- type: artifactEffect
+  id: EffectGreytideVirus
+  targetDepth: -1
+  effectHint: artifact-hint-rod
+  components:
+  - type: GameRuleArtifact
+    rules:
+    - GreytideVirus
+
+- type: artifactEffect
+  id: EffectMassHallucinations
+  targetDepth: -1
+  effectHint: artifact-hint-hallucinations
+  components:
+  - type: GameRuleArtifact
+    rules:
+    - MassHallucinations
+
+- type: artifactEffect
+  id: EffectTurnIntoBlob
+  targetDepth: -1
+  effectHint: artifact-hint-blob
+  components:
+  - type: TurnIntoBlobArtifact
+
+- type: artifactEffect
+  id: EffectTurnIntoLing
+  targetDepth: -1
+  effectHint: artifact-hint-changeling
+  components:
+  - type: TurnIntoLingArtifact
+
+- type: artifactEffect
+  id: EffectBabelTower
+  targetDepth: -1
+  effectHint: artifact-hint-babel
+  components:
+  - type: GameRuleArtifact
+    rules:
+    - BabelTower
+
+- type: artifactEffect
+  id: EffectTurnIntoTraitor
+  targetDepth: -1
+  effectHint: artifact-hint-traitor
+  components:
+  - type: TurnIntoTraitorArtifact
+
+- type: artifactEffect
+  id: EffectTurnIntoThief
+  targetDepth: -1
+  effectHint: artifact-hint-thief
+  components:
+  - type: TurnIntoThiefArtifact
+
+- type: artifactEffect
+  id: EffectTurnIntoZombie
+  targetDepth: -1
+  effectHint: artifact-hint-zombie
+  components:
+  - type: TurnIntoZombieArtifact
+
+- type: artifactEffect
+  id: EffectTurnIntoRevLeader
+  targetDepth: -1
+  effectHint: artifact-hint-revleader
+  components:
+  - type: TurnIntoRevLeaderArtifact
+
+- type: artifactEffect
+  id: EffectSpawnDoubleEnergySword
+  targetDepth: -1
+  effectHint: artifact-hint-double-energy-sword
+  components:
+  - type: SpawnArtifact
+    maxSpawns: 1
+    spawns:
+    - id: EnergySwordDouble
+
+- type: artifactEffect
+  id: EffectSpawnBagOfHolding
+  targetDepth: -1
+  effectHint: artifact-hint-bag-of-holding
+  components:
+  - type: SpawnArtifact
+    maxSpawns: 1
+    spawns:
+    - id: ClothingBackpackHolding


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adicionado um novo item de admeme chamado "dado do caos", um dado que quando você rola acontece um efeito bom ou um ruim e um novo evento da estação (de peso 0) chamado BabelTower (torre de babel) que todo mundo da estação por um certo período de tempo fala com o sotaque cogchamp e que pode ser curado prematuramente metabolizando agua benta.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Item engraçado para badmins spawnarem e apimentarem o round.


## Technical details
<!-- Summary of code changes for easier review. -->
O sistema do dado é reciclado do sistema de artefatos, eu precisei fazer algumas alterações no sistema de xenarch para que o mesmo não quebre catastroficamente.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/36e520f3-e247-4aec-918e-1ae9486ee0f6



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Adicionado dado do caos.
- add: Adicionado novo evento chamado BabelTower (torre de babel) em que todos da estação passam a falar com o sotaque do cogchamp por um certo período de tempo (esse evento tem peso 0);
- tweak: Efeitos de artefatos com target depth negativo não serão selecionados aleatóriamente pelos artefatos da sci.
- tweak: Água benta agora cura indivíduos com sotaque do cogchamp prematuramente.
- add: Adicionado um monte de efeitos de artefatos que óbviamente são para o dado do caos, no entanto os artefatos da sci não teram acesso a esses efeitos.


## Additional context

Unban me from gabystation pls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an interactive Fate Dice with unique outcomes, visual effects, and automatic replacement.
  - Launched a Babel Tower event that temporarily alters character speech.
  - Added diverse artifact effects triggering unpredictable transformations (e.g., zombie, blob, changeling, rebel leader, thief, heretic).
  - Enhanced reagent interactions to clear specific accent effects.
  - Improved dice interactivity with event triggers for dynamic gameplay.

- **Documentation**
  - Updated in-game guidebook entries and localized texts to reflect the new changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->