### PR TITLE
[FIX] Corrige Guidebooks bugados

### DIFF
--- a/Resources/ServerInfo/Guidebook/Antagonist/Antagonists.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Antagonists.xml
@@ -14,7 +14,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
   Esses agentes do caos são, na maioria das vezes, empregados ou apoiados pelo [color=#ff0000]Sindicato[/color], uma organização rival à Nanotrasen que não deseja nada além de vê-la destruída.
 
-<<<<<<< HEAD
   ## Diversos Antagonistas
   Os antagonistas podem assumir muitas formas, como:
   - [textlink="Operativos Nucleares" link="Nuclear Operatives"], com o objetivo de se infiltrar e destruir a estação.
@@ -23,17 +22,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   - [textlink="Zumbis" link="Zombies"] que anseiam pela carne de cada membro da tripulação e criatura a bordo.
   - [textlink="Ninjas Espaciais" link="SpaceNinja"], mestres da espionagem e sabotagem com equipamentos especiais.
   - [textlink="Ladrões" link="Thieves"] movidos pela cleptomania, determinados a satisfazer seu vício usando suas luvas especiais.
+  - [textlink="O Culto Cósmico" link="CosmicCult"], que busca trazer o fim de todas as coisas.
   - [textlink="Diversas criaturas não humanoides" link="MinorAntagonists"] que geralmente atacam qualquer coisa que se mova.
-=======
-  ## Various Antagonists
-  Antagonists can take many forms, like:
-  - [textlink="Nuclear operatives" link="Nuclear Operatives"], with the goal of infiltrating and destroying the station.
-  - [textlink="Traitors" link="Traitors"] amongst the crew who must assassinate, steal and decieve.
-  - [textlink="Revolutionaries" link="Revolutionaries"] who are intent on taking control of the station from the inside.
-  - [textlink="Zombies" link="Zombies"] that crave the flesh of every crew member and creature on board.
-  - [textlink="Space Ninjas" link="SpaceNinja"], masters of espionage and sabotage with special gear.
-  - [textlink="Thieves" link="Thieves"] driven by kleptomania, determined to get their fix using their special gloves.
-  - [textlink="The Cosmic Cult" link="CosmicCult"], who seek to usher in the end of all things.
-  - [textlink="Various non-humanoid creatures" link="MinorAntagonists"] that generally attack anything that moves.
->>>>>>> goob/master
+
 </Document>

--- a/Resources/ServerInfo/Guidebook/Antagonist/MinorAntagonists.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/MinorAntagonists.xml
@@ -17,19 +17,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
   A maioria, se não todos, os Antagonistas Menores são papéis controlados por fantasmas que dão aos mortos novas maneiras de causar caos na estação. Eles são gerados por eventos aleatórios.
 
-<<<<<<< HEAD
-  # Aparição
-=======
-  # Paradox Clone
+  # Clone Paradoxo
 
   <Box>
     <GuideEntityEmbed Entity="ParadoxCloneDummy"/>
   </Box>
 
-  A perfect copy of a random crewmember that was thrown into our universe by a space-time anomaly. To fix the paradox and survive they have to find and kill their original counterpart. They have no special abilities, but are have identical appearance, DNA, fingerprints, clothing, equipment and IDs, making it hard to figure out who is the orginal and who is the clone, unless you know your fellow crewmembers well.
-
-  # Revenant
->>>>>>> goob/master
+  Uma cópia perfeita de um tripulante aleatório que foi lançada em nosso universo por uma anomalia espaço-temporal. Para corrigir o paradoxo e sobreviver, ela precisa encontrar e matar sua contraparte original. Não possui habilidades especiais, mas tem aparência, DNA, impressões digitais, roupas, equipamentos e identidades idênticas aos do original, tornando difícil descobrir quem é o verdadeiro e quem é o clone — a menos que você conheça bem seus companheiros de tripulação.
+  # Aparição
 
   <Box>
     <GuideEntityEmbed Entity="MobRevenant"/>

--- a/Resources/ServerInfo/Guidebook/Antagonist/Thieves.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Thieves.xml
@@ -6,11 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 <Document>
-<<<<<<< HEAD
+
   # Ladrões
-=======
-  # Thieves
->>>>>>> goob/master
 
   <Box>
     [color=#999999][italic]"Peguei! Vou levar isso! E aquilo! Ooh, não me importo se eu pegar isso também!"[/italic][/color]
@@ -35,13 +32,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     <GuideEntityEmbed Entity="ClothingHandsChameleonThief" Caption="suas luvas de ladrão"/>
   </Box>
 
-<<<<<<< HEAD
   ## Ferramentas do Ofício
   Você tem mais dois ases na manga: seu [color=cyan]beacon[/color] e sua [color=cyan]caixa de ferramentas.[/color]
-=======
-  ## Tools of the Trade
-  You've got two more aces up your stolen sleeves: your [color=cyan]beacon[/color] and your [color=cyan]satchel.[/color]
->>>>>>> goob/master
 
   Seu [color=cyan]beacon[/color] fornece uma passagem segura para casa para objetos que podem não ser fáceis de carregar com você no transporte de evacuação. Basta encontrar um lugar isolado na estação para abrir o beacon e definir suas coordenadas para seu esconderijo.
   Quaisquer itens brilhantes próximos a ele serão [bold]teletransportados para seu cofre ao final do turno,[/bold] cumprindo seus objetivos.
@@ -52,12 +44,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     <GuideEntityEmbed Entity="ThiefBeacon"/>
   </Box>
 
-<<<<<<< HEAD
   Sua [color=cyan]caixa de ferramentas[/color] contém... bem, o que você lembrou de embalar. [bold]Você pode selecionar dois kits pré-fabricados[/bold] para ajudá-lo a completar roubos mais ambiciosos.
   Aprove suas escolhas em um lugar seguro, pois a caixa de ferramentas se dissolverá e os equipamentos cairão aos seus pés.
-=======
-  Your [color=cyan]satchel[/color] contains... well, whatever you remembered to pack. [bold]You can select two pre-made kits[/bold] to help you complete grander heists.
->>>>>>> goob/master
 
   <Box>
     <GuideEntityEmbed Entity="SatchelThief"/>
@@ -74,15 +62,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     <GuideEntityEmbed Entity="Telecrystal" Caption="Sindicalista"/>
   </Box>
 
-<<<<<<< HEAD
   ## A Joia da Coleção
   Sua cleptomania o levará a lugares. Um dia, você sentirá vontade de roubar algumas miniaturas. No outro, você desejará roubar uma máquina industrial.
-=======
-  ## Centerpiece of the Collection
-  Your kleptomania will take you places. One day, you'll feel like stealing a few figurines. Another day, you'll feel like stealing an industrial machine.
-
-  No matter. They'll all be a part of your collection within a matter of time.
->>>>>>> goob/master
 
   Não importa. Todos farão parte de sua coleção em pouco tempo.
 
@@ -92,11 +73,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
   Coisas que você pode desejar incluem, mas não se limitam a:
 
-<<<<<<< HEAD
-=======
-  Things that you may desire include but are not limited to:
-
->>>>>>> goob/master
   <Box>
    <GuideEntityEmbed Entity="ToyFigurineGreytider" Caption="Miniaturas"/>
    <GuideEntityEmbed Entity="PassengerIDCard" Caption="Cartões de Identificação"/>

--- a/Resources/ServerInfo/Guidebook/Engineering/Atmospherics.xml
+++ b/Resources/ServerInfo/Guidebook/Engineering/Atmospherics.xml
@@ -101,7 +101,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     <GuideEntityEmbed Entity="TritiumCanister"/>
     <GuideEntityEmbed Entity="AirCanister"/>
     <GuideEntityEmbed Entity="GasVentScrubber"/>
-    <GuideEntityEmbed "FrezonCanister" Caption="cilindro de frezon"/>
+    <GuideEntityEmbed Entity="FrezonCanister" Caption="cilindro de frezon"/>
   </Box>
 
   É crucial entender que um vazamento de frezon pode devastar a estação, causando um inferno congelante cheio de suéteres irritantes e queimaduras frias. O Frezon é muito frio e pode congelar a estação até a morte se até mesmo alguns moles se escaparem, então certifique-se de trancar seus cilindros ou simplesmente movê-los diretamente para uma sala de armazenamento.

--- a/Resources/ServerInfo/Guidebook/Engineering/Fires.xml
+++ b/Resources/ServerInfo/Guidebook/Engineering/Fires.xml
@@ -1,7 +1,3 @@
-<<<<<<< HEAD
-<Document>
-  # Incêndios & Espaço
-=======
 <!--
 SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
 SPDX-FileCopyrightText: 2023 Myakot <30875116+Myakot@users.noreply.github.com>
@@ -19,7 +15,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 <Document>
   # Fires
   Fires are arguably the most dangerous atmospheric upset that can occur on the station.
->>>>>>> goob/master
 
   Incêndios e vazamentos no espaço são uma inevitabilidade devido ao gás plasma altamente inflamável e ao vácuo infinito do espaço presentes na estação e ao redor dela, por isso é importante saber como gerenciá-los.
 

--- a/Resources/ServerInfo/Guidebook/Mobs/Moth.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Moth.xml
@@ -13,22 +13,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     <GuideEntityEmbed Entity="MobMoth" Caption=""/>
   </Box>
 
-<<<<<<< HEAD
-  Eles Conseguem comer algodão, tecidos e roupas, mas virtualmente quase nenhuma das comidas que outros consideram "comestíveis". Eles preferem uma temperatura mais baixa que os humanos.
-  O Sangue de Inseto deles não pode ser recuperado usando Ferro, como sangue normal.
+Eles podem comer algodão, tecidos e roupas, mas praticamente nenhum dos alimentos que outros considerariam "comestíveis". Preferem uma faixa de temperatura um pouco mais baixa do que os humanos. São obcecados pelo número "65".
 
-  As suas asas dão uma aceleração melhor se a estação não tiver gravidade, mas eles não conseguem se mover sem equipamento enquanto flutuam no espaço.
+Suas asas lhes dão melhor aceleração se não houver gravidade na estação, mas ainda assim não conseguem se mover sem equipamento quando estão flutuando no espaço.
 
-  Eles tomam [color=#1e90ff]30% menos de dano Congelante[/color] mas [color=#ffa500]30% a mais de dano de Calor, e pegam fogo mais facilmente[/color].
-=======
-  They can eat cotton, fabrics and clothing, but virtually none of the food that others would consider "edible". They prefer a somewhat lower temperature range than humans. They are obsessed with the number "65".
+Também podem dar pequenos impulsos a cada 6,5 segundos usando as asas, mas isso requer a presença de gravidade. No entanto, se movem 6,5% mais devagar do que outras espécies devido às pernas fracas.
 
-  Their wings give them better acceleration if there is no gravity on the station, but they still can't move without equipment when floating out in space.
-  They can also dash small distances once in 6.5 seconds using their wings, but that requires the gravity to be present. However they move 6.5% slower than other species due to their weak legs.
+Eles recebem 30% menos dano por Frio, mas 30% mais dano por Calor e 6,5% mais dano físico (Bruto), além de pegarem fogo com mais facilidade.
 
-  They take [color=#1e90ff]30% less Cold damage[/color] but [color=#ffa500]30% more Heat and 6.5% more Brute damage, and catch on fire more easily[/color].
-
-  They are also 6.5% lighter than most species.
->>>>>>> goob/master
+Também são 6,5% mais leves do que a maioria das espécies.
 
 </Document>

--- a/Resources/ServerInfo/Guidebook/Security/Defusal.xml
+++ b/Resources/ServerInfo/Guidebook/Security/Defusal.xml
@@ -1,8 +1,3 @@
-<<<<<<< HEAD
-﻿<Document>
-  # Desativação de Bomba Grande
-  Então, você encontrou uma bomba grande e ela está apitando. Essas bombas demoram muito para detonar e abrem um grande buraco no casco. Continue lendo e ninguém explodirá.
-=======
 <!--
 SPDX-FileCopyrightText: 2023 Kara <lunarautomaton6@gmail.com>
 SPDX-FileCopyrightText: 2023 eclips_e <67359748+Just-a-Unity-Dev@users.noreply.github.com>
@@ -13,9 +8,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 <Document>
-  # Large Bomb Defusal
-  So, you found a large bomb and it's beeping. These bombs take a long time to detonate and punch a big hole into the hull. Just keep reading, and nobody will explode.
->>>>>>> goob/master
+  # Desativação de Bomba Grande
+  Então, você encontrou uma bomba grande e ela está apitando. Essas bombas demoram muito para detonar e abrem um grande buraco no casco. Continue lendo e ninguém explodirá.
+
 
   ## Engrenagem
   Você precisa de duas ferramentas essenciais para realizar a desativação; no entanto, uma multiferramenta é extremamente útil em termos de identificação de fios.

--- a/Resources/ServerInfo/Guidebook/SpaceStation14.xml
+++ b/Resources/ServerInfo/Guidebook/SpaceStation14.xml
@@ -1,7 +1,3 @@
-<<<<<<< HEAD
-﻿<Document>
-# Estação e Turnos
-=======
 <!--
 SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
 SPDX-FileCopyrightText: 2023 Myakot <30875116+Myakot@users.noreply.github.com>
@@ -14,28 +10,27 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 <Document>
-# Station and Shifts
->>>>>>> goob/master
+# Estação e Turnos
 
 Cada rodada de SS14 é um [bold]turno autocontido[/bold] que ocorre em uma das diversas estações.
 
 As rodadas normalmente duram de [color=cyan]45 a 90 minutos[/color], mas os jogadores estão livres para sair e entrar a qualquer momento durante a rodada.
 
-## Terminal de Shuttle
-Se você entrar no meio de um turno, provavelmente aparecerá no [color=lime]terminal de shuttle[/color].
-Aqui você pode pegar bebidas, conversar com outros jogadores e esperar o shuttle para levá-lo até a estação.
+## Estação Arrivals
+Se você entrar no meio de um turno, provavelmente aparecerá na [color=lime]Estação Arrivals[/color].
+Aqui você pode pegar bebidas, conversar com outros jogadores e esperar a nave de transporte para levá-lo até a estação.
 
-As telas nas paredes mostrarão o ETA do shuttle.
+As telas nas paredes mostrarão o ETA da nave.
 Quando ele chegar, basta entrar para ser transportado até a estação.
 
-Certifique-se de ficar dentro do terminal e não ficar na zona de pouso do shuttle. [color=#EB2D3A][bold]Você pode ser esmagado pelos shuttles que estão pousando[/bold][/color].
+Certifique-se de ficar dentro da Estação Arrivals e não ficar na zona de pouso. [color=#EB2D3A][bold]Você pode ser esmagado pelas naves que estão pousando[/bold][/color].
 
 ## Navegação
 Cada estação tem uma grande variedade de locais a serem visitados.
 Esses locais variam desde departamentos específicos onde o trabalho acontece até áreas comuns onde você pode relaxar e conversar com outras pessoas.
 
 <Box>
-  <GuideEntityEmbed Entity="StationMap"/>
+  <GuideEntityEmbed Entity="StationMap" Caption="Mapa da estação"/>
   <GuideEntityEmbed Entity="SignDirectionalDorms" Caption="Placas de Direção"/>
   <GuideEntityEmbed Entity="SignBridge" Caption="Placas de Localização"/>
 </Box>
@@ -44,7 +39,7 @@ Os [color=cyan]mapas da estação[/color] fornecem uma visão geral de toda a es
 Placas [color=cyan]regulares[/color] nas paredes podem direcioná-lo para diferentes departamentos.
 
 ## Deixando a Estação
-Ao final do turno [color=gray](exceto em caso de [color=red][bold]desastre nuclear[/bold][/color])[/color], você deixará a estação através do [color=lime]shuttle de evacuação[/color].
+Ao final do turno [color=gray](exceto em caso de [color=red][bold]desastre nuclear[/bold][/color])[/color], você deixará a estação através da [color=lime]nave de evacuação[/color].
 Quando for chamado, um anúncio será feito na estação alertando a tripulação e sinalizando sua [color=cyan]chegada em 10 minutos.[/color]
 Quando ele chegar, você precisará ir até ele, embarcar e sobreviver à viagem até o [bold]Comando Central[/bold].
 
@@ -54,7 +49,7 @@ A rodada não termina oficialmente até que você chegue ao [bold]Comando Centra
   <GuideEntityEmbed Entity="CryogenicSleepUnit"/>
 </Box>
 
-Se precisar sair de uma rodada mais cedo, você pode fazer isso através de uma [color=lime]unidade de sono criogênico[/color].
+Se precisar sair de uma rodada mais cedo, você pode fazer isso através de uma [color=lime]cama de sono criogênico[/color].
 Basta entrar e sair do jogo que seus pertences serão armazenados e garantirão que não sejam roubados ou usados indevidamente.
 
 ## Mais Informações

--- a/Resources/ServerInfo/Guidebook/SpaceStation14.xml
+++ b/Resources/ServerInfo/Guidebook/SpaceStation14.xml
@@ -16,14 +16,14 @@ Cada rodada de SS14 é um [bold]turno autocontido[/bold] que ocorre em uma das d
 
 As rodadas normalmente duram de [color=cyan]45 a 90 minutos[/color], mas os jogadores estão livres para sair e entrar a qualquer momento durante a rodada.
 
-## Estação Arrivals
-Se você entrar no meio de um turno, provavelmente aparecerá na [color=lime]Estação Arrivals[/color].
+## Terminal da Arrivals
+Se você entrar no meio de um turno, provavelmente aparecerá no [color=lime]Terminal da Arrivals[/color].
 Aqui você pode pegar bebidas, conversar com outros jogadores e esperar a nave de transporte para levá-lo até a estação.
 
 As telas nas paredes mostrarão o ETA da nave.
 Quando ele chegar, basta entrar para ser transportado até a estação.
 
-Certifique-se de ficar dentro da Estação Arrivals e não ficar na zona de pouso. [color=#EB2D3A][bold]Você pode ser esmagado pelas naves que estão pousando[/bold][/color].
+Certifique-se de ficar dentro do Terminal da Arrivals e não ficar na zona de pouso. [color=#EB2D3A][bold]Você pode ser esmagado pelas naves que estão pousando[/bold][/color].
 
 ## Navegação
 Cada estação tem uma grande variedade de locais a serem visitados.


### PR DESCRIPTION
## Sobre o PR
Corrige os guidebooks que estavam bugados e adiciona/muda algumas traduções no meio disso.

## Media
![image](https://github.com/user-attachments/assets/0bf43e84-6fcf-40ad-ad2e-43e3187c4529)

**Changelog**
:cl:
- fix: Todas as páginas do Guidebook funcionam corretamente!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved merge conflict markers and removed duplicate or redundant lines in multiple guidebook documents for a cleaner user experience.
	- Corrected a malformed tag in the atmospherics guide section to ensure proper display.

- **Documentation**
	- Updated several guidebook sections to display content exclusively in Portuguese, removing English text and improving consistency.
	- Enhanced descriptions and terminology for various game elements, such as antagonist types, minor antagonists, engineering topics, and station features.
	- Expanded and clarified the "Moth" species description with more detailed traits and gameplay information.
	- Replaced English bomb defusal instructions with a comprehensive Portuguese guide, including detailed steps and tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->