### PR TITLE
Job Icons [PORT]

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -142,6 +142,7 @@ public partial class ChatBox : UIWidget
 
     public void Repopulate()
     {
+        Contents.RemoveAllChildren();
         Contents.Clear();
 
         foreach (var message in _controller.History)
@@ -152,6 +153,7 @@ public partial class ChatBox : UIWidget
 
     private void OnChannelFilter(ChatChannel channel, bool active)
     {
+        Contents.RemoveAllChildren();
         Contents.Clear();
 
         foreach (var message in _controller.History)
@@ -175,7 +177,7 @@ public partial class ChatBox : UIWidget
         {
             int displayRepeat = repeat + 1;
             int sizeIncrease = Math.Min(displayRepeat / 6, 5);
-            formatted.AddMarkup(_loc.GetString("chat-system-repeated-message-counter",
+            formatted.AddMarkupOrThrow(_loc.GetString("chat-system-repeated-message-counter",
                                 ("count", displayRepeat),
                                 ("size", 8+sizeIncrease)
                                 ));

--- a/Content.Client/_Starlight/UserInterface/RichText/IconTag.cs
+++ b/Content.Client/_Starlight/UserInterface/RichText/IconTag.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using Content.Shared.StatusIcon;
+using Robust.Client.GameObjects;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.RichText;
+using Robust.Shared.IoC;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Client.UserInterface.RichText;
+
+public sealed class IconTag : IMarkupTag
+{
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly IEntitySystemManager _entitySystem = default!;
+    private SpriteSystem? _spriteSystem;
+
+    public string Name => "icon";
+
+    public bool TryGetControl(MarkupNode node, [NotNullWhen(true)] out Control? control)
+    {
+        if (!node.Attributes.TryGetValue("src", out var id) || id.StringValue == null)
+        {
+            control = null;
+            return false;
+        }
+        _spriteSystem ??= _entitySystem.GetEntitySystem<SpriteSystem>();
+        var texture = _prototype.TryIndex<JobIconPrototype>(id.StringValue, out var iconPrototype)
+                ? _spriteSystem.Frame0(iconPrototype.Icon)
+                : null;
+        var icon = new TextureRect
+        {
+            Texture = texture,
+            SetWidth = 20,
+            SetHeight = 20,
+            Stretch = TextureRect.StretchMode.Scale,
+            MouseFilter = Control.MouseFilterMode.Stop,
+        };
+        if (node.Attributes.TryGetValue("tooltip", out var tooltip) && tooltip.StringValue != null)
+            icon.ToolTip = tooltip.StringValue;
+        control = icon;
+        return true;
+    }
+}

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -37,6 +37,8 @@ using Content.Shared.Database;
 using Content.Shared.Radio;
 using Content.Shared.Radio.Components;
 using Content.Shared.Speech;
+using Content.Shared.Silicons.Borgs.Components;
+using Content.Shared.Silicons.StationAi;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
@@ -44,6 +46,9 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Replays;
 using Robust.Shared.Utility;
+using Content.Shared.Access.Systems;
+using Content.Shared.Access.Components;
+using Content.Shared.PDA;
 
 namespace Content.Server.Radio.EntitySystems;
 
@@ -58,6 +63,7 @@ public sealed class RadioSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
+    [Dependency] private readonly AccessReaderSystem _accessReader = default!;
 
     // set used to prevent radio feedback loops.
     private readonly HashSet<string> _messages = new();
@@ -123,13 +129,55 @@ public sealed class RadioSystem : EntitySystem
             ? FormattedMessage.EscapeText(message)
             : message;
 
+        // start 🌟Starlight🌟
+
+        var iconId = "JobIconNoId";
+        var jobName = "";
+
+        if (_accessReader.FindAccessItemsInventory(messageSource, out var items))
+        {
+            foreach (var item in items)
+            {
+                // ID Card
+                if (TryComp<IdCardComponent>(item, out var id))
+                {
+                    iconId = id.JobIcon;
+                    jobName = id.LocalizedJobTitle;
+                    break;
+                }
+
+                // PDA
+                if (TryComp<PdaComponent>(item, out var pda)
+                    && pda.ContainedId != null
+                    && TryComp(pda.ContainedId, out id))
+                {
+                    iconId = id.JobIcon;
+                    jobName = id.LocalizedJobTitle;
+                    break;
+                }
+            }
+        }
+
+        if (HasComp<BorgChassisComponent>(messageSource) || HasComp<BorgBrainComponent>(messageSource))
+        {
+            iconId = "JobIconBorg";
+            jobName = Loc.GetString("job-name-borg");
+        }
+
+        if (HasComp<StationAiHeldComponent>(messageSource))
+        {
+            iconId = "JobIconStationAi";
+            jobName = Loc.GetString("job-name-station-ai");
+        }
+        // end 🌟Starlight🌟
+
         var wrappedMessage = Loc.GetString(speech.Bold ? "chat-radio-message-wrap-bold" : "chat-radio-message-wrap",
             ("color", channel.Color),
             ("fontType", speech.FontId),
             ("fontSize", speech.FontSize),
             ("verb", Loc.GetString(_random.Pick(speech.SpeechVerbStrings))),
             ("channel", $"\\[{channel.LocalizedName}\\]"),
-            ("name", name),
+            ("name", $"[icon src=\"{iconId}\" tooltip=\"{jobName}\"] {name}"),  // 🌟Starlight🌟
             ("message", content));
 
         // most radios are relayed to chat, so lets parse the chat message beforehand


### PR DESCRIPTION
Adiciona o icone do trabalho no radio 
isso porta a commit que arruma o chat e porta a commit limpa da estação andromeda (ja que a commit do starlight tava bagunçada com mais 500 coisas adicionais)

- https://github.com/ss14Starlight/space-station-14/commit/d7527d5d5c1e5cf11a383071d169de9a51d58e0b | https://github.com/LaryNevesPR/Estacao-Andromeda/pull/86/files
- https://github.com/ss14Starlight/space-station-14/pull/145/files

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Rinary, Cosmos, AgentePanela
- add: icones de trabalho no radio (Starlight port)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Radio chat messages now display the speaker's job icon and job name as a tooltip next to their name.
  - Rich text elements support a new "icon" tag, allowing job icons with optional tooltips to be embedded in chat and UI messages.

- **Bug Fixes**
  - Improved error handling for message markup in chat, ensuring errors are surfaced instead of silently ignored.
  - Enhanced reliability when clearing chat UI elements to prevent potential display issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->