### PR TITLE
Corrige jugs rotuladas

### DIFF
--- a/Resources/Locale/pt-BR/Entities/Objects/Specific/chemical-containers.ftl
+++ b/Resources/Locale/pt-BR/Entities/Objects/Specific/chemical-containers.ftl
@@ -1,50 +1,27 @@
 ent-Jug = jarro
     .desc = Usado para conter uma quantidade muito grande de produtos químicos ou soluções. Ingerir é extremamente desaconselhável.
 
-ent-JugCarbon = jarro (carbono)
-
-ent-JugIodine = jarro (iodo)
-
-ent-JugFluorine = jarro (flúor)
-
-ent-JugChlorine = jarro (clorina)
-
-ent-JugAluminium = jarro (alumínio)
-
-ent-JugPhosphorus = jarro (fósforo)
-
-ent-JugSulfur = jarro (enxofre)
-
-ent-JugSilicon = jarro (silício)
-
-ent-JugHydrogen = jarro (hidrogênio)
-
-ent-JugLithium = jarro (lítio)
-
-ent-JugSodium = jarro (sódio)
-
-ent-JugPotassium = jarro (potássio)
-
-ent-JugRadium = jarro (rádio)
-
-ent-JugIron = jarro (ferro)
-
-ent-JugCopper = jarro (cobre)
-
-ent-JugGold = jarro (ouro)
-
-ent-JugMercury = jarro (mercúrio)
-
-ent-JugSilver = jarro (prata)
-
-ent-JugEthanol = jarro (etanol)
-
-ent-JugSugar = jarro (açúcar)
-
-ent-JugNitrogen = jarro (nitrogênio)
-
-ent-JugOxygen = jarro (oxigênio)
-
-ent-JugPlantBGone = jarro (Planta-B-Gone)
-
-ent-JugWeldingFuel = jarro (combustível de solda)
+ent-JugCarbon = { ent-Jug }
+ent-JugIodine = { ent-Jug }
+ent-JugFluorine = { ent-Jug }
+ent-JugChlorine = { ent-Jug }
+ent-JugAluminium = { ent-Jug }
+ent-JugPhosphorus = { ent-Jug }
+ent-JugSulfur = { ent-Jug }
+ent-JugSilicon = { ent-Jug }
+ent-JugHydrogen = { ent-Jug }
+ent-JugLithium = { ent-Jug }
+ent-JugSodium = { ent-Jug }
+ent-JugPotassium = { ent-Jug }
+ent-JugRadium = { ent-Jug }
+ent-JugIron = { ent-Jug }
+ent-JugCopper = { ent-Jug }
+ent-JugGold = { ent-Jug }
+ent-JugMercury = { ent-Jug }
+ent-JugSilver = { ent-Jug }
+ent-JugEthanol = { ent-Jug }
+ent-JugSugar = { ent-Jug }
+ent-JugNitrogen = { ent-Jug }
+ent-JugOxygen = { ent-Jug }
+ent-JugPlantBGone = { ent-Jug }
+ent-JugWeldingFuel = { ent-Jug } 

--- a/Resources/Locale/pt-BR/Entities/Objects/Specific/chemical-containers.ftl
+++ b/Resources/Locale/pt-BR/Entities/Objects/Specific/chemical-containers.ftl
@@ -24,4 +24,4 @@ ent-JugSugar = { ent-Jug }
 ent-JugNitrogen = { ent-Jug }
 ent-JugOxygen = { ent-Jug }
 ent-JugPlantBGone = { ent-Jug }
-ent-JugWeldingFuel = { ent-Jug } 
+ent-JugWeldingFuel = { ent-Jug }


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR
Há décadas atrás mudaram onde fica o nome dos jugs. Ao invés do nome da entidade ser "jarro (hidrogênio)", mudaram para apenas "jarro" e adicionaram o label "hidrogênio". Bom de fazer isso é que quando tu rotula um jarro que já tinha um nome, ele sobrescreve o nome anterior. Sem isso, fica algo do tipo "jarro (hidrogênio) (Bica|Brute|15u)"; com isso, fica "jarro (Bica|Brute|15u)".

## Por quê? / Balanceamento
Chemms go brrrrr. Uma vez um med me questionou pq tinha o nome "hidrogênio" no jug de remédio. Não, eu não estava tentando sabotar os remédios AAAAAAAAAAAAAAAAAAAAAA

**Changelog**
:cl:
- tweak: Rotular jarros do dispersor químico agora sobrescreve o rótulo ao invés de adicionar. Por exemplo, antes, "jarro (hidrogênio) (Bica|Brute|15u)"; agora, "jarro (Bica|Brute|15u)".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - pt-BR translations for chemical container names were consolidated to reference a single base term for consistency.
  - Removed per-item duplicated localized strings, reducing translation bloat and chance of mismatches.
  - No gameplay changes; end users may see more uniform Portuguese names across chemical container variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->