### PR TITLE
Fix de varias coisas para Vampiros

### DIFF
--- a/Content.Server/GameTicking/Rules/VampireRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/VampireRuleSystem.cs
@@ -49,7 +49,7 @@ public sealed partial class VampireRuleSystem : GameRuleSystem<VampireRuleCompon
 
     public readonly ProtoId<AntagPrototype> VampirePrototypeId = "Vampire";
 
-    public readonly ProtoId<NpcFactionPrototype> ChangelingFactionId = "Vampire";
+    public readonly ProtoId<NpcFactionPrototype> VampireFactionId = "Vampire";
 
     public readonly ProtoId<NpcFactionPrototype> NanotrasenFactionId = "NanoTrasen";
 
@@ -96,7 +96,7 @@ public sealed partial class VampireRuleSystem : GameRuleSystem<VampireRuleCompon
         }
         // vampire stuff
         _npcFaction.RemoveFaction(target, NanotrasenFactionId, false);
-        _npcFaction.AddFaction(target, ChangelingFactionId);
+        _npcFaction.AddFaction(target, VampireFactionId);
 
         // make sure it's initial chems are set to max
         var vampireComponent = EnsureComp<VampireComponent>(target);

--- a/Content.Server/GameTicking/Rules/VampireRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/VampireRuleSystem.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2024 Rinary <72972221+Rinary1@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Dreykor <160512778+Dreykor@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Dreykor <Dreykor12@gmail.com>
 // SPDX-FileCopyrightText: 2025 Dreykor <arguemeu@gmail.com>
 // SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>

--- a/Content.Server/_Starlight/Vampire/VampireSystem.cs
+++ b/Content.Server/_Starlight/Vampire/VampireSystem.cs
@@ -147,7 +147,7 @@ public sealed partial class VampireSystem : EntitySystem
             if (healing == null)
                 continue;
 
-            if (healing.NextHealTick <= 0)
+            if (healing.NextHealTick >= 0) // Condição invertida denovo?
             {
                 healing.NextHealTick = 1;
                 DoCoffinHeal(uid, healing);

--- a/Content.Server/_Starlight/Vampire/VampireSystem.cs
+++ b/Content.Server/_Starlight/Vampire/VampireSystem.cs
@@ -147,7 +147,7 @@ public sealed partial class VampireSystem : EntitySystem
             if (healing == null)
                 continue;
 
-            if (healing.NextHealTick >= 0) // Condição invertida denovo?
+            if (healing.NextHealTick <= 0)
             {
                 healing.NextHealTick = 1;
                 DoCoffinHeal(uid, healing);

--- a/Content.Server/_Starlight/Vampire/VampireSystem.cs
+++ b/Content.Server/_Starlight/Vampire/VampireSystem.cs
@@ -514,6 +514,6 @@ public sealed partial class VampireSystem : EntitySystem
 
         // Garante que vamp tenha VampireDeathsEmbraceComponent
 
-        var deathsEmbraceComp = EnsureComp<vampiredeathsEmbraceComponent>(uid);
+        var deathsEmbraceComp = EnsureComp<VampireDeathsEmbraceComponent>(uid);
     }
 }

--- a/Content.Server/_Starlight/Vampire/VampireSystem.cs
+++ b/Content.Server/_Starlight/Vampire/VampireSystem.cs
@@ -150,8 +150,13 @@ public sealed partial class VampireSystem : EntitySystem
             if (healing.NextHealTick <= 0)
             {
                 healing.NextHealTick = 1;
+            }
+
+            if (healing.NextHealTick > 0)
+            {
                 DoCoffinHeal(uid, healing);
             }
+
             healing.NextHealTick -= frameTime;
         }
 

--- a/Content.Server/_Starlight/Vampire/VampireSystem.cs
+++ b/Content.Server/_Starlight/Vampire/VampireSystem.cs
@@ -511,5 +511,9 @@ public sealed partial class VampireSystem : EntitySystem
             mindComp.DefaultChannel = "VampireMind";
         if (!mindComp.Channels.Contains("VampireMind"))
             mindComp.Channels.Add("VampireMind");
+
+        // Garante que vamp tenha VampireDeathsEmbraceComponent
+
+        var deathsEmbraceComp = EnsureComp<vampiredeathsEmbraceComponent>(uid);
     }
 }


### PR DESCRIPTION
TODO:
 - [ ] Garantir que vampiros recebam VampireDeathEmbrace componente, alem de outros faltando, ao se tornarem vampiros.
- [ ] Concertar o sistema de cura constante quando um vampiro estar em um caixão.
- [ ] Quando um vampiro for resgatado pelo VampireDeathEmbrace, ele deve ser completamente curado e revivido.
- [ ] Habilidade de escolher mutações não é possivel usar dependendo da raça do jogador.
- [ ] Buffar as habilidades de todos as mutações de vampiros, excluindo o caminho do goliath.
- [ ] Verificar possivel crashamento de servidor ao iniciar a rodada com modo de jogo de vampiro.


Aceito ajuda se for possivel, tem coisa que não sei se consigo resolver.

<--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
