### PR TITLE
fix: Corrige bug da cc

### DIFF
--- a/Resources/Prototypes/_Gabystation/centcomm_weights.yml
+++ b/Resources/Prototypes/_Gabystation/centcomm_weights.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 AgentePanela <agentepanela@gmail.com>
 # SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Gabystation/centcomm_weights.yml
+++ b/Resources/Prototypes/_Gabystation/centcomm_weights.yml
@@ -6,6 +6,6 @@
 - type: weightedRandom
   id: CentcommWeights
   weights:
-    "/Maps/_Gabystation/Centcomms/summerComm": 1
+    "/Maps/_Gabystation/Centcomms/summerComm.yml": 1
     "/Maps/centcomm.yml": 1
     "/Maps/_Gabystation/Centcomms/oldComm.yml": 1


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR
Zim

**Changelog**
:cl:
- fix: Bug do Comando Central não spawnando e a evacuação não vindo corrigido.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added.
- Bug Fixes
  - Fixed a configuration issue that could prevent the Summer Comm variant from being selected during CentComm rotations. Selection weights remain unchanged.
- Chores
  - Updated copyright attribution for 2025.

No gameplay changes are intended; this improves reliability of map selection only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->