### PR TITLE
fix: Corrige um documento

### DIFF
--- a/Resources/Locale/pt-BR/corvax/paper/doc-printer.ftl
+++ b/Resources/Locale/pt-BR/corvax/paper/doc-printer.ftl
@@ -1288,37 +1288,37 @@ doc-text-printer-REPORTACCOMPLISHMENTGOALS =
                                 ⠀[italic]Espaço para carimbos[/italic]
 
 # Gaby add
-doc-text-printer-ReportStation =
-[color=#1b67a5]░░██░░ [head=2]Documento Oficial[/head]
-▀████▀ [head=3]Assunto: Relatório Setorial – Status Operacional da Estação[/head]
-▄█▀▀█▄ [head=3]De: Comando da Estação[/head]
-[/color]──────────────────────────────────────────
-
-Relatório geral de status da estação, com informações coletadas e organizadas por setor:
-
-[color=#f2e052][bold]Engenharia:[/bold][/color]
-[INSIRA AQUI UM RESUMO DA SITUAÇÃO]
-
-[color=#d28150][bold]Setor de Cargas:[/bold][/color]
-[INSIRA AQUI UM RESUMO DA SITUAÇÃO]
-
-[color=#ff5c5c][bold]Segurança:[/bold][/color]
-[INSIRA AQUI UM RESUMO DA SITUAÇÃO]
-
-[color=#5b97bc][bold]Departamento Médico:[/bold][/color]
-[INSIRA AQUI UM RESUMO DA SITUAÇÃO]
-
-[color=#9fed58][bold]Setor Civil e Serviços:[/bold][/color]
-[INSIRA AQUI UM RESUMO DA SITUAÇÃO]
-
-[color=#c96dbf][bold]Pesquisa Científica (SCI):[/bold][/color]
-[INSIRA AQUI UM RESUMO DA SITUAÇÃO]
-
-As seguintes porcentagens de progresso foram atingidas:
-• Engenharia: 0%\
-• Civil: 0%\
-• Experimental: 0%\
-• Segurança: 0%
-
-=============================================
-                                ⠀[italic]Espaço para carimbos[/italic]
+doc-text-printer-RelatorioSetorial =
+    {"["}color=#1b67a5]░░██░░ [head=2]Documento Oficial[/head]
+    ▀████▀ [head=3]Assunto: Relatório Setorial – Status Operacional da Estação[/head]
+    ▄█▀▀█▄ [head=3]De: Comando da Estação[/head]
+    {"["}/color]──────────────────────────────────────────
+    
+    Relatório geral de status da estação, com informações coletadas e organizadas por setor:
+    
+    {"["}color=#f2e052][bold]Engenharia:[/bold][/color]
+    \[INSIRA AQUI UM RESUMO DA SITUAÇÃO\]
+    
+    {"["}color=#d28150][bold]Setor de Cargas:[/bold][/color]
+    \[INSIRA AQUI UM RESUMO DA SITUAÇÃO\]
+    
+    {"["}color=#ff5c5c][bold]Segurança:[/bold][/color]
+    INSIRA AQUI UM RESUMO DA SITUAÇÃO\]
+    
+    {"["}color=#5b97bc][bold]Departamento Médico:[/bold][/color]
+    \[INSIRA AQUI UM RESUMO DA SITUAÇÃO\]
+    
+    {"["}color=#9fed58][bold]Setor Civil e Serviços:[/bold][/color]
+    \[INSIRA AQUI UM RESUMO DA SITUAÇÃO\]
+    
+    {"["}color=#c96dbf][bold]Pesquisa Científica (SCI):[/bold][/color]
+    \[INSIRA AQUI UM RESUMO DA SITUAÇÃO\]
+    
+    As seguintes porcentagens de progresso foram atingidas:
+    - Engenharia: 0%
+    - Civil: 0%
+    - Experimental: 0%
+    - Segurança: 0%
+    
+    =============================================
+                                    ⠀[italic]Espaço para carimbos[/italic]

--- a/Resources/Prototypes/Corvax/Catalog/Fills/Paper/document.yml
+++ b/Resources/Prototypes/Corvax/Catalog/Fills/Paper/document.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2024 Panela <107573283+AgentePanela@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 AgentePanela <agentepanela@gmail.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   parent: Paper
   id: PrintedDocument

--- a/Resources/Prototypes/Corvax/Catalog/Fills/Paper/document.yml
+++ b/Resources/Prototypes/Corvax/Catalog/Fills/Paper/document.yml
@@ -518,3 +518,11 @@
   components:
     - type: Paper
       content: doc-text-printer-REPORTACCOMPLISHMENTGOALS
+
+- type: entity
+  parent: PrintedDocument
+  id: PrintedDocumentRelatorioSetorial
+  name: Relatório setorial
+  components:
+    - type: Paper
+      content: doc-text-printer-RelatorioSetorial

--- a/Resources/Prototypes/Corvax/Catalog/Fills/Paper/document.yml
+++ b/Resources/Prototypes/Corvax/Catalog/Fills/Paper/document.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2024 Panela <107573283+AgentePanela@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 AgentePanela <agentepanela@gmail.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/Corvax/Recipes/Lathes/Packs/docPrinter.yml
+++ b/Resources/Prototypes/Corvax/Recipes/Lathes/Packs/docPrinter.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2025 AgentePanela <agentepanela@gmail.com>
+# SPDX-FileCopyrightText: 2025 Dreykor <160512778+Dreykor@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: latheRecipePack
   id: docPrinterRecipePack
   recipes:

--- a/Resources/Prototypes/Corvax/Recipes/Lathes/Packs/docPrinter.yml
+++ b/Resources/Prototypes/Corvax/Recipes/Lathes/Packs/docPrinter.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 AgentePanela <agentepanela@gmail.com>
 # SPDX-FileCopyrightText: 2025 Dreykor <160512778+Dreykor@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/Corvax/Recipes/Lathes/Packs/docPrinter.yml
+++ b/Resources/Prototypes/Corvax/Recipes/Lathes/Packs/docPrinter.yml
@@ -59,7 +59,8 @@
     - PrintedDocumentJudgmentRecipe
     - PrintedDocumentStatementHealtheRecipe
     - PrintedDocumentDecisionToStartTrialRecipe
-    - PrintedDocumentReportStation # Gaby add
+    # GabyStation documents
+    - PrintedDocumentRelatorioSetorialRecipe 
 
 - type: latheRecipePack
   id: docPrinterRecipeEmagPack

--- a/Resources/Prototypes/Recipes/Lathes/printer.yml
+++ b/Resources/Prototypes/Recipes/Lathes/printer.yml
@@ -509,3 +509,13 @@
   category: ErrorDocument
   completetime: 2
   applyMaterialDiscount: false
+
+# GabyStation documents start
+- type: latheRecipe
+  id: PrintedDocumentRelatorioSetorialRecipe
+  parent: BaseDocumentRecipe
+  result: PrintedDocumentRelatorioSetorial
+  category: Reports
+  completetime: 2
+  applyMaterialDiscount: false
+# GabyStation documents end

--- a/Resources/Prototypes/Recipes/Lathes/printer.yml
+++ b/Resources/Prototypes/Recipes/Lathes/printer.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2024 Panela <107573283+AgentePanela@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Dreykor <160512778+Dreykor@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/Recipes/Lathes/printer.yml
+++ b/Resources/Prototypes/Recipes/Lathes/printer.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2024 Panela <107573283+AgentePanela@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Dreykor <160512778+Dreykor@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: latheRecipe
   abstract: true
   id: BaseDocumentRecipe


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR
Dando erro no linter, esse PR resolve pelo menos o primeiro problema.

## Technical details
Uma confusão gigantesca mexer com ftl e markdown ao mesmo tempo. Deixar algumas coisas que eu entendi aqui caso alguém tenha um problema parecido.

### Sintaxe de texto de várias linha no FTL

Em traduções com mais de uma linha, obrigatoriamente, precisa-se de pelo menos um **espaço** de indentação (não use tabs). Por exemplo

```ftl
meu-texto-traduzido-numeros = 
    Os três primeiros números em português são:
    1: um
    2: dois
    3: três
```

Dentro de jogo, a loc `meu-texto-traduzido-numeros` vai valer 

```
Os três primeiros números em português são:
1: um
2: dois
3: três
```

Outra coisa, quando temos várias linhas, nenhuma pode iniciar com os caracteres especiais `*`, `.`, `[` e `{`. Esses caracteres são usados pela sintaxe dos arquivos ftl. Se quisermos usar eles, precisamos escapar eles. Fica assim:

```ftl
meu-texto-traduzido-delimitadores =
    Chamamos alguns delimitadores da seguinte maneira:
    (: parênteses
    {"["}: colchetes
    {"{"}: chaves
```

Dentro de jogo, a loc `meu-texto-traduzido-delimitadores` vai valer

```
Chamamos alguns delimitadores da seguinte maneira:
(: parênteses
[: colchetes
{: chaves
```

Importante notar que só precisa escapar eles se forem o primeiro caracter da linha, caso seja o segundo ou adiante não se tem a necessidade de escapar eles. Outra coisa importante de notar, espaços também são caracteres.

Sobre os espaços, em textos com várias linhas, o interpretador vai verificar a menor indentação e usar ela como "base". Por exemplo

```
meu-texto-traduzido-espacos = 
    <- mesmo que no arquivo de ftl aqui tem quatro espaços, no resultado não terá nada
        <- aqui tem exatamente quatro espaços
    0 espaços! Se quissésemos iniciar essa linha com [, teriamos que escapar ele
     <- exatamente um espaço. Aqui não haveria a necessidade de escapar o [, o primeiro caracter é um espaço.
```

Nessa situação, o interpretador entenderia como a indentação "base" por 4 espaços. Isso pois se tomarmos o minimo de espaço de todas as linhas, obtemos 4. Depois dos espaços "base", o texto vai aparecer normalmente dentro do jogo. Então, a loc `meu-texto-traduzido-espacos` vira

```
<- mesmo que no arquivo de ftl aqui tem quatro espaços, no resultado não terá nada
    <- aqui tem exatamente quatro espaços
0 espaços! Se quissésemos iniciar essa linha com [, teriamos que escapar ele 
 <- exatamente um espaço. Aqui não haveria a necessidade de escapar o [, o primeiro caracter é um espaço.
```

### Markdown e FTL
Agora, com isso, conseguimos resolver um problema comum: escrever markdown num arquivo ftl. Comum? Sim, comum fora do jogo (todo comentario, post, readme no github interpreta markdown) e dentro do jogo! A maioria das UIs interpretam markdown que geralmente vem dos arquivos de tradução. Por exemplo, as mensagens no radio são escritas em markdown e tem origem nos arquivos de tradução. Os papeis suportam markdown para que possamos fazer coisas bonitinhas.

Um exemplinho. "[color=green]olá[\color]" ficaria um "olá" verde no chat do jogo. Caso queiramos usar um colchete temos que escapar ele com um \. Então, para mostrar "[" teriamos que usar "\[". 

Misturando markdown e FTL nois encontra essa coisa feiosa:

```
doc-text-printer-RelatorioSetorial =
    {"["}color=#1b67a5]░░██░░ [head=2]Documento Oficial[/head]
    ▀████▀ [head=3]Assunto: Relatório Setorial – Status Operacional da Estação[/head]
    ▄█▀▀█▄ [head=3]De: Comando da Estação[/head]
    {"["}/color]──────────────────────────────────────────
    
    Relatório geral de status da estação, com informações coletadas e organizadas por setor:
    
    {"["}color=#f2e052][bold]Engenharia:[/bold][/color]
    \[INSIRA AQUI UM RESUMO DA SITUAÇÃO\]
    
    {"["}color=#d28150][bold]Setor de Cargas:[/bold][/color]
    \[INSIRA AQUI UM RESUMO DA SITUAÇÃO\]
    
    {"["}color=#ff5c5c][bold]Segurança:[/bold][/color]
    INSIRA AQUI UM RESUMO DA SITUAÇÃO\]
    
    {"["}color=#5b97bc][bold]Departamento Médico:[/bold][/color]
    \[INSIRA AQUI UM RESUMO DA SITUAÇÃO\]
    
    {"["}color=#9fed58][bold]Setor Civil e Serviços:[/bold][/color]
    \[INSIRA AQUI UM RESUMO DA SITUAÇÃO\]
    
    {"["}color=#c96dbf][bold]Pesquisa Científica (SCI):[/bold][/color]
    \[INSIRA AQUI UM RESUMO DA SITUAÇÃO\]
    
    As seguintes porcentagens de progresso foram atingidas:
    - Engenharia: 0%
    - Civil: 0%
    - Experimental: 0%
    - Segurança: 0%
    
    =============================================
                                    ⠀[italic]Espaço para carimbos[/italic]
```

Há momentos que precisamos escapar colchetes no markdown e outras horas no FTL. Por exemplo `{"["}color=#c96dbf][bold]Pesquisa Científica (SCI):[/bold][/color]` vira o texto `[color=#c96dbf][bold]Pesquisa Científica (SCI):[/bold][/color]` e dentro de um papel no game é o texto `Pesquisa Científica (SCI):` em negrito e roxo claro.

No caso de ` \[INSIRA AQUI UM RESUMO DA SITUAÇÃO\]`, queremos que o colchete apareça no papel, então precisamos escapar o colchete pro markdown mostrar corretamente. E, lembrando da dica que somente precisa escapar no ftl quando é o primeiro caracter, chegamos em `\[INSIRA AQUI UM RESUMO DA SITUAÇÃO\]` (escapamos o último também em md).    

Essa coisa feiosa (?), fica assim dentro de jogo:

<img width="517" height="768" alt="image" src="https://github.com/user-attachments/assets/021e1575-f6ec-41cd-b03e-76843d3b8151" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Relatório setorial" printed document, available via lathe recipe under the "Reports" category.

* **Improvements**
  * Updated the formatting and localization for the sector status report document in Portuguese (Brazil), improving clarity and consistency.

* **Chores**
  * Added copyright and license headers to relevant resource files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->