### PR TITLE
Remove capacitor de matter bin das máquinas da atmos

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -121,6 +121,7 @@
 # SPDX-FileCopyrightText: 2024 yglop <95057024+yglop@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <41803390+Kyoth25f@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 # SPDX-FileCopyrightText: 2025 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -1494,7 +1494,7 @@
       prototype: Electrolyzer
       stackRequirements:
         Steel: 5
-        Capacitor: 4
+        Manipulator: 4
         CableHV: 5
         Plasteel: 2
 
@@ -1507,9 +1507,7 @@
     - type: MachineBoard
       prototype: Crystallizer
       stackRequirements:
-        Capacitor: 2
-        Manipulator: 4
-        MatterBin: 4
+        Manipulator: 10
         Steel: 5
         Glass: 5
 
@@ -1522,9 +1520,7 @@
     - type: MachineBoard
       prototype: BluespaceSender
       stackRequirements:
-        Capacitor: 4
-        Manipulator: 4
-        MatterBin: 2
+        Manipulator: 10
         Steel: 5
 
 - type: entity
@@ -1538,8 +1534,7 @@
   - type: MachineBoard
     prototype: GasThermoMachineUpgradedFreezer
     stackRequirements:
-      MatterBin: 2
-      Capacitor: 2
+      Manipulator: 4
       Plasma: 1
   - type: Construction
     graph: ThermomachineBoard
@@ -1557,8 +1552,7 @@
   - type: MachineBoard
     prototype: GasThermoMachineUpgradedHeater
     stackRequirements:
-      MatterBin: 2
-      Capacitor: 2
+      Manipulator: 4
       Plasma: 1
   - type: Construction
     graph: ThermomachineBoard
@@ -1576,8 +1570,7 @@
   - type: MachineBoard
     prototype: GasThermoMachineAdvancedFreezer
     stackRequirements:
-      MatterBin: 2
-      Capacitor: 2
+      Manipulator: 4
       Plasma: 1
   - type: Construction
     graph: ThermomachineBoard
@@ -1595,8 +1588,7 @@
   - type: MachineBoard
     prototype: GasThermoMachineAdvancedHeater
     stackRequirements:
-      MatterBin: 2
-      Capacitor: 2
+      Manipulator: 4
       Plasma: 1
   - type: Construction
     graph: ThermomachineBoard

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -74,7 +74,6 @@
 # SPDX-FileCopyrightText: 2024 MureixloI <132683811+MureixloI@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Nairod <110078045+Nairodian@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 NakataRin <45946146+NakataRin@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 OrangeMoronage9622 <whyteterry0092@gmail.com>
 # SPDX-FileCopyrightText: 2024 PJBot <pieterjan.briers+bot@gmail.com>
 # SPDX-FileCopyrightText: 2024 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
@@ -83,9 +82,7 @@
 # SPDX-FileCopyrightText: 2024 Psychpsyo <60073468+Psychpsyo@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Repo <47093363+Titian3@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 RiceMar1244 <138547931+RiceMar1244@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 ScarKy0 <106310278+ScarKy0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 ShadowCommander <10494922+ShadowCommander@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Simon <63975668+Simyon264@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 SlamBamActionman <83650252+SlamBamActionman@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Stalen <33173619+stalengd@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 TakoDragon <69509841+BackeTako@users.noreply.github.com>
@@ -123,6 +120,15 @@
 # SPDX-FileCopyrightText: 2024 wafehling <wafehling@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 yglop <95057024+yglop@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <41803390+Kyoth25f@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+# SPDX-FileCopyrightText: 2025 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
+# SPDX-FileCopyrightText: 2025 ScarKy0 <106310278+ScarKy0@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Simon <63975668+Simyon264@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 āda <ss.adasts@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR
Os capacitores e matters bin foram removidos do jogo. Esse PR atualiza as receitas exclusivas do Gaby.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new medical biofabricator machine board.

- Changes
  - Updated build requirements for several machine boards to emphasize Manipulator components, reducing or removing Capacitor and Matter Bin needs.
  - Specific boards affected include electrolyzer, crystallizer, bluespace gas sender, and advanced/upgraded thermomachines (heater and freezer).
  - Some boards now require higher Manipulator counts (up to 10) and plasma where applicable, while keeping existing metal/glass tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->