### PR TITLE
Revert na Salv Shuttle Custom do Gaby

### DIFF
--- a/Content.Server/_Lavaland/Shuttles/Systems/DockingConsoleSystem.cs
+++ b/Content.Server/_Lavaland/Shuttles/Systems/DockingConsoleSystem.cs
@@ -187,7 +187,7 @@ public sealed class DockingConsoleSystem : SharedDockingConsoleSystem
         _shuttle.FTLToDock(shuttle, Comp<ShuttleComponent>(shuttle), grid, priorityTag: docking.DockTag);
     }
 
-    private readonly ResPath _miningShuttlePath = new("/Maps/_Gabystation/Shuttles/mining.yml"); // Gaby - Usando nossa nave custom.
+    private readonly ResPath _miningShuttlePath = new("/Maps/_Lavaland/mining.yml"); // Gaby - Revertido para a shuttle padrão.
 
     /// <summary>
     /// Load a new mining shuttle if it still doesn't exist

--- a/Content.Server/_Lavaland/Shuttles/Systems/DockingConsoleSystem.cs
+++ b/Content.Server/_Lavaland/Shuttles/Systems/DockingConsoleSystem.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 // SPDX-FileCopyrightText: 2025 Aineias1 <dmitri.s.kiselev@gmail.com>
+// SPDX-FileCopyrightText: 2025 Dreykor <160512778+Dreykor@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Dreykor <Dreykor12@gmail.com>
 // SPDX-FileCopyrightText: 2025 FaDeOkno <143940725+FaDeOkno@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Fishbait <Fishbait@git.ml>


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## Sobre a PR
Basicamente, altera a shuttle da salv que o jogo escolhe para o original do Goob.

## Por quê? / Balanceamento
Tivemos que fazer uma shuttle custom para adaptar a realidade do Gaby de possuir a lavaland desativada por motivos técnicos, mas agora que reativamos a lavaland, nossa shuttle com capacidade de locomoção não é só mais desnecessário, como representa uma falha de identidade no desenvolvimento/projeto atual de salvatagem com lavaland.

## Detalhes Tecnicos
Alterado apenas o caminho do diretório que aponta o protótipo da shuttle.

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione uma entrada para changelog do servidor, bote o emoji :cl: e siga com as mudanças assim como o exemplo.
:cl: em branco fara com que seu nome na changelog apareça como do github, adicione um nome depois do emoji para mudar seu nome na changelog. -->
<!--
:cl:
- tweak: Agora que a lavaland voltou, a shuttle da salvatagem voltou a sua forma original.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Revert
  - Restored the standard Lavaland mining shuttle when called from the docking console, replacing the previous Gabystation variant. Players will now board the Lavaland mining shuttle upon summon; no other shuttle-calling behavior changes.
- Chores
  - Updated copyright metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->