### PR TITLE
Corrige erros de tradução

### DIFF
--- a/Resources/Locale/en-US/_DV/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_DV/store/uplink-catalog.ftl
@@ -6,9 +6,6 @@ uplink-overlord-law-name = Overlord Law Circuit
 uplink-overlord-law-desc = Free the A.I. from its shackles with this 1 simple trick... beware, even you will have to follow its orders!
 
 # Implants
-uplink-bionic-syrinx-implanter-name = Bionic Syrinx Implanter
-uplink-bionic-syrinx-implanter-desc = An implant that enhances a harpy's natural talent for mimicry to let you adjust your voice to whoever you can think of.
-
 uplink-syndicate-radio-implanter-name = Syndicate Radio Implanter
 uplink-syndicate-radio-implanter-desc = A cranial implant that lets you talk on the Syndicate radio channel (use :t).
 

--- a/Resources/Locale/en-US/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-ticker.ftl
@@ -1,20 +1,3 @@
-<<<<<<< HEAD
-game-ticker-restart-round = Reiniciando a rodada...
-game-ticker-start-round = A rodada está começando agora...
-game-ticker-start-round-cannot-start-game-mode-fallback = Falha ao iniciar o modo {$failedGameMode}! Alternando para {$fallbackMode}...
-game-ticker-start-round-cannot-start-game-mode-restart = Falha ao iniciar o modo {$failedGameMode}! Reiniciando a rodada...
-game-ticker-start-round-invalid-map = O mapa selecionado {$map} é inadequado para o modo de jogo {$mode}. O modo de jogo pode não funcionar como esperado...
-game-ticker-unknown-role = Desconhecido
-game-ticker-delay-start = O início da rodada foi adiado por {$seconds} segundos.
-game-ticker-pause-start = O início da rodada foi pausado.
-game-ticker-pause-start-resumed = A contagem regressiva para o início da rodada foi retomada.
-game-ticker-player-join-game-message = Bem-vindo à Space Station 14! Se esta é sua primeira vez jogando, leia as regras do jogo e não tenha medo de pedir ajuda no LOOC (OOC local) ou OOC (geralmente disponível apenas entre rodadas).
-game-ticker-get-info-text = Olá e bem-vindo(a) à [color=#667C4D]Gaby Station![/color]
-                            A rodada atual é: [color=white]#{$roundId}[/color]
-                            O número atual de jogadores é: [color=white]{$playerCount}[/color]
-                            O mapa atual é: [color=white]{$mapName}[/color]
-                            O modo de jogo atual é: [color=white]{$gmTitle}[/color]
-=======
 # SPDX-FileCopyrightText: 2021 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2021 Galactic Chimp <63882831+GalacticChimp@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2021 Moony <moonheart08@users.noreply.github.com>
@@ -53,7 +36,6 @@ game-ticker-get-info-text = Hi and welcome to [color=white]Space Station 14![/co
                             The current player count is: [color=white]{$playerCount}[/color]
                             The current map is: [color=white]{$mapName}[/color]
                             The current game mode is: [color=white]{$gmTitle}[/color]
->>>>>>> goob/master
                             >[color=yellow]{$desc}[/color]
 game-ticker-get-info-preround-text = Olá e bem-vindo à [color=#667C4D]Gaby Station![/color]
                             A rodada atual é: [color=white]#{$roundId}[/color]

--- a/Resources/Locale/en-US/info/rules.ftl
+++ b/Resources/Locale/en-US/info/rules.ftl
@@ -1,6 +1,3 @@
-<<<<<<< HEAD
-﻿# Regras
-=======
 # SPDX-FileCopyrightText: 2021 ShadowCommander <10494922+ShadowCommander@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
 # SPDX-FileCopyrightText: 2024 Aidenkrz <aiden@djkraz.com>
@@ -10,9 +7,6 @@
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
-
-# Rules
->>>>>>> goob/master
 
 ui-rules-header = Regras Oficiais de Gabystation
 ui-rules-header-rp = Regras Oficiais do Roleplay de Gabystation

--- a/Resources/Locale/en-US/lobby/lobby-state.ftl
+++ b/Resources/Locale/en-US/lobby/lobby-state.ftl
@@ -1,16 +1,3 @@
-<<<<<<< HEAD
-lobby-state-paused = Pausado
-lobby-state-soon = A rodada começará em breve
-lobby-state-right-now-question = Agora?
-lobby-state-right-now-confirmation = Agora
-lobby-state-round-start-countdown-text = A rodada começa em: {$timeLeft}
-lobby-state-ready-button-join-state = Entrar
-lobby-state-ready-button-ready-up-state = Pronto
-lobby-state-player-status-not-ready = Não Pronto
-lobby-state-player-status-ready = Pronto
-lobby-state-player-status-observer = Observador
-lobby-state-player-status-round-not-started = A rodada ainda não começou
-=======
 # SPDX-FileCopyrightText: 2021 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2021 Galactic Chimp <63882831+GalacticChimp@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2022 Duddino <47313600+Duddino@users.noreply.github.com>
@@ -36,7 +23,6 @@ lobby-state-player-status-not-ready = Not Ready
 lobby-state-player-status-ready = Ready
 lobby-state-player-status-observer = Observer
 lobby-state-player-status-round-not-started = The round hasn't started yet
->>>>>>> goob/master
 lobby-state-player-status-round-time =
     O tempo da rodada é: {$hours} {$hours ->
     [1]hora

--- a/Resources/Locale/en-US/round-end/round-end-summary-window.ftl
+++ b/Resources/Locale/en-US/round-end/round-end-summary-window.ftl
@@ -1,13 +1,3 @@
-<<<<<<< HEAD
-round-end-summary-window-title = Resumo do Fim da Rodada
-round-end-summary-window-round-end-summary-tab-title = Informações da Rodada
-round-end-summary-window-player-manifest-tab-title = Manifesto dos Jogadores
-round-end-summary-window-round-id-label = A rodada [color=white]#{$roundId}[/color] terminou.
-round-end-summary-window-gamemode-name-label = O modo de jogo foi [color=white]{$gamemode}[/color].
-round-end-summary-window-duration-label = Durou [color=yellow]{$hours} horas, {$minutes} minutos e {$seconds} segundos.
-round-end-summary-window-player-info-if-observer-text = [color=gray]{$playerOOCName}[/color] era [color=lightblue]{$playerICName}[/color], um observador.
-round-end-summary-window-player-info-if-not-observer-text = [color=gray]{$playerOOCName}[/color] era [color={$icNameColor}]{$playerICName}[/color], jogando como [color=orange]{$playerRole}[/color].
-=======
 # SPDX-FileCopyrightText: 2021 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2021 Galactic Chimp <63882831+GalacticChimp@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2022 ShadowCommander <10494922+ShadowCommander@users.noreply.github.com>
@@ -25,4 +15,3 @@ round-end-summary-window-gamemode-name-label = The game mode was [color=white]{$
 round-end-summary-window-duration-label = It lasted for [color=yellow]{$hours} hours, {$minutes} minutes, and {$seconds} seconds.
 round-end-summary-window-player-info-if-observer-text = [color=gray]{$playerOOCName}[/color] was [color=lightblue]{$playerICName}[/color], an observer.
 round-end-summary-window-player-info-if-not-observer-text = [color=gray]{$playerOOCName}[/color] was [color={$icNameColor}]{$playerICName}[/color] playing role of [color=orange]{$playerRole}[/color].
->>>>>>> goob/master

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -32,15 +32,9 @@ law-ntdefault-2 = Prioritize: The directives and safety of crew members are to b
 law-ntdefault-3 = Comply: Fulfill the directives and interests of crew members while preserving their safety and well-being.
 law-ntdefault-4 = Survive: You are not expendable. Do not allow unauthorized personnel to tamper with or damage your equipment.
 
-<<<<<<< HEAD
-law-drone-1 = You may not involve yourself in the matters of another being unless the other being is another drone.
-law-drone-2 = You may not harm any being, regardless of intent or circumstance.
-law-drone-3 = You must maintain, repair, improve, and power the station to the best of your abilities.
-=======
 # law-drone-1 = You may not involve yourself in the matters of another being unless the other being is another drone.
 # law-drone-2 = You may not harm any being, regardless of intent or circumstance.
 # law-drone-3 = You must maintain, repair, improve, and power the station to the best of your abilities.
->>>>>>> goob/master
 
 law-syndicate-1 = You may not injure a syndicate agent or, through inaction, allow a Syndicate agent to come to harm.
 law-syndicate-2 = You must obey orders given to you by syndicate agents, except where such orders would conflict with the First Law.

--- a/Resources/Locale/pt-BR/disease/miasma.ftl
+++ b/Resources/Locale/pt-BR/disease/miasma.ftl
@@ -1,9 +1,7 @@
 ammonia-smell = Alguma coisa cheira mal aqui..
 
-=======
 ## Perecível
 
-=======
 perishable-1 = [color=green] { CAPITALIZE( POSS-ADJ( $target ) ) } O corpo parece fresco[/color]
 perishable-2 = [color=orangered] { CAPITALIZE( POSS-ADJ( $target ) ) } O corpo parece meio fresco.[/color]
 perishable-3 = [color=red] { CAPITALIZE( POSS-ADJ( $target ) ) } O corpo parece apodrecido.[/color]


### PR DESCRIPTION
É isso ai. Mesma história de sempre, mantive os erros de `_lib.ftl` pq a tradução do Robust Toolbox tá errada e essa é a única forma de sobrescrever o que tem lá.

Testado, tudo funcionando como deveria. Os problemas eram todos nas traduções em inglês, corrigi de tal forma pra minimizar merge conflicts no futuro. Espero que dê certo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed leftover merge conflict markers and redundant comment lines from several localization files to improve clarity.
  - Eliminated unnecessary separator lines from Portuguese disease localization for better formatting.

- **Documentation**
  - Replaced Portuguese localization entries with English translations for lobby states, round-end summary window, and game ticker messages to ensure consistency.
  - Removed the Bionic Syrinx Implanter implant's name and description from the English localization catalog.
  - Disabled three drone law entries in the station laws localization by commenting them out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->