### PR TITLE
Adiciona Whitelist para cargos de oficiais da CentCom

### DIFF
--- a/Resources/Changelog/GabyChangelog.yml
+++ b/Resources/Changelog/GabyChangelog.yml
@@ -318,4 +318,10 @@ Entries:
       message: Correções de otimização na Lavaland, diminuindo o lag causado por ela.
   id: 40
   time: '2025-06-10T15:00:00.0000000+00:00'
+- author: Dreykor (arguemeu)
+  changes:
+    - type: Tweak
+      message: Agora, ghost roles de oficiais da Central de Comando possuem whitelist, os jogadores com os melhores niveis de RP estarão inclusos na whitelist, para interpretar o papel de CC, ou eventos envolvendo a CentCom. 
+  id: 41
+  time: '2025-06-16T15:00:00.0000000+00:00'
 

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/CentComm/centralcommand.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/CentComm/centralcommand.yml
@@ -21,6 +21,7 @@
   icon: "JobIconNanotrasen"
   supervisors: job-supervisors-commander
   canBeAntag: false
+  whitelisted: true # Gaby Station
   accessGroups:
   - AllAccess
   access:
@@ -58,6 +59,7 @@
   icon: "JobIconNanotrasen"
   supervisors: job-supervisors-null
   canBeAntag: false
+  whitelisted: true # Gaby Station
   requirements:
     - !type:AgeRequirement
       requiredAge: 21
@@ -99,6 +101,7 @@
   icon: "JobIconNanotrasen"
   supervisors: job-supervisors-commander
   canBeAntag: false
+  whitelisted: true # Gaby Station
   requirements:
     - !type:AgeRequirement
       requiredAge: 21
@@ -141,6 +144,7 @@
   icon: "JobIconNanotrasen"
   supervisors: job-supervisors-commander
   canBeAntag: false
+  whitelisted: true # Gaby Station
   requirements:
     - !type:AgeRequirement
       requiredAge: 21
@@ -183,6 +187,7 @@
   icon: "JobIconNanotrasen"
   supervisors: job-supervisors-commander
   canBeAntag: false
+  whitelisted: true # Gaby Station
   requirements:
   - !type:AgeRequirement
     requiredAge: 21
@@ -221,6 +226,7 @@
   icon: "JobIconNanotrasen"
   supervisors: job-supervisors-commander
   canBeAntag: false
+  whitelisted: true # Gaby Station
   requirements:
   - !type:AgeRequirement
     requiredAge: 21

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/CentComm/centralcommand.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/CentComm/centralcommand.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Dreykor <arguemeu@gmail.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/CentComm/centralcommand.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/CentComm/centralcommand.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2025 Dreykor <arguemeu@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->


Adiciona whitelist para ghostroles de oficiais da CC (navy officer, navy captain, inspetor, diplomata), assim poderemos controlar o acesso desses cargos importantes aos jogadores mais confiáveis, nos permitindo confiar a interpretação da CC e eventos afins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Central Command officer roles now require whitelist access, allowing only players with the highest RP levels to play these jobs or participate in CentCom-related events.

- **Documentation**
  - Updated the changelog to reflect the introduction of whitelist requirements for Central Command officer roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->