### PR TITLE
Shitany: Fase 1 (Rework botânica)

### DIFF
--- a/Content.Server/Botany/Systems/BotanySwabSystem.cs
+++ b/Content.Server/Botany/Systems/BotanySwabSystem.cs
@@ -74,6 +74,7 @@
 // SPDX-FileCopyrightText: 2024 to4no_fix <156101927+chavonadelal@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 voidnull000 <18663194+voidnull000@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Tropica1Owl <tropicalowl@outlook.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Server/Botany/Systems/BotanySwabSystem.cs
+++ b/Content.Server/Botany/Systems/BotanySwabSystem.cs
@@ -151,7 +151,7 @@ public sealed class BotanySwabSystem : EntitySystem
             if (old == null)
                 return;
             plant.Seed = _mutationSystem.Cross(swab.SeedData, old); // Cross-pollenate
-            swab.SeedData = old; // Transfer old plant pollen to swab
+            swab.SeedData = null; // Transfer old plant pollen to swab / Gaby change - Clears the swab after usage
             _popupSystem.PopupEntity(Loc.GetString("botany-swab-to"), args.Args.Target.Value, args.Args.User);
         }
 

--- a/Content.Server/Botany/Systems/BotanySwabSystem.cs
+++ b/Content.Server/Botany/Systems/BotanySwabSystem.cs
@@ -74,6 +74,7 @@
 // SPDX-FileCopyrightText: 2024 to4no_fix <156101927+chavonadelal@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 voidnull000 <18663194+voidnull000@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 // SPDX-FileCopyrightText: 2025 Tropica1Owl <tropicalowl@outlook.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -132,14 +132,11 @@ public sealed class MutationSystem : EntitySystem
                 val[otherChem.Key] = Random(0.5f) ? otherChem.Value : val[otherChem.Key];
             }
             // if target plant doesn't have this chemical, has 50% chance to add it.
-            else
+            else // Gaby change - Plants now add every missing chemical from the swab, guaranteed.
             {
-                if (Random(0.5f))
-                {
-                    var fixedChem = otherChem.Value;
-                    fixedChem.Inherent = false;
-                    val.Add(otherChem.Key, fixedChem);
-                }
+                var fixedChem = otherChem.Value;
+                fixedChem.Inherent = false;
+                val.Add(otherChem.Key, fixedChem);
             }
         }
 
@@ -192,12 +189,12 @@ public sealed class MutationSystem : EntitySystem
     }
     private void CrossFloat(ref float val, float other)
     {
-        val = Random(0.5f) ? val : other;
+        val = (val + other) / 2f; // Gaby change - Crosses the float between a medium point instead of picking one or the other
     }
 
     private void CrossInt(ref int val, int other)
     {
-        val = Random(0.5f) ? val : other;
+        val = (int)Math.Floor((val + other) / 2.0f); // Gaby change - Same as above, just with the added benefit of rounding up
     }
 
     private void CrossBool(ref bool val, bool other)

--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -13,6 +13,8 @@
 // SPDX-FileCopyrightText: 2024 drakewill-CRL <46307022+drakewill-CRL@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
+// SPDX-FileCopyrightText: 2025 Tropica1Owl <tropicalowl@outlook.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -13,6 +13,7 @@
 // SPDX-FileCopyrightText: 2024 drakewill-CRL <46307022+drakewill-CRL@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 // SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 // SPDX-FileCopyrightText: 2025 Tropica1Owl <tropicalowl@outlook.com>
 //


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## Sobre a PR
<!-- O que ela muda? -->
Da mesma criadora de shitmed...

Shitany.

Esse PR é mais algo para eu testar as águas de algo maior, eu acredito que a botânica do SS14 é lotada de RNG ao ponto de ser meio nojento, e esse rework (atualmente só do cotonete) visa reduzir drásticamente o RNG.
## Por quê? / Balanceamento
<!-- Discuta do por que da existencia da PR. (opcional | recomendado) -->
A botânica atualmente é um trabalho atualmente que envolve muita adivinhação, chance e grind pra fazer coisas que em outras versões do SS13/14 seriam banalmente fáceis.

Eu havia conversado com o Mocho (quem pegou o shitmed após eu pular fora) sobre fazer um rework de botânica mesmo, mexer em como o cotonete funciona para reduzir o RNG. Essa é a minha primeira tentativa de fazer isso.

### O que mudou?

Agora todo status numérico das plantas ficarão sempre na média entre duas plantas combinadas, se você tem um trigo com 50 de potência e 3 de colheita, e um chanterelle com 1 de potência e 5 de colheita, após passar o cotonete o chanterelle vai, **garantido**, ficar com 25.5 de potência e 4 de colheita, além de ter farinha. O cotonete também ficará limpo após o segundo uso, permitindo que seja re-usado.

Isso vale pra todos os status numéricos, até os que não são possíveis de ver dentro do jogo. Todo valor que resulta em um **inteiro** sempre será arredondado pra baixo, todavia.

### O que NÃO mudou:

Todo status, traço e mutação que é entre "ter ou não ter" continua sendo 50% de chance de ser transferido. Eu acho que se fosse garantido daí já ia virar o cúmulo do OP.

Se você passar o cotonete e a segunda planta não ter um químico que o cotonete tem há 50% de chance de algum químico aleatório ser removido da planta também.

Por fim, se ambas as plantas possuem o mesmo químico, a quantia produzida continua sendo escolhida aleatóriamente.

## Detalhes Tecnicos
<!-- Mudanças do codigo para uma review mais facil (opcional). -->

Como eu tive que botar minhas mãos sujas no código direto do jogo eu acabei botando comentários em tudo que mudei, caso Goob venha fazer um sistema de botânica melhor ou isso aqui se tornar irrelevante favor reverter.

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

Imagem abaixo demonstrando o cenário que tinha explicado mais cedo:

<img width="401" height="285" alt="image" src="https://github.com/user-attachments/assets/4b2292e0-b0bd-4e35-90b0-9d359f30cb51" />


## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione uma entrada para changelog do servidor, bote o emoji :cl: e siga com as mudanças assim como o exemplo.
:cl: em branco fara com que seu nome na changelog apareça como do github, adicione um nome depois do emoji para mudar seu nome na changelog. -->

:cl:
- tweak: Botânica é finalmente divertida, cheque o Github para aprender sobre como o cotonete funciona.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Gameplay Changes
  - Swabs are now consumed after a cross-pollination and must be reloaded with new pollen for further use.
  - Crossbreeding always transfers chemicals present in the pollen to plants that lack them, removing the previous chance-based behavior.
  - Trait/stat outcomes from crossbreeding are now averaged between parent values (integers round down), replacing prior randomness for more predictable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->