### PR TITLE
Corrige traduções

### DIFF
--- a/Resources/Locale/pt-BR/_DV/cosmiccult/preset-cosmiccult.ftl
+++ b/Resources/Locale/pt-BR/_DV/cosmiccult/preset-cosmiccult.ftl
@@ -190,5 +190,5 @@ cosmiccult-spire-entropy = Um fragmento de entropia se condensa na superfície d
 cosmiccult-entropy-inserted = Você infunde {$count} entropia no Monólito.
 cosmiccult-entropy-unavailable = Você não pode fazer isso agora.
 cosmiccult-astral-ascendant = {$name}, Ascendente
-cosmiccult-gear-pickup-rejection = O(a) {$ITEM} resiste ao toque de {CAPITALIZE(THE($TARGET))}!
+cosmiccult-gear-pickup-rejection = {ARTIGO-O($ITEM)} {$ITEM} resiste ao toque de {CAPITALIZE(THE($TARGET))}!
 cosmiccult-gear-pickup = Você sente-se se desfazendo ao segurar o(a) {$ITEM}!

--- a/Resources/Locale/pt-BR/cargo/price-gun-component.ftl
+++ b/Resources/Locale/pt-BR/cargo/price-gun-component.ftl
@@ -1,4 +1,4 @@
-price-gun-pricing-result = O dispositivo considera {O($object)} valer {$price} spesos.
+price-gun-pricing-result = O dispositivo considera {ARTIGO-O($object)} valer {$price} spesos.
 price-gun-verb-text = Avaliação
-price-gun-verb-message = Avaliar {O($object)}.
+price-gun-verb-message = Avaliar {ARTIGO-O($object)}.
 price-gun-bounty-complete = O dispositivo confirma que a recompensa contida nele foi concluída.

--- a/Resources/Locale/pt-BR/components/base-computer-ui-component.ftl
+++ b/Resources/Locale/pt-BR/components/base-computer-ui-component.ftl
@@ -1,1 +1,1 @@
-base-computer-ui-component-not-powered = {CAPITALIZE(O($machine))} não tem energia
+base-computer-ui-component-not-powered = {CAPITALIZE(ARTIGO-O($machine))} não tem energia


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR
Corrige uma tradução super chatinha que toda hora aparece. `O() não tem energia`. Grandíssimo ou grandíssima foi o ou a ser que um dia escreveu isso, me deu a ideia de criar as funções pt-br.

## Por quê? / Balanceamento
Chato.

**Changelog**
:cl:
- tweak: Tradução ao clica num objeto sem energia corrigida.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Portuguese (Brazil) localization by updating several strings to use a dynamic article macro, ensuring articles match the grammatical gender or context of referenced items.
  * Adjusted phrasing in multiple UI messages for more natural and accurate language presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->