### PR TITLE
Adiciona anestesia básica na caixa cirurgica

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -17,9 +17,11 @@
 # SPDX-FileCopyrightText: 2023 coolmankid12345 <55817627+coolmankid12345@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2023 coolmankid12345 <coolmankid12345@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2023 lapatison <100279397+lapatison@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+# SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
+# SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -19,6 +19,7 @@
 # SPDX-FileCopyrightText: 2023 lapatison <100279397+lapatison@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>

--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -98,6 +98,9 @@
       - id: MedicalStitches
       - id: BoxLatexGloves
       - id: BoxSterileMask
+      # Gaby Station -> Medical QoL
+      - id: NitrousOxideTankFilled
+      - id: ClothingMaskBreathMedical
 
 - type: entity
   id: CrateMedicalScrubs


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR
Adiciona um tanque cheio de n2o e uma máscara médica na caixa de cirurgia.

## Por quê? / Balanceamento
É uma sugestão recorrente. Também me parece faltar um consenso em ter ou não esses itens nos mapas; alguns tens, outros não. Como alguns mapas tem, fica bem evidente e chato a falta em outros. 

**Changelog**
:cl:
- add: Tanque de óxido nitroso e mascará médica adicionados na caixa de cirurgia!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Surgery supply crates now include a nitrous oxide tank and a medical breathing mask, expanding anesthesia and respiratory support options.
  * Improves operating room readiness by providing essential gas and protective equipment out of the box, reducing setup time and resupply trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->