### PR TITLE
Mudança no PTL

### DIFF
--- a/Resources/Prototypes/_Goobstation/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Cargo/cargo_engineering.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Samariehh <samarieh666@gmail.com>

--- a/Resources/Prototypes/_Goobstation/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Cargo/cargo_engineering.yml
@@ -1,4 +1,7 @@
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
+# SPDX-FileCopyrightText: 2025 Samariehh <samarieh666@gmail.com>
+# SPDX-FileCopyrightText: 2025 john git <113782077+whateverusername0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 whateverusername0 <whateveremail>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Goobstation/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Cargo/cargo_engineering.yml
@@ -9,6 +9,6 @@
     sprite: _Goobstation/Structures/Machines/PTL/pt_laser.rsi
     state: base
   product: MachinePowerTransmissionLaserCrate
-  cost: 5000
+  cost: 200000 #Gabystation
   category: cargoproduct-category-name-engineering
   group: market

--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Crates/engineering.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Samariehh <samarieh666@gmail.com>

--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Crates/engineering.yml
@@ -5,7 +5,7 @@
 
 - type: entity
   id: MachinePowerTransmissionLaserCrate
-  parent: CrateGenericSteel
+  parent: CrateEngineeringSecure #Gabystation
   name: power transmission laser crate
   components:
   - type: StorageFill

--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Crates/engineering.yml
@@ -1,4 +1,7 @@
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
+# SPDX-FileCopyrightText: 2025 Samariehh <samarieh666@gmail.com>
+# SPDX-FileCopyrightText: 2025 john git <113782077+whateverusername0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 whateverusername0 <whateveremail>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION

## Sobre a PR
Ajusta o valor do PTL para 200 mil(Que antes era 5 mil) e agora ele vem em uma caixa segura da engenharia.

## Por quê? / Balanceamento
O preço do PTL era extremamente baixo comparado ao que ele gerava de dinheiro. Isso fez com que o departamento de cargo ficasse obsoleto devido à quantidade massiva de dinheiro que era gerada pela engenharia. Um simples TEG poderia gerar dinheiro suficiente para comprar diversos PTL e continuar gerando ainda mais dinheiro de forma praticamente infinita. Essa mudança de preço vai impedir que a engenharia consiga fazer uma montanha de dinheiro no começo do turno, e agora vai levar mais tempo.

Ainda mais, agora o PTL vem em uma caixa segura da engenharia, pois ele é uma forma de gerar dinheiro extremamente delicada. Qualquer posicionamento errado do PTL faria com que a estação ficasse sem energia, e muita gente comprava PTL e fixava em qualquer lugar. Com essa mudança vai reduzir o risco de alguém fazer esse tipo de coisa.

## Technical details
Apenas mudança bem pequena.




**Changelog**
:cl:


- tweak: Agora PTL custa 200 mil e agora vem em uma caixa segura da engenharia.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The cost of the Cargo Engineering PTL product has been significantly increased.
  * The Machine Power Transmission Laser Crate now uses a more secure crate type.
* **Other**
  * Updated copyright information to reflect additional authors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->