### PR TITLE
Otimiza `GabyLightCycleSystem`

### DIFF
--- a/Content.Server/_Gabystation/LightCycle/GabyLightCycleSystem.cs
+++ b/Content.Server/_Gabystation/LightCycle/GabyLightCycleSystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Server.Chat.Systems;
 using Content.Server.Station.Components;
 using Robust.Shared.Audio;

--- a/Content.Server/_Gabystation/LightCycle/GabyLightCycleSystem.cs
+++ b/Content.Server/_Gabystation/LightCycle/GabyLightCycleSystem.cs
@@ -28,13 +28,15 @@ namespace Content.Server.Time
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
 
         private int _currentHour;
-        private double _tickCount = 0;
         private string? _hexColor = "#FFFFFF";
         private bool _isNight = false;
         private Dictionary<int, Color>? _mapColor = new Dictionary<int, Color>();
         private static readonly Regex? HexPattern = new Regex(@"^#([A-Fa-f0-9]){6}$");
         private static readonly SoundSpecifier? NightAlert = new SoundPathSpecifier("/Audio/_Gabystation/Announcements/nightshift.ogg");
         private static readonly SoundSpecifier? DayAlert = new SoundPathSpecifier("/Audio/_Gabystation/Announcements/dayshift.ogg");
+
+        private double _updateTimer = 0.0f;
+        private const double UpdateInterval = 1.0f; // Roda uma vez por segundo
 
         public override void Initialize()
         {
@@ -79,13 +81,12 @@ namespace Content.Server.Time
         }
         public override void Update(float frameTime)
         {
-            _tickCount++;
-            var updatePerTick = _configuration.GetCVar(CCVars.UpdatePerTick);
+            _updateTimer += frameTime;
 
-            if (updatePerTick == 0 || _tickCount % updatePerTick != 0)
+            if (_updateTimer < UpdateInterval)
                 return;
+            _updateTimer = 0;
 
-            _tickCount = 0;
             _currentHour = TimeSpan.FromSeconds(GetStationTime()).Hours;
             foreach (var comp in EntityQuery<GabyLightCycleComponent>())
             {

--- a/Content.Server/_Gabystation/LightCycle/GabyLightCycleSystem.cs
+++ b/Content.Server/_Gabystation/LightCycle/GabyLightCycleSystem.cs
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 // SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Server/_Gabystation/LightCycle/GabyLightCycleSystem.cs
+++ b/Content.Server/_Gabystation/LightCycle/GabyLightCycleSystem.cs
@@ -40,8 +40,8 @@ namespace Content.Server.Time
         private static readonly SoundSpecifier? NightAlert = new SoundPathSpecifier("/Audio/_Gabystation/Announcements/nightshift.ogg");
         private static readonly SoundSpecifier? DayAlert = new SoundPathSpecifier("/Audio/_Gabystation/Announcements/dayshift.ogg");
 
-        private double _updateTimer = 0.0f;
-        private const double UpdateInterval = 1.0f; // Roda uma vez por segundo
+        private double _updateTimer = 0.0;
+        private const double UpdateInterval = 1.0; // Roda uma vez por segundo
 
         public override void Initialize()
         {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/09dfa268-f2a6-4041-98b2-057735e7e839)

Antes das 17h é a branch `gaby` e depois é esse PR.

Esses testes foram feitos em condições bemmm ideias. A todo momento havia apenas um player parado online no mapa Saltern. Muito provavelmente, na produção, esse sistema não deve ocupar o top 3, como fez nos testes. Mas não pq ele consome menos e, sim, pq os outros consomem mais que ele. Ele ainda tem um impacto grande na performance.

Considerando que o tickrate ideal é 30, cada frametime pode ser no máximo 34ms. Em condições ideais, o sistema consome 3ms que é 8% do frametime máximo. MUITA COISA!!. Muita coisa principalmente pra um sistema que só muda as luizinhas umas três vezes por round JKASDHJKASHGJDKSA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the timing mechanism for light cycle updates, ensuring updates occur at consistent intervals. This change enhances the reliability and predictability of lighting changes in the environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->