### PR TITLE
Corrige bugs no loudout

### DIFF
--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -85,6 +85,8 @@ namespace Content.Shared.Localizations
             //_loc.AddFunction(cultureEn, "MANY", FormatMany);
             _loc.AddFunction(cultureEn, "POWERWATTS", FormatPowerWatts);
             _loc.AddFunction(cultureEn, "POWERJOULES", FormatPowerJoules);
+            // NOTE: ENERGYWATTHOURS() still takes a value in joules, but formats as watt-hours.
+            _loc.AddFunction(cultureEn, "ENERGYWATTHOURS", FormatEnergyWattHours);
             _loc.AddFunction(cultureEn, "UNITS", FormatUnits);
             _loc.AddFunction(cultureEn, "TOSTRING", args => FormatToString(cultureEn, args));
             _loc.AddFunction(cultureEn, "LOC", FormatLoc);

--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -14,6 +14,7 @@
 // SPDX-FileCopyrightText: 2024 icekot8 <93311212+icekot8@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 AgentePanela <agentepanela@gmail.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 // SPDX-FileCopyrightText: 2025 Kyle Tyo <akikai297@gmail.com>
 // SPDX-FileCopyrightText: 2025 Kyoth25f <41803390+Kyoth25f@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Myra <vasilis@pikachu.systems>

--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2021 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2021 E F R <602406+Efruit@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2021 Galactic Chimp <63882831+GalacticChimp@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
 // SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto <6766154+Zumorica@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
 // SPDX-FileCopyrightText: 2022 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
@@ -13,8 +12,14 @@
 // SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Stalen <33173619+stalengd@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 icekot8 <93311212+icekot8@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 AgentePanela <agentepanela@gmail.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Kyle Tyo <akikai297@gmail.com>
+// SPDX-FileCopyrightText: 2025 Kyoth25f <41803390+Kyoth25f@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Myra <vasilis@pikachu.systems>
+// SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
+// SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 // SPDX-FileCopyrightText: 2025 pathetic meowmeow <uhhadd@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Shared/Preferences/Loadouts/LoadoutGroupPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutGroupPrototype.cs
@@ -38,6 +38,7 @@
 
 using Content.Shared.Inventory;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array;
 
 namespace Content.Shared.Preferences.Loadouts;
 
@@ -45,7 +46,7 @@ namespace Content.Shared.Preferences.Loadouts;
 /// Corresponds to a set of loadouts for a particular slot.
 /// </summary>
 [Prototype]
-public sealed partial class LoadoutGroupPrototype : IPrototype
+public sealed partial class LoadoutGroupPrototype : IPrototype, IInheritingPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = string.Empty;
@@ -82,4 +83,12 @@ public sealed partial class LoadoutGroupPrototype : IPrototype
     /// </summary>
     [DataField]
     public SlotFlags? ExclusiveWith;
+
+    [ViewVariables]
+    [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<LoadoutGroupPrototype>))]
+    public string[]? Parents { get; private set; }
+
+    [ViewVariables]
+    [AbstractDataField]
+    public bool Abstract { get; private set; } = false;
 }

--- a/Content.Shared/Preferences/Loadouts/LoadoutGroupPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutGroupPrototype.cs
@@ -30,7 +30,9 @@
 // SPDX-FileCopyrightText: 2024 Арт <123451459+JustArt1m@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 BloodfiendishOperator <141253729+Diggy0@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Froffy025 <scotttaco025@gmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 // SPDX-FileCopyrightText: 2025 Tayrtahn <tayrtahn@gmail.com>
 //

--- a/Content.Shared/Preferences/Loadouts/LoadoutGroupPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutGroupPrototype.cs
@@ -31,6 +31,7 @@
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 BloodfiendishOperator <141253729+Diggy0@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Froffy025 <scotttaco025@gmail.com>
+// SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>

--- a/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
@@ -74,18 +74,15 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using Content.Shared.Inventory;
 using Content.Shared.CCVar;
-using Content.Shared.Humanoid.Prototypes;
-using Content.Shared.Random;
 using Robust.Shared.Collections;
 using Robust.Shared.Configuration;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace Content.Shared.Preferences.Loadouts;
 
@@ -139,7 +136,6 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
         var groupRemove = new ValueList<string>();
         var protoManager = collection.Resolve<IPrototypeManager>();
         var configManager = collection.Resolve<IConfigurationManager>();
-        var exclusiveWith = new ValueList<SlotFlags>(); // Goobstation
 
         if (!protoManager.TryIndex(Role, out var roleProto))
         {
@@ -200,19 +196,6 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
                 groupRemove.Add(group);
                 continue;
             }
-
-            // Goobstation - Start
-            if (groupProto.ExclusiveWith is { } exclusive)
-            {
-                if (exclusiveWith.Contains(exclusive))
-                {
-                    groupRemove.Add(group);
-                    continue;
-                }
-
-                exclusiveWith.Add(exclusive);
-            }
-            // Goobstation - End
 
             var loadouts = groupLoadouts[..Math.Min(groupLoadouts.Count, groupProto.MaxLimit)];
 

--- a/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
@@ -66,7 +66,9 @@
 // SPDX-FileCopyrightText: 2024 Арт <123451459+JustArt1m@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 BloodfiendishOperator <141253729+Diggy0@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Froffy025 <scotttaco025@gmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
 // SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 // SPDX-FileCopyrightText: 2025 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>

--- a/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
@@ -67,6 +67,7 @@
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 BloodfiendishOperator <141253729+Diggy0@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Froffy025 <scotttaco025@gmail.com>
+// SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>

--- a/Resources/Locale/en-US/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/preferences/loadout-groups.ftl
@@ -55,14 +55,14 @@ loadout-group-hop-backpack = Head of Personnel backpack
 loadout-group-hop-outerclothing = Head of Personnel outer clothing
 
 # Civilian
-loadout-group-passenger-jumpsuit = Civilian Jumpsuits
-loadout-group-passenger-mask = Civilian Facewear
-loadout-group-passenger-hat = Civilian Headwear
-loadout-group-passenger-gloves = Civilian Gloves
-loadout-group-passenger-outerclothing = Civilian Outerwear
-loadout-group-passenger-shoes = Civilian Footwear
-loadout-group-passenger-neck = Civilian Neckwear
-loadout-group-passenger-belt = Civilian Beltwear
+loadout-group-civilian-jumpsuit = Civilian Jumpsuits
+loadout-group-civilian-mask = Civilian Facewear
+loadout-group-civilian-hat = Civilian Headwear
+loadout-group-civilian-gloves = Civilian Gloves
+loadout-group-civilian-outerclothing = Civilian Outerwear
+loadout-group-civilian-shoes = Civilian Footwear
+loadout-group-civilian-neck = Civilian Neckwear
+loadout-group-civilian-belt = Civilian Beltwear
 
 loadout-group-bartender-head = Bartender head
 loadout-group-bartender-jumpsuit = Bartender jumpsuit

--- a/Resources/Locale/pt-BR/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/pt-BR/chat/managers/chat-manager.ftl
@@ -19,6 +19,7 @@ chat-manager-no-such-channel = Não existe canal com a chave '{$key}'!
 chat-manager-whisper-headset-on-message = Você não pode sussurrar no rádio!
 
 chat-manager-server-wrap-message = [bold]{$message}[/bold]
+chat-manager-sender-announcement = Central de Comando
 chat-manager-sender-announcement-wrap-message = [font size=14][bold]Anúncio de {$sender}:[/font][font size=12]
                                                 {$message}[/bold][/font]
 chat-manager-entity-say-wrap-message = [BubbleHeader][bold][Name]{$entityName}[/Name][/bold][/BubbleHeader] {$verb}, [font={$fontType} size={$fontSize}]"[BubbleContent]{$message}[/BubbleContent]"[/font]

--- a/Resources/Locale/pt-BR/preferences/loadout-groups.ftl
+++ b/Resources/Locale/pt-BR/preferences/loadout-groups.ftl
@@ -54,14 +54,14 @@ loadout-group-hop-backpack = Mochila do Chefe dos Funcionarios
 loadout-group-hop-outerclothing = Casaco do Chefe dos Funcionarios
 
 # Civilian
-loadout-group-passenger-jumpsuit = Roupas Civis
-loadout-group-passenger-mask = Máscaras Civis
-loadout-group-passenger-hat = Chapéus Civis
-loadout-group-passenger-gloves = Luvas Civis
-loadout-group-passenger-outerclothing = Casacos Civis
-loadout-group-passenger-shoes = Calçados Civis
-loadout-group-passenger-neck = Pescoços Civis
-loadout-group-passenger-belt = Cintos Civis
+loadout-group-civilian-jumpsuit = Roupas Civis
+loadout-group-civilian-mask = Máscaras Civis
+loadout-group-civilian-hat = Chapéus Civis
+loadout-group-civilian-gloves = Luvas Civis
+loadout-group-civilian-outerclothing = Casacos Civis
+loadout-group-civilian-shoes = Calçados Civis
+loadout-group-civilian-neck = Pescoços Civis
+loadout-group-civilian-belt = Cintos Civis
 
 loadout-group-bartender-head = Chapeu do Barman
 loadout-group-bartender-jumpsuit = Roupa do Barman

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -74,10 +74,13 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 BloodfiendishOperator <141253729+Diggy0@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Froffy025 <scotttaco025@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
+# SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 paige404 <59348003+paige404@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 starch <starchpersonal@gmail.com>
 #

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -201,7 +201,7 @@
 
 # Gloves
 - type: loadout
-  id: GreyTideGloves
+  id: GreyTiderGloves
   effects:
   - !type:GroupLoadoutEffect
     proto: GreyTider

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -75,6 +75,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 BloodfiendishOperator <141253729+Diggy0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Froffy025 <scotttaco025@gmail.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -77,6 +77,7 @@
 # SPDX-FileCopyrightText: 2025 Froffy025 <scotttaco025@gmail.com>
 # SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 # SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -111,7 +111,7 @@
 
 # Face
 - type: loadout
-  id: PassengerFace
+  id: GreyTiderMask
   effects:
   - !type:GroupLoadoutEffect
     proto: GreyTider
@@ -197,7 +197,7 @@
 
 # Gloves
 - type: loadout
-  id: PassengerGloves
+  id: GreyTideGloves
   effects:
   - !type:GroupLoadoutEffect
     proto: GreyTider

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -140,6 +140,7 @@
 # SPDX-FileCopyrightText: 2025 JORJ949 <159719201+JORJ949@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Julian Giebel <juliangiebel@live.de>
 # SPDX-FileCopyrightText: 2025 KingFroozy <140668342+KingFroozy@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 # SPDX-FileCopyrightText: 2025 Momo <Rsnesrud@gmail.com>
 # SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Phooooooooooooooooooooooooooooooosphate <184853112+Phooooooooooooooooooooooooooooooosphate@users.noreply.github.com>

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -513,7 +513,7 @@
   id: CivilianFace
   name: loadout-group-civilian-mask
   minLimit: 0
-  loadouts: [GreyTiderFace]
+  loadouts: [GreyTiderMask]
 
 - type: loadoutGroup
   id: CivilianGloves

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -509,13 +509,13 @@
   id: CivilianFace
   name: loadout-group-civilian-mask
   minLimit: 0
-  loadouts: [CivilianFace]
+  loadouts: [GreyTiderFace]
 
 - type: loadoutGroup
   id: CivilianGloves
-  name: loadout-group-passenger-gloves
+  name: loadout-group-civilian-gloves
   minLimit: 0
-  loadouts: [CivilianGloves]
+  loadouts: [GreyTiderGloves]
 
 - type: loadoutGroup
   id: CivilianBackpack
@@ -615,13 +615,13 @@
   id: CivilianBelt  # Goobstation Loadout Rework Addition
   name: loadout-group-civilian-belt
   minLimit: 0
-  loadouts:
-  - WaistLeatherBag
+  loadouts: [WaistLeatherBag]
 
 - type: loadoutGroup
   id: CivilianShoes
   name: loadout-group-civilian-shoes
-  minLimit: 1
+  minLimit: 0
+  exclusiveWith: FEET #Goostation
   loadouts:
     - BlackShoes
     - WinterBoots
@@ -630,6 +630,11 @@
     - LoadoutSalvageBoots
     - LaceupShoes
   # Goob Loadouts Rework End
+
+- type: loadoutGroup
+  id: CivilianShoesRequired
+  parent: CivilianShoes
+  minLimit: 1 #Passengers also need to be forced to wear shoes.
 
 - type: loadoutGroup
   id: BartenderHead
@@ -898,10 +903,8 @@
   id: ClownShoes
   name: loadout-group-clown-shoes
   minLimit: 1
-  loadouts:
-  - ClownShoes
-  - JesterShoes
-
+  exclusiveWith: FEET #Goostation
+  loadouts: [ClownShoes, JesterShoes]
 - type: loadoutGroup
   id: SurvivalClown
   name: loadout-group-survival-clown
@@ -1072,10 +1075,8 @@
   id: QuartermasterShoes
   name: loadout-group-quartermaster-shoes
   minLimit: 1
-  loadouts:
-  - BrownShoes
-  - CargoWinterBoots
-
+  exclusiveWith: FEET #Goostation
+  loadouts: [BrownShoes, CargoWinterBoots]
 - type: loadoutGroup
   id: CargoTechnicianHead
   name: loadout-group-cargo-technician-head
@@ -1118,10 +1119,8 @@
   id: CargoTechnicianShoes
   name: loadout-group-cargo-technician-shoes
   minLimit: 1
-  loadouts:
-  - BlackShoes
-  - CargoWinterBoots
-
+  exclusiveWith: FEET #Goostation
+  loadouts: [BlackShoes, CargoWinterBoots]
 - type: loadoutGroup
   id: SalvageSpecialistBackpack
   name: loadout-group-salvage-specialist-backpack
@@ -1143,6 +1142,7 @@
   id: SalvageSpecialistShoes
   name: loadout-group-salvage-specialist-shoes
   minLimit: 1
+  exclusiveWith: FEET #Goostation
   loadouts:
   - SalvageBoots
   - CargoWinterBoots
@@ -1187,10 +1187,8 @@
   id: ChiefEngineerShoes
   name: loadout-group-chief-engineer-shoes
   minLimit: 1
-  loadouts:
-  - BrownShoes
-  - EngineeringWinterBoots
-
+  exclusiveWith: FEET #Goostation
+  loadouts: [BrownShoes, EngineeringWinterBoots]
 - type: loadoutGroup
   id: TechnicalAssistantJumpsuit
   name: loadout-group-technical-assistant-jumpsuit
@@ -1246,10 +1244,8 @@
   id: StationEngineerShoes
   name: loadout-group-station-engineer-shoes
   minLimit: 1
-  loadouts:
-  - WorkBoots
-  - EngineeringWinterBoots
-
+  exclusiveWith: FEET #Goostation
+  loadouts: [WorkBoots, EngineeringWinterBoots]
 - type: loadoutGroup
   id: StationEngineerID
   name: loadout-group-station-engineer-id
@@ -1298,10 +1294,8 @@
   id: AtmosphericTechnicianShoes
   name: loadout-group-atmospheric-technician-shoes
   minLimit: 1
-  loadouts:
-  - WhiteShoes
-  - EngineeringWinterBoots
-
+  exclusiveWith: FEET #Goostation
+  loadouts: [WhiteShoes, EngineeringWinterBoots]
 - type: loadoutGroup
   id: SurvivalExtended
   name: loadout-group-survival-extended
@@ -1352,10 +1346,8 @@
   id: ResearchDirectorShoes
   name: loadout-group-research-director-shoes
   minLimit: 1
-  loadouts:
-  - BrownShoes
-  - ScienceWinterBoots
-
+  exclusiveWith: FEET #Goostation
+  loadouts: [BrownShoes, ScienceWinterBoots]
 - type: loadoutGroup
   id: ScientistHead
   name: loadout-group-scientist-head
@@ -1412,11 +1404,8 @@
   id: ScientistShoes
   name: loadout-group-scientist-shoes
   minLimit: 1
-  loadouts:
-  - WhiteShoes
-  - BlackShoes
-  - ScienceWinterBoots
-
+  exclusiveWith: FEET #Goostation
+  loadouts: [WhiteShoes, BlackShoes, ScienceWinterBoots]
 - type: loadoutGroup
   id: ScientistGloves
   name: loadout-group-scientist-gloves
@@ -1687,10 +1676,8 @@
   id: ChiefMedicalOfficerShoes
   name: loadout-group-chief-medical-officer-shoes
   minLimit: 1
-  loadouts:
-  - BrownShoes
-  - MedicalWinterBoots
-
+  exclusiveWith: FEET #Goostation
+  loadouts: [BrownShoes, MedicalWinterBoots]
 - type: loadoutGroup
   id: MedicalDoctorHead
   name: loadout-group-medical-doctor-head
@@ -1743,10 +1730,8 @@
   id: MedicalShoes
   name: loadout-group-medical-doctor-shoes
   minLimit: 1
-  loadouts:
-  - WhiteShoes
-  - MedicalWinterBoots
-
+  exclusiveWith: FEET #Goostation
+  loadouts: [WhiteShoes, MedicalWinterBoots]
 - type: loadoutGroup
   id: MedicalDoctorPDA
   name: loadout-group-medical-doctor-id
@@ -1845,11 +1830,8 @@
   id: ParamedicShoes
   name: loadout-group-paramedic-shoes
   minLimit: 1
-  loadouts:
-  - BlueShoes
-  - WhiteShoes
-  - MedicalWinterBoots
-
+  exclusiveWith: FEET #Goostation
+  loadouts: [BlueShoes, WhiteShoes, MedicalWinterBoots]
 - type: loadoutGroup
   id: MedicalEyewear
   name: loadout-group-medical-glasses

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -122,6 +122,7 @@
 # SPDX-FileCopyrightText: 2024 to4no_fix <156101927+chavonadelal@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 voidnull000 <18663194+voidnull000@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Арт <123451459+JustArt1m@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 AgentePanela <agentepanela@gmail.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
@@ -133,11 +134,13 @@
 # SPDX-FileCopyrightText: 2025 Cass <45694413+CubixThree@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Creatorbot01 <creatorbot02@gmail.com>
 # SPDX-FileCopyrightText: 2025 Creatorbot01 <creatorbot20@gmail.com>
+# SPDX-FileCopyrightText: 2025 Froffy025 <scotttaco025@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 JORJ949 <159719201+JORJ949@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Julian Giebel <juliangiebel@live.de>
 # SPDX-FileCopyrightText: 2025 KingFroozy <140668342+KingFroozy@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Momo <Rsnesrud@gmail.com>
+# SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Phooooooooooooooooooooooooooooooosphate <184853112+Phooooooooooooooooooooooooooooooosphate@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Pumkin69 <judeb@DESKTOP-M4B8G5D>
 # SPDX-FileCopyrightText: 2025 RadsammyT <32146976+RadsammyT@users.noreply.github.com>

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -389,10 +389,10 @@
 
 # Civilian
 - type: loadoutGroup
-  id: PassengerJumpsuit
-  name: loadout-group-passenger-jumpsuit
-  minLimit: 0 # Gabystation
-  exclusiveWith: INNERCLOTHING # Goobstation
+  id: CivilianJumpsuit
+  name: loadout-group-civilian-jumpsuit
+  minLimit: 0
+  exclusiveWith: INNERCLOTHING  # Goobstation
   loadouts:
   - GreyJumpsuit
   - GreyJumpskirt
@@ -495,28 +495,30 @@
  # goob changes end
 
 - type: loadoutGroup
-  id: PassengerHat
-  name: loadout-group-passenger-hat
-  minLimit: 0
-  loadouts:
-  - HeadbandBlack
+  id: CivilianJumpsuitRequired #Passengers need to be forced to spawn with clothes.
+  parent: CivilianJumpsuit #They can have the same clothes as everyone else.
+  minLimit: 1 #But they better have clothes on.
 
 - type: loadoutGroup
-  id: PassengerFace
-  name: loadout-group-passenger-mask
+  id: CivilianHat
+  name: loadout-group-civilian-hat
   minLimit: 0
-  loadouts:
-  - PassengerFace
+  loadouts: [HeadbandBlack]
 
 - type: loadoutGroup
-  id: PassengerGloves
+  id: CivilianFace
+  name: loadout-group-civilian-mask
+  minLimit: 0
+  loadouts: [CivilianFace]
+
+- type: loadoutGroup
+  id: CivilianGloves
   name: loadout-group-passenger-gloves
   minLimit: 0
-  loadouts:
-  - PassengerGloves
+  loadouts: [CivilianGloves]
 
 - type: loadoutGroup
-  id: CommonBackpack
+  id: CivilianBackpack
   name: loadout-group-backpack
   exclusiveWith: BACK # Goobstation
   loadouts:
@@ -530,8 +532,8 @@
   # Goobstation Loadout Rework End
 
 - type: loadoutGroup
-  id: PassengerNeck
-  name: loadout-group-passenger-neck
+  id: CivilianNeck
+  name: loadout-group-civilian-neck
   minLimit: 0
   loadouts:
   - Mantle
@@ -546,8 +548,8 @@
   # Goobstation Loadout Rework End
 
 - type: loadoutGroup
-  id: PassengerOuterClothing
-  name: loadout-group-passenger-outerclothing
+  id: CivilianOuterClothing
+  name: loadout-group-civilian-outerclothing
   minLimit: 0
   loadouts:
   - PassengerWintercoat
@@ -610,24 +612,24 @@
   # Goobstation Loadout Rework End
 
 - type: loadoutGroup
-  id: PassengerBelt # Goobstation Loadout Rework Addition
-  name: loadout-group-passenger-belt
+  id: CivilianBelt  # Goobstation Loadout Rework Addition
+  name: loadout-group-civilian-belt
   minLimit: 0
   loadouts:
   - WaistLeatherBag
 
 - type: loadoutGroup
-  id: PassengerShoes
-  name: loadout-group-passenger-shoes
+  id: CivilianShoes
+  name: loadout-group-civilian-shoes
   minLimit: 1
   loadouts:
-  - BlackShoes
-  - WinterBoots
-  #Goob Loadouts Rework Start
-  - LoadoutWorkBoots
-  - LoadoutSalvageBoots
-  - LaceupShoes
-  #Goob Loadouts Rework End
+    - BlackShoes
+    - WinterBoots
+  # Goob Loadouts Rework Start
+    - LoadoutWorkBoots
+    - LoadoutSalvageBoots
+    - LaceupShoes
+  # Goob Loadouts Rework End
 
 - type: loadoutGroup
   id: BartenderHead

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -135,6 +135,7 @@
 # SPDX-FileCopyrightText: 2025 Creatorbot01 <creatorbot02@gmail.com>
 # SPDX-FileCopyrightText: 2025 Creatorbot01 <creatorbot20@gmail.com>
 # SPDX-FileCopyrightText: 2025 Froffy025 <scotttaco025@gmail.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 JORJ949 <159719201+JORJ949@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Julian Giebel <juliangiebel@live.de>

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -117,7 +117,9 @@
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
+
 # Command real
+
 - type: roleLoadout
   id: JobCaptain
   groups:
@@ -131,19 +133,20 @@
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CaptainGloves
+  - CivilianJumpsuitRequired
+  - CivilianBackpack
+  - CivilianHat
+  - CivilianNeck
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianShoes
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - CaptainEnvirohelm
   - CaptainEnvirosuit
   - CaptainEnvirogloves
-  - CaptainGloves
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
 
 - type: roleLoadout
   id: JobHeadOfPersonnel
@@ -159,18 +162,20 @@
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - HoPGloves
+  - CivilianJumpsuitRequired
+  - CivilianBackpack
+  - CivilianHat
+  - CivilianNeck
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianShoes
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - HoPEnvirohelm
   - HoPEnvirosuit
   - HoPEnvirogloves
-  - HoPGloves  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
 
 # Silicons
 - type: roleLoadout
@@ -188,9 +193,15 @@
   id: JobPassenger
   groups:
   - GroupTankHarness
-  - PassengerJumpsuit
-  - CommonBackpack
-  - GenericJumpsuitLoadout
+  - CivilianJumpsuitRequired
+  - CivilianBackpack
+  - CivilianHat
+  - CivilianNeck
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianShoes
+  - CivilianBelt
   - Glasses
   - Survival
   - Trinkets
@@ -200,13 +211,6 @@
   - AssistantEnvirohelm
   - AssistantEnvirosuit
   - AssistantEnvirogloves
-  - PassengerHat
-  - PassengerNeck
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerShoes
-  - PassengerBelt
 
 - type: roleLoadout
   id: JobBartender
@@ -214,49 +218,49 @@
   - GroupTankHarness
   - BartenderHead
   - BartenderJumpsuit
-  - CommonBackpack
+  - CivilianBackpack
   - BartenderOuterClothing
   - Glasses
   - Survival
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianShoes
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - BartenderEnvirohelm
   - BartenderEnvirosuit
   - BartenderEnvirogloves
-  - PassengerJumpsuit
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerShoes
-  - PassengerBelt
 
 - type: roleLoadout
   id: JobServiceWorker
   groups:
   - GroupTankHarness
   - BartenderJumpsuit
-  - CommonBackpack
+  - CivilianBackpack
   - Glasses
   - Survival
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianShoes
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - ServiceWorkerEnvirohelm
   - ServiceWorkerEnvirosuit
   - ServiceWorkerEnvirogloves
-  - PassengerJumpsuit
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerShoes
-  - PassengerBelt
 
 - type: roleLoadout
   id: JobChef
@@ -265,49 +269,49 @@
   - ChefHead
   - ChefMask
   - ChefJumpsuit
-  - CommonBackpack
+  - CivilianBackpack
   - ChefOuterClothing
   - Glasses
   - Survival
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianShoes
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - ChefEnvirohelm
   - ChefEnvirosuit
   - ChefEnvirogloves
-  - PassengerJumpsuit
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerShoes
-  - PassengerBelt
 
 - type: roleLoadout
   id: JobLibrarian
   groups:
   - GroupTankHarness
   - LibrarianJumpsuit
-  - CommonBackpack
+  - CivilianBackpack
   - Glasses
   - Survival
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianShoes
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - LibrarianEnvirohelm
   - LibrarianEnvirosuit
   - LibrarianEnvirogloves
-  - PassengerJumpsuit
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerShoes
-  - PassengerBelt
 
 - type: roleLoadout
   id: JobLawyer
@@ -315,24 +319,24 @@
   - GroupTankHarness
   - LawyerNeck
   - LawyerJumpsuit
-  - CommonBackpack
+  - CivilianBackpack
   - Glasses
   - Survival
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianShoes
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - LawyerEnvirohelm
   - LawyerEnvirosuit
   - LawyerEnvirogloves
-  - PassengerJumpsuit
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerShoes
-  - PassengerBelt
 
 - type: roleLoadout
   id: JobChaplain
@@ -342,25 +346,25 @@
   - ChaplainMask
   - ChaplainNeck
   - ChaplainJumpsuit
-  - CommonBackpack
+  - CivilianBackpack
   - ChaplainOuterClothing
   - Glasses
   - Survival
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianShoes
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - ChaplainEnvirohelm
   - ChaplainEnvirosuit
   - ChaplainEnvirogloves
-  - PassengerJumpsuit
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerShoes
-  - PassengerBelt
 
 - type: roleLoadout
   id: JobJanitor
@@ -369,7 +373,7 @@
   - JanitorHead
   - JanitorJumpsuit
   - JanitorGloves
-  - CommonBackpack
+  - CivilianBackpack
   - JanitorOuterClothing
   - Glasses
   - Survival
@@ -377,18 +381,18 @@
   - JanitorPlunger
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianShoes
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - JanitorEnvirohelm
   - JanitorEnvirosuit
   - JanitorEnvirogloves
-  - PassengerJumpsuit
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerShoes
-  - PassengerBelt
 
 - type: roleLoadout
   id: JobBotanist
@@ -403,18 +407,18 @@
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianShoes
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - BotanistEnvirohelm
   - BotanistEnvirosuit
   - BotanistEnvirogloves
-  - PassengerJumpsuit
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerShoes
-  - PassengerBelt
 
 - type: roleLoadout
   id: JobClown
@@ -429,15 +433,14 @@
   - Glasses
   - SurvivalClown
   - Trinkets
-
-  - PassengerJumpsuit
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerShoes
-  - PassengerBelt
+  - CivilianJumpsuit
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianShoes
+  - CivilianBelt
   - Animals
   # Goobstation - EE Plasmeme Change.
   - ClownEnvirohelm
@@ -458,14 +461,14 @@
   - Glasses
   - SurvivalMime
   - Trinkets
-  - PassengerJumpsuit
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerShoes
-  - PassengerBelt
+  - CivilianJumpsuit
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianShoes
+  - CivilianBelt
   - Animals
   # Goobstation - EE Plasmeme Change.
   - MimeEnvirohelm
@@ -478,7 +481,7 @@
   groups:
   - GroupTankHarness
   - MusicianJumpsuit
-  - CommonBackpack
+  - CivilianBackpack
   - MusicianOuterClothing
   - Glasses
   - Survival
@@ -486,18 +489,18 @@
   - Instruments
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianShoes
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - MusicianEnvirohelm
   - MusicianEnvirosuit
   - MusicianEnvirogloves
-  - PassengerJumpsuit
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerShoes
-  - PassengerBelt
 
 # Cargo
 - type: roleLoadout
@@ -515,19 +518,19 @@
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianBelt
+  - CivilianShoes
   # Goobstation - EE Plasmeme Change.
   - QuartermasterEnvirohelm
   - QuartermasterEnvirosuit
   - QuartermasterEnvirogloves
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
-  - PassengerShoes
 
 - type: roleLoadout
   id: JobCargoTechnician
@@ -543,18 +546,18 @@
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - CargoTechnicianEnvirohelm
   - CargoTechnicianEnvirosuit
   - CargoTechnicianEnvirogloves
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
 
 - type: roleLoadout
   id: JobSalvageSpecialist
@@ -569,18 +572,18 @@
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - SalvageEnvirohelm
   - SalvageEnvirosuit
   - SalvageEnvirogloves
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
 
 # Engineering
 - type: roleLoadout
@@ -597,17 +600,17 @@
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
   # Goobstation - EE Plasmeme Change.
   - ChiefEngineerEnvirohelm
   - ChiefEngineerEnvirosuit
   - ChiefEngineerEnvirogloves
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
 
 - type: roleLoadout
   id: JobTechnicalAssistant
@@ -619,18 +622,18 @@
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - TechnicalAssistantEnvirohelm
   - TechnicalAssistantEnvirosuit
   - TechnicalAssistantEnvirogloves
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
 
 - type: roleLoadout
   id: JobStationEngineer
@@ -646,18 +649,18 @@
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - StationEngineerEnvirohelm
   - StationEngineerEnvirosuit
   - StationEngineerEnvirogloves
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
 
 - type: roleLoadout
   id: JobAtmosphericTechnician
@@ -672,18 +675,18 @@
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - AtmosEnvirohelm
   - AtmosEnvirosuit
   - AtmosEnvirogloves
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
 
 # Science
 - type: roleLoadout
@@ -702,18 +705,18 @@
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - ResearchDirectorEnvirosuit
   - ResearchDirectorEnvirohelm
   - ResearchDirectorEnvirogloves
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
 
 - type: roleLoadout
   id: JobScientist
@@ -732,18 +735,18 @@
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - ScientistEnvirohelm
   - ScientistEnvirosuit
   - ScientistEnvirogloves
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
 
 - type: roleLoadout
   id: JobResearchAssistant
@@ -756,18 +759,18 @@
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - ResearchAssistantEnvirohelm
   - ResearchAssistantEnvirosuit
   - ResearchAssistantEnvirogloves
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
 
 # Security
 - type: roleLoadout
@@ -786,11 +789,11 @@
   - SecurityStar
   - Animals
   - GroupSpeciesBreathToolSecurity
+  - HeadofSecurityGloves
   # Goobstation - EE Plasmeme Change.
   - HeadofSecurityEnvirohelm
   - HeadofSecurityEnvirosuit
   - HeadofSecurityEnvirogloves
-  - HeadofSecurityGloves
 
 - type: roleLoadout
   id: JobWarden
@@ -849,19 +852,19 @@
   - SecurityStar
   - Animals
   - GroupSpeciesBreathToolSecurity
+  - DetectiveGloves
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - DetectiveEnvirohelm
   - DetectiveEnvirosuit
   - DetectiveEnvirogloves
-  - DetectiveGloves
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
 
 - type: roleLoadout
   id: JobSecurityCadet
@@ -898,17 +901,17 @@
   - Trinkets
   - Animals
   - GroupSpeciesBreathToolMedical
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
   # Goobstation - EE Plasmeme Change.
   - ChiefMedicalOfficerEnvirohelm
   - ChiefMedicalOfficerEnvirosuit
   - ChiefMedicalOfficerEnvirogloves
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
 
 - type: roleLoadout
   id: JobMedicalDoctor
@@ -927,17 +930,17 @@
   - Trinkets
   - Animals
   - GroupSpeciesBreathToolMedical
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
   # Goobstation - EE Plasmeme Change.
   - MedicalDoctorEnvirohelm
   - MedicalDoctorEnvirosuit
   - MedicalDoctorEnvirogloves
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
 
 - type: roleLoadout
   id: JobMedicalIntern
@@ -950,17 +953,17 @@
   - Trinkets
   - Animals
   - GroupSpeciesBreathToolMedical
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
   # Goobstation - EE Plasmeme Change.
   - MedicalInternEnvirohelm
   - MedicalInternEnvirosuit
   - MedicalInternEnvirogloves
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
 
 - type: roleLoadout
   id: JobChemist
@@ -977,17 +980,17 @@
   - Trinkets
   - Animals
   - GroupSpeciesBreathToolMedical
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
   # Goobstation - EE Plasmeme Change.
   - ChemistEnvirohelm
   - ChemistEnvirosuit
   - ChemistEnvirogloves
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
 
 - type: roleLoadout
   id: JobParamedic
@@ -1005,17 +1008,17 @@
   - Trinkets
   - Animals
   - GroupSpeciesBreathToolMedical
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
   # Goobstation - EE Plasmeme Change.
   - ParamedicEnvirohelm
   - ParamedicEnvirosuit
   - ParamedicEnvirogloves
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
 
 # Wildcards
 - type: roleLoadout
@@ -1024,23 +1027,23 @@
   - ZookeeperHead
   - ZookeeperJumpsuit
   - GroupTankHarness
-  - CommonBackpack
+  - CivilianBackpack
   - Glasses
   - Survival
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - ZookeeperEnvirohelm
   - ZookeeperEnvirosuit
   - ZookeeperEnvirogloves
-  - PassengerJumpsuit
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
 
 - type: roleLoadout
   id: JobReporter
@@ -1048,22 +1051,23 @@
   - GroupTankHarness
   - ReporterJumpsuit
   - ReporterOuterClothing # Goobstation - Bodycams
-  - CommonBackpack
+  - CivilianBackpack
   - Glasses
   - Survival
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - ReporterEnvirohelm
   - ReporterEnvirosuit
-  - ReporterEnvirogloves  - PassengerJumpsuit
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
+  - ReporterEnvirogloves
 
 
 - type: roleLoadout
@@ -1077,18 +1081,18 @@
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - PsychologistEnvirohelm
   - PsychologistEnvirosuit
   - PsychologistEnvirogloves
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
 
 - type: roleLoadout
   id: JobBoxer
@@ -1096,22 +1100,22 @@
   - GroupTankHarness
   - BoxerJumpsuit
   - BoxerGloves
-  - CommonBackpack
+  - CivilianBackpack
   - Glasses
   - Survival
   - Trinkets
   - Animals
   - GroupSpeciesBreathTool
+  - CivilianJumpsuit
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianBelt
   # Goobstation - EE Plasmeme Change.
   - BoxerEnvirohelm
   - BoxerEnvirosuit
-  - PassengerJumpsuit
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
 
 # These loadouts are used for non-crew spawns, like off-station antags and event mobs
 # They will be used without player configuration, thus they will only ever apply what is forced by MinLimit

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -103,12 +103,15 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 BloodfiendishOperator <141253729+Diggy0@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Froffy025 <scotttaco025@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Phooooooooooooooooooooooooooooooosphate <184853112+Phooooooooooooooooooooooooooooooosphate@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 grub <unalterableness@gmail.com>
 # SPDX-FileCopyrightText: 2025 lzk <124214523+lzk228@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -104,6 +104,7 @@
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 BloodfiendishOperator <141253729+Diggy0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Froffy025 <scotttaco025@gmail.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Phooooooooooooooooooooooooooooooosphate <184853112+Phooooooooooooooooooooooooooooooosphate@users.noreply.github.com>

--- a/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 # SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
 #

--- a/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
@@ -13,7 +13,6 @@
   - AdminAssistantShoes
   - AdminAssistantEar
   - AdminAssistantGloves
-  - CommonBackpack
   - Glasses
   - Survival
   - Trinkets

--- a/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+# SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # Command
 - type: roleLoadout
   id: JobAdministrativeAssistant

--- a/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
@@ -13,11 +13,11 @@
   - Trinkets
   - GroupSpeciesBreathTool
   # Gaby change
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianBelt

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Fun/boombox.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Fun/boombox.yml
@@ -1,4 +1,7 @@
+# SPDX-FileCopyrightText: 2025 AgentePanela <agentepanela@gmail.com>
+# SPDX-FileCopyrightText: 2025 Dreykor <160512778+Dreykor@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 # SPDX-FileCopyrightText: 2025 mkanke-real <mikekanke@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Fun/boombox.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Fun/boombox.yml
@@ -20,7 +20,7 @@
     - state: boombox
       map: ["enum.JukeboxVisualLayers.Base"]
     - state: light
-      map: [ "enum.ToggleVisuals.Layer" ]
+      map: [ "enum.ToggleableVisuals.Layer" ]
       visible: false
       shader: unshaded
   - type: Appearance

--- a/Resources/Prototypes/_Gabystation/Entities/Objects/Weapons/Guns/Pistol/PlasmaCutter.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Objects/Weapons/Guns/Pistol/PlasmaCutter.yml
@@ -17,7 +17,7 @@
     - state: welder_flame
       visible: false
       shader: unshaded
-      map: ["enum.ToggleVisuals.Layer"]
+      map: ["enum.ToggleableVisuals.Layer"]
   - type: GenericVisualizer
     visuals:
       enum.ToggleableVisuals.Enabled:

--- a/Resources/Prototypes/_Gabystation/Entities/Objects/Weapons/Guns/Pistol/PlasmaCutter.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Objects/Weapons/Guns/Pistol/PlasmaCutter.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2024 VictorJob <victorjobnogueira12@gmail.com>
 # SPDX-FileCopyrightText: 2025 AgentePanela <agentepanela@gmail.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Gabystation/Entities/Objects/Weapons/Guns/Pistol/PlasmaCutter.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Objects/Weapons/Guns/Pistol/PlasmaCutter.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2024 VictorJob <victorjobnogueira12@gmail.com>
+# SPDX-FileCopyrightText: 2025 AgentePanela <agentepanela@gmail.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: Tag
   id: MagazinePlasmaCutter
 

--- a/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts.yml
@@ -79,9 +79,12 @@
 # SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+# SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 grub <unalterableness@gmail.com>
 # SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
 # SPDX-FileCopyrightText: 2025 shityaml <unalterableness@gmail.com>

--- a/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts.yml
@@ -78,6 +78,7 @@
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 # SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>

--- a/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts.yml
@@ -109,14 +109,14 @@
   - NanotrasenRepresentativeEnvirosuit
   - NanotrasenRepresentativeEnvirogloves
   # Civil loadout
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianBelt
 
 - type: roleLoadout
   id: JobBlueshieldOfficer
@@ -138,14 +138,14 @@
   - BlueshieldOfficerEnvirogloves
   - BlueshieldOfficerGloves
   # Civil loadout
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianBelt
 
 - type: roleLoadout
   id: JobNanotrasenCareerTrainer
@@ -167,14 +167,14 @@
   - CentComOfficerEnvirosuit
   - CentComOfficerEnvirogloves
   # Civil loadout
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianBelt
 
 - type: roleLoadout
   id: RoleSurvivalNukieHonkops
@@ -205,14 +205,14 @@
   - BrigmedicEnvirosuit
   - BrigmedicEnvirogloves
   # Civil loadout
-  - PassengerJumpsuit
-  - CommonBackpack
-  - PassengerNeck
-  - PassengerHat
-  - PassengerFace
-  - PassengerGloves
-  - PassengerOuterClothing
-  - PassengerBelt
+  - CivilianJumpsuit
+  - CivilianBackpack
+  - CivilianNeck
+  - CivilianHat
+  - CivilianFace
+  - CivilianGloves
+  - CivilianOuterClothing
+  - CivilianBelt
 
 # gives plasmaman a plasma breathing tank
 # other species get nothing


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR
Porta os commits que corrigem bugs no loudout.

Falta testar.

**Changelog**
:cl:
- fix: Loudouts corrigidos!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Passenger loadout groups renamed to Civilian variants; several roles now require a civilian jumpsuit. New civilian items added (black headband, GreyTider mask/gloves), expanded civilian backpacks and trinkets (gold/silver rings, canes, tape recorder). Footwear groups enforce mutual exclusion; new role-specific gloves (Captain/HoP/HoS/Detective).

* **Bug Fixes**
  * Validation change removed cross-group exclusivity enforcement, altering how conflicting group selections are allowed.

* **Documentation**
  * Locale keys and in-game names updated to “Civilian” labels (en-US and pt-BR).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->