### PR TITLE
Correção de bug ancião de chatsan no locale BR

### DIFF
--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -90,6 +90,7 @@
 # SPDX-FileCopyrightText: 2025 AgentePanela <agentepanela@gmail.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Dreykor <arguemeu@gmail.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 ImWeax <59857479+ImWeax@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 TurboTracker <130304754+TurboTrackerss14@users.noreply.github.com>

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -87,10 +87,14 @@
 # SPDX-FileCopyrightText: 2024 to4no_fix <156101927+chavonadelal@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 tosatur <63034378+tosatur@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 voidnull000 <18663194+voidnull000@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 AgentePanela <agentepanela@gmail.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Dreykor <arguemeu@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 ImWeax <59857479+ImWeax@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 TurboTracker <130304754+TurboTrackerss14@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Weax <59857479+ImWeax@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 joshepvodka <86210200+joshepvodka@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Accents that work off of word replacements.

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -529,13 +529,13 @@
     chatsan-word-50: chatsan-replacement-50
     chatsan-word-51: chatsan-replacement-51
     chatsan-word-52: chatsan-replacement-52
-    chatsan-word-53: chatsan-replacement-53
-    chatsan-word-54: chatsan-replacement-54
+    chatsan-word-53: chatsan-replacement-manutencao
+    chatsan-word-54: chatsan-replacement-manutencao
     chatsan-word-55: chatsan-replacement-55
     chatsan-word-56: chatsan-replacement-56
     chatsan-word-57: chatsan-replacement-57
-    chatsan-word-58: chatsan-replacement-58
-    chatsan-word-59: chatsan-replacement-59
+    chatsan-word-58: chatsan-replacement-poise
+    chatsan-word-59: chatsan-replacement-poise
     chatsan-word-60: chatsan-replacement-60
     chatsan-word-61: chatsan-replacement-61
     chatsan-word-62: chatsan-replacement-62
@@ -550,6 +550,56 @@
     chatsan-word-70: chatsan-replacement-70
     chatsan-word-71: chatsan-replacement-71
     # goob end
+    # Gaby start
+    chatsan-word-72: chatsan-replacement-72
+    chatsan-word-73: chatsan-replacement-73
+    chatsan-word-74: chatsan-replacement-74
+    chatsan-word-75: chatsan-replacement-75
+    chatsan-word-76: chatsan-replacement-76
+    chatsan-word-77: chatsan-replacement-77
+    chatsan-word-78: chatsan-replacement-78
+    chatsan-word-79: chatsan-replacement-79
+    chatsan-word-80: chatsan-replacement-80
+    chatsan-word-81: chatsan-replacement-tambem
+    chatsan-word-82: chatsan-replacement-tambem
+    chatsan-word-83: chatsan-replacement-83
+    chatsan-word-84: chatsan-replacement-84
+    chatsan-word-85: chatsan-replacement-85
+    chatsan-word-86: chatsan-replacement-86
+    chatsan-word-87: chatsan-replacement-87
+    chatsan-word-88: chatsan-replacement-88
+    chatsan-word-89: chatsan-replacement-89
+    chatsan-word-90: chatsan-replacement-qualquer
+    chatsan-word-91: chatsan-replacement-qualquer
+    chatsan-word-92: chatsan-replacement-92
+    chatsan-word-93: chatsan-replacement-93
+    chatsan-word-94: chatsan-replacement-94
+    chatsan-word-95: chatsan-replacement-caralho
+    chatsan-word-96: chatsan-replacement-caralho
+    chatsan-word-97: chatsan-replacement-97
+    chatsan-word-98: chatsan-replacement-98
+    chatsan-word-99: chatsan-replacement-99
+    chatsan-word-100: chatsan-replacement-100
+    chatsan-word-101: chatsan-replacement-101
+    chatsan-word-102: chatsan-replacement-102
+    chatsan-word-103: chatsan-replacement-103
+    chatsan-word-104: chatsan-replacement-cacete
+    chatsan-word-105: chatsan-replacement-cacete
+    chatsan-word-106: chatsan-replacement-106
+    chatsan-word-107: chatsan-replacement-moleque
+    chatsan-word-108: chatsan-replacement-moleque
+    chatsan-word-109: chatsan-replacement-109
+    chatsan-word-110: chatsan-replacement-110
+    chatsan-word-111: chatsan-replacement-111
+    chatsan-word-112: chatsan-replacement-112
+    chatsan-word-113: chatsan-replacement-113
+    chatsan-word-114: chatsan-replacement-114
+    chatsan-word-115: chatsan-replacement-115
+    chatsan-word-116: chatsan-replacement-116
+    chatsan-word-117: chatsan-replacement-117
+    chatsan-word-118: chatsan-replacement-118
+    chatsan-word-119: chatsan-replacement-119
+    # Gaby end
 
 - type: accent
   id: liar


### PR DESCRIPTION

## Sobre a PR
Corrige chatsan, para que seja usado todos os que existem no locale BR

## Por quê? / Balanceamento
Correção de bug

## Technical details

## Midia
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

<!--## Requirements -->
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
<!-- Adicione uma entrada para changelog do servidor, bote o emoji :cl: e siga com as mudanças assim como o exemplo.
:cl: em branco fara com que seu nome na changelog apareça como do github, adicione um nome depois do emoji para mudar seu nome na changelog. -->
:cl:
- fix: Correções em um bug que desabilitava metade de substituições de falas abreviadas, agora, por exemplo, falar qm no chat vai ser substituido por intendente de carga, e por ai vai.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the list of word replacements in the chatsanitize accent, adding numerous new mappings for improved text handling.

* **Style**
  * Updated some existing word replacements to use more specific replacement tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->