### PR TITLE
[Bounty] Enshittificar Cirurgias e Cia

### DIFF
--- a/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
+++ b/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: 2024 deltanedas <@deltanedas:kde.org>
 // SPDX-FileCopyrightText: 2025 AgentePanela <agentepanela@gmail.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 // SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>

--- a/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
+++ b/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
@@ -1,8 +1,10 @@
 // SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
 // SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 deltanedas <@deltanedas:kde.org>
+// SPDX-FileCopyrightText: 2025 AgentePanela <agentepanela@gmail.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 // SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>
 // SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>

--- a/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
+++ b/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
@@ -46,6 +46,8 @@ public sealed class SurgerySystem : SharedSurgerySystem
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly WoundSystem _wounds = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
+
     public override void Initialize()
     {
         base.Initialize();

--- a/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
+++ b/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
@@ -41,7 +41,6 @@ public sealed class SurgerySystem : SharedSurgerySystem
 {
     [Dependency] private readonly BodySystem _body = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
-    [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly IPrototypeManager _prototypes = default!;
     [Dependency] private readonly PopupSystem _popup = default!;

--- a/Content.Shared/_Gabystation/CCVar/CVars.Gaby.cs
+++ b/Content.Shared/_Gabystation/CCVar/CVars.Gaby.cs
@@ -29,27 +29,29 @@ public sealed partial class GabyCVars
     // Enshittificar Cirurgias e Cia
 
     /// <summary>
-    /// Quantidade de veneno causado por passo ao fazer uma cirurgia sem luva ou sem máscara.
+    /// Poison damage applied per surgery step when the surgeon lacks proper PPE.
+    /// Triggers when missing gloves or mask and not sanitized.
     /// </summary>
-    public static readonly CVarDef<float> SurgeryWithoutEquipmentDamage =
-        CVarDef.Create("gaby.surgery.surgery_without_equipment_damage", 5f, CVar.SERVER | CVar.REPLICATED);
+    public static readonly CVarDef<float> SurgerySepsisEquipmentPenalty =
+        CVarDef.Create("gaby.surgery.sepsis_equipment_penalty", 5f, CVar.SERVER | CVar.REPLICATED);
 
     /// <summary>
-    /// Quantidade de veneno causado por passo ao fazer uma cirurgia fora da mesa de operação.
+    /// Poison damage applied per surgery step when operating outside proper surgical tables.
     /// </summary>
-    public static readonly CVarDef<float> SurgeryOffTableDamage =
-        CVarDef.Create("gaby.surgery.surgery_off_table_damage", 5f, CVar.SERVER | CVar.REPLICATED);
+    public static readonly CVarDef<float> SurgerySepsisLocationPenalty =
+        CVarDef.Create("gaby.surgery.sepsis_location_penalty", 5f, CVar.SERVER | CVar.REPLICATED);
 
     /// <summary>
-    /// Quantidade de veneno causado por passo e por ser vivo ao fazer uma cirurgia além da lotação máxima.
+    /// Poison damage applied per surgery step for each unsanitazed person around surgery.
     /// </summary>
-    public static readonly CVarDef<float> SurgeryMaxLotationDamage =
-        CVarDef.Create("gaby.surgery.surgery_max_lotation_damage", 5f, CVar.SERVER | CVar.REPLICATED);
+    public static readonly CVarDef<float> SurgerySepsisCrowdingPenalty =
+        CVarDef.Create("gaby.surgery.sepsis_crowding_penalty", 5f, CVar.SERVER | CVar.REPLICATED);
 
     /// <summary>
-    /// Distância em tiles que será procurado entidades pra lotação máxima.
+    /// Range in tiles to check for crowding around surgery sites.
+    /// Only living entities within this range count toward crowding penalties.
     /// </summary>
-    public static readonly CVarDef<float> SurgeryMaxLotationDistance =
-        CVarDef.Create("gaby.surgery.surgery_max_lotation_range", 5f, CVar.SERVER | CVar.REPLICATED);
+    public static readonly CVarDef<float> SurgeryCrowdingCheckRange =
+        CVarDef.Create("gaby.surgery.crowding_check_range", 5f, CVar.SERVER | CVar.REPLICATED);
 
 }

--- a/Content.Shared/_Gabystation/CCVar/CVars.Gaby.cs
+++ b/Content.Shared/_Gabystation/CCVar/CVars.Gaby.cs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2025 AgentePanela <agentepanela@gmail.com>
 // SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
+// SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 // SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 joshepvodka <86210200+joshepvodka@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 joshepvodka <guilherme.ornel@gmail.com>

--- a/Content.Shared/_Gabystation/CCVar/CVars.Gaby.cs
+++ b/Content.Shared/_Gabystation/CCVar/CVars.Gaby.cs
@@ -47,12 +47,6 @@ public sealed partial class GabyCVars
         CVarDef.Create("gaby.surgery.surgery_max_lotation_damage", 5f, CVar.SERVER | CVar.REPLICATED);
 
     /// <summary>
-    /// Quantidade máxima de seres vivos permitida ao redor de uma cirurgia (sem contar o paciente).
-    /// </summary>
-    public static readonly CVarDef<int> SurgeryMaxLotation =
-        CVarDef.Create("gaby.surgery.surgery_max_lotation", 3, CVar.SERVER | CVar.REPLICATED);
-
-    /// <summary>
     /// Distância em tiles que será procurado entidades pra lotação máxima.
     /// </summary>
     public static readonly CVarDef<float> SurgeryMaxLotationDistance =

--- a/Content.Shared/_Gabystation/CCVar/CVars.Gaby.cs
+++ b/Content.Shared/_Gabystation/CCVar/CVars.Gaby.cs
@@ -24,4 +24,37 @@ public sealed partial class GabyCVars
     /// </summary>
     public static readonly CVarDef<bool> ICAlternateJobTitlesEnable =
         CVarDef.Create("ic.alternate_job_titles_enable", true, CVar.SERVER | CVar.REPLICATED);
+
+    // Enshittificar Cirurgias e Cia
+
+    /// <summary>
+    /// Quantidade de veneno causado por passo ao fazer uma cirurgia sem luva ou sem máscara.
+    /// </summary>
+    public static readonly CVarDef<float> SurgeryWithoutEquipmentDamage =
+        CVarDef.Create("gaby.surgery.surgery_without_equipment_damage", 5f, CVar.SERVER | CVar.REPLICATED);
+
+    /// <summary>
+    /// Quantidade de veneno causado por passo ao fazer uma cirurgia fora da mesa de operação.
+    /// </summary>
+    public static readonly CVarDef<float> SurgeryOffTableDamage =
+        CVarDef.Create("gaby.surgery.surgery_off_table_damage", 5f, CVar.SERVER | CVar.REPLICATED);
+
+    /// <summary>
+    /// Quantidade de veneno causado por passo e por ser vivo ao fazer uma cirurgia além da lotação máxima.
+    /// </summary>
+    public static readonly CVarDef<float> SurgeryMaxLotationDamage =
+        CVarDef.Create("gaby.surgery.surgery_max_lotation_damage", 5f, CVar.SERVER | CVar.REPLICATED);
+
+    /// <summary>
+    /// Quantidade máxima de seres vivos permitida ao redor de uma cirurgia (sem contar o paciente).
+    /// </summary>
+    public static readonly CVarDef<int> SurgeryMaxLotation =
+        CVarDef.Create("gaby.surgery.surgery_max_lotation", 3, CVar.SERVER | CVar.REPLICATED);
+
+    /// <summary>
+    /// Distância em tiles que será procurado entidades pra lotação máxima.
+    /// </summary>
+    public static readonly CVarDef<float> SurgeryMaxLotationDistance =
+        CVarDef.Create("gaby.surgery.surgery_max_lotation_range", 5f, CVar.SERVER | CVar.REPLICATED);
+
 }

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -746,11 +746,9 @@ public abstract partial class SharedSurgerySystem
 
         bool IsSanitazed(EntityUid ent)
         {
-            if (HasComp<SanitizedComponent>(args.User))
-                return true;
-
-            return _inventory.TryGetSlotEntity(args.User, "gloves", out var _)
-                && _inventory.TryGetSlotEntity(args.User, "mask", out var _);
+            return HasComp<SanitizedComponent>(ent)
+                || _inventory.TryGetSlotEntity(ent, "gloves", out var _)
+                && _inventory.TryGetSlotEntity(ent, "mask", out var _);
         }
     }
 

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -691,18 +691,24 @@ public abstract partial class SharedSurgerySystem
     }
     private void HandleSanitization(SurgeryStepEvent args)
     {
-        if (_inventory.TryGetSlotEntity(args.User, "gloves", out var _)
-            && _inventory.TryGetSlotEntity(args.User, "mask", out var _))
+        var sepsis = new DamageSpecifier();
+
+        // Check if the (user has gloves on && user has mask on) || (user has SanitizedComponent)
+        if ((!_inventory.TryGetSlotEntity(args.User, "gloves", out var _) || !_inventory.TryGetSlotEntity(args.User, "mask", out var _))
+            && !HasComp<SanitizedComponent>(args.User))
+            sepsis += new DamageSpecifier(_prototypes.Index<DamageTypePrototype>("Poison"), 5);
+
+        // Gaby Station -> Enshittificar Cirurgias e Cia
+        // Check if the (patient is buckled) && (patient is buckled to an operating table)
+        if (!TryComp<BuckleComponent>(args.Body, out var buckle)
+            || !HasComp<OperatingTableComponent>(buckle.BuckledTo))
+            sepsis += new DamageSpecifier(_prototypes.Index<DamageTypePrototype>("Poison"), 5);
+
+        // If there is (no damage) || (patient is a "patient" && patient is immune to sepsis), then theres nothing to do
+        if (!sepsis.DamageDict.Any()
+            || TryComp<SurgeryTargetComponent>(args.Body, out var surgeryTargetComponent) && surgeryTargetComponent.SepsisImmune)
             return;
 
-        if (HasComp<SanitizedComponent>(args.User))
-            return;
-
-        if (TryComp<SurgeryTargetComponent>(args.Body, out var surgeryTargetComponent) &&
-            surgeryTargetComponent.SepsisImmune)
-            return;
-
-        var sepsis = new DamageSpecifier(_prototypes.Index<DamageTypePrototype>("Poison"), 5);
         var ev = new SurgeryStepDamageEvent(args.User, args.Body, args.Part, args.Surgery, sepsis, 0.5f);
         RaiseLocalEvent(args.Body, ref ev);
     }

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -1,11 +1,14 @@
 // SPDX-FileCopyrightText: 2024 Skubman <ba.fallaria@gmail.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Janet Blackquill <uhhadd@gmail.com>
 // SPDX-FileCopyrightText: 2025 Kayzel <43700376+KayzelW@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 // SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 // SPDX-FileCopyrightText: 2025 Roudenn <romabond091@gmail.com>
 // SPDX-FileCopyrightText: 2025 Spatison <137375981+Spatison@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Trest <144359854+trest100@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2024 Skubman <ba.fallaria@gmail.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Janet Blackquill <uhhadd@gmail.com>
 // SPDX-FileCopyrightText: 2025 Kayzel <43700376+KayzelW@users.noreply.github.com>

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -89,7 +89,6 @@ public abstract partial class SharedSurgerySystem
             subs.Event<SurgeryStepChosenBuiMsg>(OnSurgeryTargetStepChosen);
         });
 
-        _config.OnValueChanged(GabyCVars.SurgeryMaxLotation, newValue => _surgeryMaxLotation = newValue);
         _config.OnValueChanged(GabyCVars.SurgeryMaxLotationDamage, newValue => _surgeryMaxLotationDamage = newValue);
         _config.OnValueChanged(GabyCVars.SurgeryMaxLotationDistance, newValue => _surgeryMaxLotationDistance = newValue);
         _config.OnValueChanged(GabyCVars.SurgeryOffTableDamage, newValue => _surgeryOffTableDamage = newValue);
@@ -705,7 +704,6 @@ public abstract partial class SharedSurgerySystem
     private float _surgeryOffTableDamage = 5f;
     private float _surgeryMaxLotationDistance = 5f;
     private float _surgeryMaxLotationDamage = 5f;
-    private int _surgeryMaxLotation = 5;
 
     private void HandleSanitization(SurgeryStepEvent args)
     {
@@ -726,7 +724,7 @@ public abstract partial class SharedSurgerySystem
             sepsis += new DamageSpecifier(poisonPrototype, _surgeryOffTableDamage);
 
         // Conta a entidades que estão vivas, não são borgs, estão sem luva/mascara e tem acesso ao paciente.
-        var mobCount = _lookup.GetEntitiesInRange(args.Body, _surgeryMaxLotationDistance)
+        var unsanitazedMobCount = _lookup.GetEntitiesInRange(args.Body, _surgeryMaxLotationDistance)
             .Where(ent =>
                 _mobState.IsAlive(ent)
                 && !HasComp<BorgChassisComponent>(ent)
@@ -735,9 +733,8 @@ public abstract partial class SharedSurgerySystem
             )
             .Count();
 
-        // Only the surgeon and more two people around the surgery.
-        if (mobCount > _surgeryMaxLotation)
-            sepsis += new DamageSpecifier(poisonPrototype, _surgeryMaxLotationDamage * (mobCount - _surgeryMaxLotation));
+        if (unsanitazedMobCount > 0)
+            sepsis += new DamageSpecifier(poisonPrototype, _surgeryMaxLotationDamage * unsanitazedMobCount);
         // Gaby Station -> Enshittificar Cirurgias e Cia end
 
         // If there is (no damage), theres nothing to do.

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -58,6 +58,11 @@ namespace Content.Shared._Shitmed.Medical.Surgery;
 
 public abstract partial class SharedSurgerySystem
 {
+    private float _sepsisEquipmentPenalty;
+    private float _sepsisLocationPenalty;
+    private float _sepsisCrowdingPenalty;
+    private float _crowdingCheckRange;
+
     private void InitializeSteps()
     {
         SubscribeLocalEvent<SurgeryStepComponent, SurgeryStepEvent>(OnToolStep);
@@ -89,10 +94,10 @@ public abstract partial class SharedSurgerySystem
             subs.Event<SurgeryStepChosenBuiMsg>(OnSurgeryTargetStepChosen);
         });
 
-        _config.OnValueChanged(GabyCVars.SurgeryMaxLotationDamage, newValue => _surgeryMaxLotationDamage = newValue);
-        _config.OnValueChanged(GabyCVars.SurgeryMaxLotationDistance, newValue => _surgeryMaxLotationDistance = newValue);
-        _config.OnValueChanged(GabyCVars.SurgeryOffTableDamage, newValue => _surgeryOffTableDamage = newValue);
-        _config.OnValueChanged(GabyCVars.SurgeryWithoutEquipmentDamage, newValue => _surgeryWithoutEquipmentDamage = newValue);
+        _config.OnValueChanged(GabyCVars.SurgerySepsisEquipmentPenalty, value => _sepsisEquipmentPenalty = value, true);
+        _config.OnValueChanged(GabyCVars.SurgerySepsisLocationPenalty, value => _sepsisLocationPenalty = value, true);
+        _config.OnValueChanged(GabyCVars.SurgerySepsisCrowdingPenalty, value => _sepsisCrowdingPenalty = value, true);
+        _config.OnValueChanged(GabyCVars.SurgeryCrowdingCheckRange, value => _crowdingCheckRange = value, true);
     }
 
     private void SubSurgery<TComp>(EntityEventRefHandler<TComp, SurgeryStepEvent> onStep,
@@ -700,11 +705,6 @@ public abstract partial class SharedSurgerySystem
 
     }
 
-    private float _surgeryWithoutEquipmentDamage = 5f;
-    private float _surgeryOffTableDamage = 5f;
-    private float _surgeryMaxLotationDistance = 5f;
-    private float _surgeryMaxLotationDamage = 5f;
-
     private void HandleSanitization(SurgeryStepEvent args)
     {
         // If the (patient is a "patient" && patient is immune to sepsis), then theres nothing to do.
@@ -715,16 +715,15 @@ public abstract partial class SharedSurgerySystem
         var poisonPrototype = _prototypes.Index<DamageTypePrototype>("Poison");
 
         if (!IsSanitazed(args.User))
-            sepsis += new DamageSpecifier(poisonPrototype, _surgeryWithoutEquipmentDamage);
+            sepsis += new DamageSpecifier(poisonPrototype, _sepsisEquipmentPenalty);
 
         // Gaby Station -> Enshittificar Cirurgias e Cia start
         // Check if the (patient is buckled) && (patient is buckled to an operating table).
         if (!TryComp<BuckleComponent>(args.Body, out var buckleComponent)
             || !HasComp<OperatingTableComponent>(buckleComponent.BuckledTo))
-            sepsis += new DamageSpecifier(poisonPrototype, _surgeryOffTableDamage);
+            sepsis += new DamageSpecifier(poisonPrototype, _sepsisLocationPenalty);
 
-        // Conta a entidades que estão vivas, não são borgs, estão sem luva/mascara e tem acesso ao paciente.
-        var unsanitazedMobCount = _lookup.GetEntitiesInRange(args.Body, _surgeryMaxLotationDistance)
+        var unsanitazedMobCount = _lookup.GetEntitiesInRange(args.Body, _crowdingCheckRange)
             .Where(ent =>
                 _mobState.IsAlive(ent)
                 && !HasComp<BorgChassisComponent>(ent)
@@ -734,7 +733,7 @@ public abstract partial class SharedSurgerySystem
             .Count();
 
         if (unsanitazedMobCount > 0)
-            sepsis += new DamageSpecifier(poisonPrototype, _surgeryMaxLotationDamage * unsanitazedMobCount);
+            sepsis += new DamageSpecifier(poisonPrototype, _sepsisCrowdingPenalty * unsanitazedMobCount);
         // Gaby Station -> Enshittificar Cirurgias e Cia end
 
         // If there is (no damage), theres nothing to do.

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -3,9 +3,11 @@
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Janet Blackquill <uhhadd@gmail.com>
 // SPDX-FileCopyrightText: 2025 Kayzel <43700376+KayzelW@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 // SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 // SPDX-FileCopyrightText: 2025 Roudenn <romabond091@gmail.com>
 // SPDX-FileCopyrightText: 2025 Spatison <137375981+Spatison@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Trest <144359854+trest100@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -726,7 +726,7 @@ public abstract partial class SharedSurgerySystem
             sepsis += new DamageSpecifier(poisonPrototype, _surgeryOffTableDamage);
 
         // Conta a entidades que estão vivas, não são borgs, estão sem luva/mascara e tem acesso ao paciente.
-        var mobCount = _lookup.GetEntitiesInRange(args.Body, _surgeryMaxLotationDistance, flags: LookupFlags.Dynamic)
+        var mobCount = _lookup.GetEntitiesInRange(args.Body, _surgeryMaxLotationDistance)
             .Where(ent =>
                 _mobState.IsAlive(ent)
                 && !HasComp<BorgChassisComponent>(ent)

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -51,9 +51,8 @@ using Content.Shared.Popups;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 using System.Linq;
-using Content.Shared.Mobs.Components;
-using Content.Shared.Physics;
 using Content.Shared._Gabystation.CCVar;
+using Content.Shared.Silicons.Borgs.Components;
 
 namespace Content.Shared._Shitmed.Medical.Surgery;
 
@@ -717,9 +716,7 @@ public abstract partial class SharedSurgerySystem
         var sepsis = new DamageSpecifier();
         var poisonPrototype = _prototypes.Index<DamageTypePrototype>("Poison");
 
-        // Check if the (user has gloves on && user has mask on) || (user has SanitizedComponent).
-        if ((!_inventory.TryGetSlotEntity(args.User, "gloves", out var _) || !_inventory.TryGetSlotEntity(args.User, "mask", out var _))
-            && !HasComp<SanitizedComponent>(args.User))
+        if (!IsSanitazed(args.User))
             sepsis += new DamageSpecifier(poisonPrototype, _surgeryWithoutEquipmentDamage);
 
         // Gaby Station -> Enshittificar Cirurgias e Cia start
@@ -728,8 +725,14 @@ public abstract partial class SharedSurgerySystem
             || !HasComp<OperatingTableComponent>(buckleComponent.BuckledTo))
             sepsis += new DamageSpecifier(poisonPrototype, _surgeryOffTableDamage);
 
+        // Conta a entidades que estão vivas, não são borgs, estão sem luva/mascara e tem acesso ao paciente.
         var mobCount = _lookup.GetEntitiesInRange(args.Body, _surgeryMaxLotationDistance, flags: LookupFlags.Dynamic)
-            .Where(ent => _mobState.IsAlive(ent) && _interaction.InRangeUnobstructed(args.Body, ent, -1))
+            .Where(ent =>
+                _mobState.IsAlive(ent)
+                && !HasComp<BorgChassisComponent>(ent)
+                && !IsSanitazed(ent)
+                && _interaction.InRangeUnobstructed(args.Body, ent, -1)
+            )
             .Count();
 
         // Only the surgeon and more two people around the surgery.
@@ -743,6 +746,15 @@ public abstract partial class SharedSurgerySystem
 
         var ev = new SurgeryStepDamageEvent(args.User, args.Body, args.Part, args.Surgery, sepsis, 0.5f);
         RaiseLocalEvent(args.Body, ref ev);
+
+        bool IsSanitazed(EntityUid ent)
+        {
+            if (HasComp<SanitizedComponent>(args.User))
+                return true;
+
+            return _inventory.TryGetSlotEntity(args.User, "gloves", out var _)
+                && _inventory.TryGetSlotEntity(args.User, "mask", out var _);
+        }
     }
 
     private bool TryToolAudio(Entity<SurgeryStepComponent> ent, SurgeryStepEvent args)

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -1,14 +1,11 @@
 // SPDX-FileCopyrightText: 2024 Skubman <ba.fallaria@gmail.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Janet Blackquill <uhhadd@gmail.com>
 // SPDX-FileCopyrightText: 2025 Kayzel <43700376+KayzelW@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 // SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 // SPDX-FileCopyrightText: 2025 Roudenn <romabond091@gmail.com>
 // SPDX-FileCopyrightText: 2025 Spatison <137375981+Spatison@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Trest <144359854+trest100@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
@@ -51,6 +48,8 @@ using Content.Shared.Popups;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 using System.Linq;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Physics;
 
 namespace Content.Shared._Shitmed.Medical.Surgery;
 
@@ -694,22 +693,35 @@ public abstract partial class SharedSurgerySystem
     }
     private void HandleSanitization(SurgeryStepEvent args)
     {
-        var sepsis = new DamageSpecifier();
+        // If the (patient is a "patient" && patient is immune to sepsis), then theres nothing to do.
+        if (TryComp<SurgeryTargetComponent>(args.Body, out var surgeryTargetComponent) && surgeryTargetComponent.SepsisImmune)
+            return;
 
-        // Check if the (user has gloves on && user has mask on) || (user has SanitizedComponent)
+        var sepsis = new DamageSpecifier();
+        var poisonPrototype = _prototypes.Index<DamageTypePrototype>("Poison");
+
+        // Check if the (user has gloves on && user has mask on) || (user has SanitizedComponent).
         if ((!_inventory.TryGetSlotEntity(args.User, "gloves", out var _) || !_inventory.TryGetSlotEntity(args.User, "mask", out var _))
             && !HasComp<SanitizedComponent>(args.User))
-            sepsis += new DamageSpecifier(_prototypes.Index<DamageTypePrototype>("Poison"), 5);
+            sepsis += new DamageSpecifier(poisonPrototype, 5);
 
-        // Gaby Station -> Enshittificar Cirurgias e Cia
-        // Check if the (patient is buckled) && (patient is buckled to an operating table)
+        // Gaby Station -> Enshittificar Cirurgias e Cia start
+        // Check if the (patient is buckled) && (patient is buckled to an operating table).
         if (!TryComp<BuckleComponent>(args.Body, out var buckleComponent)
             || !HasComp<OperatingTableComponent>(buckleComponent.BuckledTo))
-            sepsis += new DamageSpecifier(_prototypes.Index<DamageTypePrototype>("Poison"), 5);
+            sepsis += new DamageSpecifier(poisonPrototype, 5);
 
-        // If there is (no damage) || (patient is a "patient" && patient is immune to sepsis), then theres nothing to do
-        if (!sepsis.DamageDict.Any()
-            || TryComp<SurgeryTargetComponent>(args.Body, out var surgeryTargetComponent) && surgeryTargetComponent.SepsisImmune)
+        var mobCount = _lookup.GetEntitiesInRange(args.Body, 5, flags: LookupFlags.Dynamic)
+            .Where(ent => _mobState.IsAlive(ent) && _interaction.InRangeUnobstructed(args.Body, ent, -1))
+            .Count();
+
+        // Only the surgeon and more two people around the surgery.
+        if (mobCount > 3)
+            sepsis += new DamageSpecifier(poisonPrototype, 5 * (mobCount - 3));
+        // Gaby Station -> Enshittificar Cirurgias e Cia end
+
+        // If there is (no damage), theres nothing to do.
+        if (!sepsis.DamageDict.Any())
             return;
 
         var ev = new SurgeryStepDamageEvent(args.User, args.Body, args.Part, args.Surgery, sepsis, 0.5f);

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -53,6 +53,7 @@ using Robust.Shared.Utility;
 using System.Linq;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Physics;
+using Content.Shared._Gabystation.CCVar;
 
 namespace Content.Shared._Shitmed.Medical.Surgery;
 
@@ -88,6 +89,12 @@ public abstract partial class SharedSurgerySystem
         {
             subs.Event<SurgeryStepChosenBuiMsg>(OnSurgeryTargetStepChosen);
         });
+
+        _config.OnValueChanged(GabyCVars.SurgeryMaxLotation, newValue => _surgeryMaxLotation = newValue);
+        _config.OnValueChanged(GabyCVars.SurgeryMaxLotationDamage, newValue => _surgeryMaxLotationDamage = newValue);
+        _config.OnValueChanged(GabyCVars.SurgeryMaxLotationDistance, newValue => _surgeryMaxLotationDistance = newValue);
+        _config.OnValueChanged(GabyCVars.SurgeryOffTableDamage, newValue => _surgeryOffTableDamage = newValue);
+        _config.OnValueChanged(GabyCVars.SurgeryWithoutEquipmentDamage, newValue => _surgeryWithoutEquipmentDamage = newValue);
     }
 
     private void SubSurgery<TComp>(EntityEventRefHandler<TComp, SurgeryStepEvent> onStep,
@@ -694,6 +701,13 @@ public abstract partial class SharedSurgerySystem
         return group.Any(damageType => damageableComp.Damage.DamageDict.TryGetValue(damageType, out var value) && value > 0);
 
     }
+
+    private float _surgeryWithoutEquipmentDamage = 5f;
+    private float _surgeryOffTableDamage = 5f;
+    private float _surgeryMaxLotationDistance = 5f;
+    private float _surgeryMaxLotationDamage = 5f;
+    private int _surgeryMaxLotation = 5;
+
     private void HandleSanitization(SurgeryStepEvent args)
     {
         // If the (patient is a "patient" && patient is immune to sepsis), then theres nothing to do.
@@ -706,21 +720,21 @@ public abstract partial class SharedSurgerySystem
         // Check if the (user has gloves on && user has mask on) || (user has SanitizedComponent).
         if ((!_inventory.TryGetSlotEntity(args.User, "gloves", out var _) || !_inventory.TryGetSlotEntity(args.User, "mask", out var _))
             && !HasComp<SanitizedComponent>(args.User))
-            sepsis += new DamageSpecifier(poisonPrototype, 5);
+            sepsis += new DamageSpecifier(poisonPrototype, _surgeryWithoutEquipmentDamage);
 
         // Gaby Station -> Enshittificar Cirurgias e Cia start
         // Check if the (patient is buckled) && (patient is buckled to an operating table).
         if (!TryComp<BuckleComponent>(args.Body, out var buckleComponent)
             || !HasComp<OperatingTableComponent>(buckleComponent.BuckledTo))
-            sepsis += new DamageSpecifier(poisonPrototype, 5);
+            sepsis += new DamageSpecifier(poisonPrototype, _surgeryOffTableDamage);
 
-        var mobCount = _lookup.GetEntitiesInRange(args.Body, 5, flags: LookupFlags.Dynamic)
+        var mobCount = _lookup.GetEntitiesInRange(args.Body, _surgeryMaxLotationDistance, flags: LookupFlags.Dynamic)
             .Where(ent => _mobState.IsAlive(ent) && _interaction.InRangeUnobstructed(args.Body, ent, -1))
             .Count();
 
         // Only the surgeon and more two people around the surgery.
-        if (mobCount > 3)
-            sepsis += new DamageSpecifier(poisonPrototype, 5 * (mobCount - 3));
+        if (mobCount > _surgeryMaxLotation)
+            sepsis += new DamageSpecifier(poisonPrototype, _surgeryMaxLotationDamage * (mobCount - _surgeryMaxLotation));
         // Gaby Station -> Enshittificar Cirurgias e Cia end
 
         // If there is (no damage), theres nothing to do.

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -703,8 +703,8 @@ public abstract partial class SharedSurgerySystem
 
         // Gaby Station -> Enshittificar Cirurgias e Cia
         // Check if the (patient is buckled) && (patient is buckled to an operating table)
-        if (!TryComp<BuckleComponent>(args.Body, out var buckle)
-            || !HasComp<OperatingTableComponent>(buckle.BuckledTo))
+        if (!TryComp<BuckleComponent>(args.Body, out var buckleComponent)
+            || !HasComp<OperatingTableComponent>(buckleComponent.BuckledTo))
             sepsis += new DamageSpecifier(_prototypes.Index<DamageTypePrototype>("Poison"), 5);
 
         // If there is (no damage) || (patient is a "patient" && patient is immune to sepsis), then theres nothing to do

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
@@ -49,7 +49,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
-using Content.Shared.Examine;
+using Robust.Shared.Configuration;
 
 namespace Content.Shared._Shitmed.Medical.Surgery;
 

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
@@ -46,6 +46,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using Content.Shared.Examine;
 
 namespace Content.Shared._Shitmed.Medical.Surgery;
 
@@ -71,6 +72,8 @@ public abstract partial class SharedSurgerySystem : EntitySystem
     [Dependency] private readonly ConsciousnessSystem _consciousness = default!;
     [Dependency] private readonly PainSystem _pain = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly SharedInteractionSystem _interaction = default!;
 
     /// <summary>
     /// Cache of all surgery prototypes' singleton entities.

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Janet Blackquill <uhhadd@gmail.com>
 // SPDX-FileCopyrightText: 2025 Kayzel <43700376+KayzelW@users.noreply.github.com>

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
@@ -77,6 +77,7 @@ public abstract partial class SharedSurgerySystem : EntitySystem
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
 
     /// <summary>
     /// Cache of all surgery prototypes' singleton entities.

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
@@ -3,8 +3,10 @@
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Janet Blackquill <uhhadd@gmail.com>
 // SPDX-FileCopyrightText: 2025 Kayzel <43700376+KayzelW@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 // SPDX-FileCopyrightText: 2025 Roudenn <romabond091@gmail.com>
 // SPDX-FileCopyrightText: 2025 Spatison <137375981+Spatison@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Trest <144359854+trest100@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/operating_table.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/operating_table.yml
@@ -5,6 +5,7 @@
 # SPDX-FileCopyrightText: 2024 deltanedas <@deltanedas:kde.org>
 # SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 #

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/operating_table.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/operating_table.yml
@@ -5,6 +5,8 @@
 # SPDX-FileCopyrightText: 2024 deltanedas <@deltanedas:kde.org>
 # SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+# SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/operating_table.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/operating_table.yml
@@ -43,3 +43,8 @@
     ports:
     - OperatingTable
   # End Shitmed Changes
+  # Gaby Station -> Enshittificar Cirurgias e Cia start
+  - type: GuideHelp
+    guides:
+    - Surgery
+  # Gaby Station -> Enshittificar Cirurgias e Cia end

--- a/Resources/ServerInfo/_Shitmed/Guidebook/Medical/Surgery.xml
+++ b/Resources/ServerInfo/_Shitmed/Guidebook/Medical/Surgery.xml
@@ -8,54 +8,63 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 <Document>
-# Surgery
-Your usual weekly activity. By performing surgical operations on your patients, you can heal wounds, remove or add body parts, organs, and more.
+# Cirurgias
+As cirurgias fazem parte do seu dia a dia de trabalho. Você é capaz de operar um paciente para tratar feridas, remover ou adicionar partes do corpo, tratar órgãos e muito mais.
 
-## The Basics
-To start surgery your patient needs to be laying down, and ideally sedated.
+## Iniciando a
+Antes de iniciar uma cirurgia, seu paciente precisa estar deitado e, idealmente, sedado. Os sedativos mais comuns são inalação de óxido nitroso e morfina.
 
-If they are not sedated, they will be in a lot of pain, which decreases their mood, and will make surgical wounds worse.
+Caso ele não esteja sedado, ele sentirá muita dor, o que afetará seu humor e agravará as feridas cirúrgicas. 
 
 <Box>
-<GuideEntityEmbed Entity="NitrousOxideTank" Caption="nitrous oxide"/>
-<GuideEntityEmbed Entity="ClothingMaskBreathMedical" Caption="any breathing tool"/>
+<GuideEntityEmbed Entity="NitrousOxideTank" Caption="óxido nitroso"/>
+<GuideEntityEmbed Entity="ClothingMaskBreathMedical" Caption="máscara de respiração"/>
 </Box>
 
-You also need to wear protective gear such as a mask and gloves to prevent harming the patient due to contamination.
+## Ambiente esterilizado
+
+Você deve vestir luvas e máscaras para prevenir machucar o paciente por contaminação. 
+
+Para garantir um ambiente esterilizado, todos próximos da cirurgia (excluindo o paciente) precisam usar também luvas e máscaras e o paciente deve estar em uma mesa cirúrgica.
+
+Animais vivos próximos da cirurgia também causam sepse no paciente.
 
 <Box>
-<GuideEntityEmbed Entity="ClothingMaskSterile" Caption="any mask"/>
-<GuideEntityEmbed Entity="ClothingHandsGlovesNitrile" Caption="any gloves"/>
+<GuideEntityEmbed Entity="ClothingMaskSterile" Caption="qualquer máscara"/>
+<GuideEntityEmbed Entity="ClothingHandsGlovesNitrile" Caption="qualquer luva"/>
+<GuideEntityEmbed Entity="OperatingTable" Caption="mesa cirúrgica"/>
+
 </Box>
 
-## Getting Started
+## Iniciando
 
-To engage in surgery, you'll need a set of surgical tools.
+Para iniciar uma cirurgia, você precisa de um conjunto de ferramentas cirúrgicas.
 
 <Box>
-<GuideEntityEmbed Entity="Scalpel" Caption="scalpel"/>
-<GuideEntityEmbed Entity="Retractor" Caption="retractor"/>
-<GuideEntityEmbed Entity="Hemostat" Caption="hemostat"/>
-<GuideEntityEmbed Entity="Drill" Caption="drill"/>
+<GuideEntityEmbed Entity="Scalpel" Caption="bisturi"/>
+<GuideEntityEmbed Entity="Retractor" Caption="retrator"/>
+<GuideEntityEmbed Entity="Hemostat" Caption="hemostato"/>
+<GuideEntityEmbed Entity="Drill" Caption="furadeira"/>
 </Box>
 <Box>
-<GuideEntityEmbed Entity="Saw" Caption="saw"/>
-<GuideEntityEmbed Entity="Cautery" Caption="cautery"/>
+<GuideEntityEmbed Entity="Saw" Caption="serra"/>
+<GuideEntityEmbed Entity="Cautery" Caption="cauterizador"/>
 <GuideEntityEmbed Entity="BoneGel" Caption="bone gel"/>
 </Box>
 
-Once you've got tools in hand, interact with your patient to begin surgery. You'll be able to choose which part you want to operate on.
+Assim que tiver as ferramentas em mãos, interaja com o paciente para iniciar a cirurgia. Você poderá escolher que parte quer operar.
 
-## Ghetto Surgery
+## Cirurgia improvisada
 
-Certain non-surgical tools can be used in a pinch, use the scalpel examine icon to see how good or bad something is.
+Algumas ferramentas não-cirúrgias podem ser usadas em emergências. Clique no ícone de bisturi ao examinar para ver o quão bom ou ruim uma ferramenta é.
+
 <Box>
-<GuideEntityEmbed Entity="Welder" Caption="welder"/>
-<GuideEntityEmbed Entity="Wirecutter" Caption="wirecutter"/>
-<GuideEntityEmbed Entity="KitchenKnife" Caption="knife"/>
-<GuideEntityEmbed Entity="Crowbar" Caption="crowbar"/>
+<GuideEntityEmbed Entity="Welder" Caption="soldador"/>
+<GuideEntityEmbed Entity="Wirecutter" Caption="cortador de fio"/>
+<GuideEntityEmbed Entity="KitchenKnife" Caption="faca"/>
+<GuideEntityEmbed Entity="Crowbar" Caption="pé de cabra"/>
 </Box>
 
-They aren't ideal compared to real surgical equipment, but they'll do in a pinch!
+Elas não são as ideais quando comparadas a ferramentas cirúrgicas reais, mas servem em emergências.
 
 </Document>


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR
Faz passos da cirurgia fora de uma mesa de cirurgia e a presença de pessoas não-epizadas causarem dano de veneno.

## Por quê? / Balanceamento
Bounty, vide o tópico Enshittificar Cirurgias e Cia em #bounties.

## Detalhes Técnicos
O dano é somativo. Caso a cirurgiã esteja sem máscara ou sem luva e fazendo uma cirurgia fora da mesa de cirurgia, o paciente vai receber 5 de dano de estar sem equipamento e 5 de dano de ser fora da mesa. 

~~Cada pessoa além da cirurgiã + 2 seres vivos causa 5 de dano por passo. Então, por exemplo, três pessoas na sala durante uma cirurgia, além do paciente, não afeta o paciente. Mas, já, quatro pessoas faz com que cada passo dê 5 de dano. A conta é: `5 * (quantidade de pessoas - 3)` de dano, sempre que isso for positivo.~~

Cada pessoa sem luva e máscara a um raio de 5 tiles causa 5 de dano por passo na cirurgia. Então, por exemplo, três pessoas na sala; duas de EPI médico; e outra sem. O paciente tomaria 5 de dano a cada passo da cirurgia por haver uma pessoa sem EPI próximo. Se os três citados tivessem sem luvas ou sem máscaras, o paciente tomaria 15 de veneno por passo.

Apenas mobs vivos, não-borgs, sem EPI médico e com acesso (uma reta não obstruída entre o paciente e a pessoa) contam para o dano. Ter dois borgs auxiliando em uma cirurgia não causaria nenhum problema. Entretanto, ter animais presentes, como na maioria não da pra equipar luva e máscara, causa sepse na cirurgia.

Sobre performance, buscar entidades é pesadinho mas isso é feito somente quanto termina um passo (não é a cada tick).

## Coisas a fazer
- [x] Testar;
- [x] Corrigir bug da contagem de mobs;
- [x] Adicionar mídia da lotação;
- [x] Ajeitar documentação e nome das variáveis CVar;
- [x] Balancear os valores padrão;
- [x] Fazer changelog (falar sobre as CVars e funcionalidades).

## Anexos
https://github.com/user-attachments/assets/2b11f45a-8889-4c61-bd91-2ff3d7c4220e

**Changelog**
:cl: GenericDwarf e Kyoth25f
- tweak: Fazer cirurgias fora da mesa de cirurgia causa sepse no paciente.
- tweak: Pessoas sem EPI médico próximo de uma cirurgia a contaminam.
- add: Animais vivos próxima as cirurgias também causam sepse no paciente. Não esqueça de checar se não há nenhum rato por perto...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Surgery-related sepsis/infection now accumulates and applies consistently in a single step.
  * Missing surgeon PPE or an unbuckled patient — and crowded operating areas — now increase infection (poison) risk as intended.
  * Sepsis events are only raised when there is actual damage to apply.

* **Refactor**
  * Infection calculation streamlined for clearer, more predictable outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->