### PR TITLE
[fix] Corrige sumário do fim de round

### DIFF
--- a/Resources/Locale/pt-BR/objectives/round-end.ftl
+++ b/Resources/Locale/pt-BR/objectives/round-end.ftl
@@ -5,14 +5,16 @@ objectives-round-end-result = {$count ->
 
 objectives-round-end-result-in-custody = {$custody} fora de {$count} {MAKEPLURAL($agent)} estavam sob custódia.
 
-objectives-player-user-named = [color=White]{$name}[/color] ([color=gray]{$user}[/color])
+objectives-player-user-named = [color=white]{$name}[/color] ([color=gray]{$user}[/color])
 objectives-player-user = [color=gray]{$user}[/color]
-objectives-player-named = [color=White]{$name}[/color]
+objectives-player-named = [color=white]{$name}[/color]
 
 objectives-no-objectives = {$custody}{$title} era um {$agent}.
 objectives-with-objectives = {$custody}{$title} era um {$agent} que tinha os seguintes objetivos:
 
-objectives-objective-success = {$objective} | [color={$markupColor}]Sucesso![/color]
-objectives-objective-fail = {$objective} | [color={$markupColor}]Falha![/color] ({$progress}%)
+objectives-objective-success = {$objective} | [color=green]Sucesso![/color] ({TOSTRING($progress, "P0")})
+objectives-objective-partial-success = {$objective} | [color=yellow]Sucesso parcial![/color] ({TOSTRING($progress, "P0")})
+objectives-objective-partial-failure = {$objective} | [color=orange]Falha parcial![/color] ({TOSTRING($progress, "P0")})
+objectives-objective-fail = {$objective} | [color=red]Falha![/color] ({TOSTRING($progress, "P0")})
 
 objectives-in-custody = [bold][color=red]| EM CUSTÓDIA | [/color][/bold]


### PR DESCRIPTION
## Sobre a PR
Atualiza as traduções. Em inglês as traduções do final de round foram atualizadas, esse PR atualiza em português também.

Interessante criar algum tipo de aviso ou issue sempre que mexerem na tradução em inglês, daí fica claro o que devemos atualizar.

## Technical details
Em inglês:
```ftl
objectives-objective-success = {$objective} | [color=green]Success![/color] ({TOSTRING($progress, "P0")})
objectives-objective-partial-success = {$objective} | [color=yellow]Partial Success![/color] ({TOSTRING($progress, "P0")})
objectives-objective-partial-failure = {$objective} | [color=orange]Partial Failure![/color] ({TOSTRING($progress, "P0")})
objectives-objective-fail = {$objective} | [color=red]Failure![/color] ({TOSTRING($progress, "P0")})
```
Em português:
```ftl
objectives-objective-success = {$objective} | [color=green]Sucesso![/color] ({TOSTRING($progress, "P0")})
objectives-objective-partial-success = {$objective} | [color=yellow]Sucesso parcial![/color] ({TOSTRING($progress, "P0")})
objectives-objective-partial-failure = {$objective} | [color=orange]Falha parcial![/color] ({TOSTRING($progress, "P0")})
objectives-objective-fail = {$objective} | [color=red]Falha![/color] ({TOSTRING($progress, "P0")})

```

## Midia
Antes ter um changeling crashava o end round.
<img width="522" height="582" alt="image" src="https://github.com/user-attachments/assets/c5bc1a88-f0e8-443c-90e3-a59a29fd8d08" />

**Changelog**
:cl:
- fix: Corrige o sumário de End Round.