### PR TITLE
Corrige evento de Necromorph

### DIFF
--- a/Resources/Prototypes/_Gabystation/GameRules/GabyEvents.yml
+++ b/Resources/Prototypes/_Gabystation/GameRules/GabyEvents.yml
@@ -23,6 +23,6 @@
     table: !type:GroupSelector
       children:
       - id: NecromorphSlasher
-        weight: 0.04  # aprox 44.72%
+        weight: 0.04
       - id: NecromorphSlasherCorpo
-        weight: 0.1   # aprox 89.44%
+        weight: 0.1

--- a/Resources/Prototypes/_Gabystation/GameRules/GabyEvents.yml
+++ b/Resources/Prototypes/_Gabystation/GameRules/GabyEvents.yml
@@ -1,3 +1,10 @@
+# SPDX-FileCopyrightText: 2024 VictorJob <117521143+VictorJob@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 VictorJob <victorjobnogueira12@gmail.com>
+# SPDX-FileCopyrightText: 2025 AgentePanela <agentepanela@gmail.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   id: NecromorphSpawn
   parent: BaseStationEventShortDelay

--- a/Resources/Prototypes/_Gabystation/GameRules/GabyEvents.yml
+++ b/Resources/Prototypes/_Gabystation/GameRules/GabyEvents.yml
@@ -12,10 +12,17 @@
     minimumPlayers: 15
     weight: 5
     duration: 60
-    maxOccurrences: 1 # Gabystation - necromorph nerf (são mto forte pra ter toda hora)
+    maxOccurrences: 1 # necromorph nerf (são mto forte pra ter toda hora)
+    chaos: 
+      Hostile: 20
+      Medical: 50
+    eventType: HostileSpawn
+  - type: GameRule
+    chaosScore: 40
   - type: VentCrittersRule
-    entries:
-    - id: NecromorphSlasher
-      prob: 0.04
-    - id: NecromorphSlasherCorpo
-      prob: 0.1
+    table: !type:GroupSelector
+      children:
+      - id: NecromorphSlasher
+        weight: 0.04  # aprox 44.72%
+      - id: NecromorphSlasherCorpo
+        weight: 0.1   # aprox 89.44%

--- a/Resources/Prototypes/_Gabystation/GameRules/GabyEvents.yml
+++ b/Resources/Prototypes/_Gabystation/GameRules/GabyEvents.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2024 VictorJob <117521143+VictorJob@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 VictorJob <victorjobnogueira12@gmail.com>
 # SPDX-FileCopyrightText: 2025 AgentePanela <agentepanela@gmail.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
Tava faltando os campos novos dos GameDirectos. Segui os valores padrão das outras `VentCrittersRule` para o `chaos`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new chaos-related properties and event type for certain station events.
  - Added a new rule with a chaos score for specific game events.

- **Refactor**
  - Updated critter spawn configuration to use weighted selection for improved event variety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->