### PR TITLE
[HOTFIX] Corrige mobs do gaby

### DIFF
--- a/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/alternate.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/alternate.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 P e p e . <josephpereira413@gmail.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   name: xenonid burrower
   id: BaseMobAlternate

--- a/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/alternate.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/alternate.yml
@@ -1,7 +1,135 @@
 - type: entity
+  name: xenonid burrower
+  id: BaseMobAlternate
+  parent: SimpleSpaceMobBase
+  description: They mostly come at night. Mostly.
+  components:
+  - type: Insulated
+  - type: CombatMode
+  - type: InputMover
+  - type: MobMover
+  - type: HTN
+    rootTask:
+      task: XenoCompound
+    blackboard:
+      NavClimb: !type:Bool
+        true
+      NavInteract: !type:Bool
+        true
+      NavPry: !type:Bool
+        true
+      NavSmash: !type:Bool
+        true
+  - type: Prying
+    pryPowered: true
+    force: true
+    speedModifier: 1.5
+    useSound:
+      path: /Audio/Items/crowbar.ogg
+  - type: UseDelay # Goobstation - For insta prying
+    delay: 1
+  - type: Reactive
+    groups:
+      Flammable: [Touch]
+      Extinguish: [Touch]
+  - type: NpcFactionMember
+    factions:
+    - Xeno
+  - type: Hands
+  - type: ComplexInteraction
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/Xenos/burrower.rsi
+    layers:
+    - map: ["enum.DamageStateVisualLayers.Base"]
+      state: running
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.25
+        density: 1000
+        mask:
+        - MobMask
+        layer:
+        - MobLayer
+  - type: MobState
+    allowedStates:
+    - Alive
+    - Dead
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      50: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      25: 0.5
+  - type: Stamina
+    critThreshold: 200
+  - type: Bloodstream
+    bloodReagent: FluorosulfuricAcid
+    bloodMaxVolume: 650
+  - type: MeleeWeapon
+    altDisarm: false
+    angle: 0
+    soundHit:
+     collection: AlienClaw
+    animation: WeaponArcBite
+    damage:
+      groups:
+        Brute: 6
+  - type: DamageStateVisuals
+    rotate: true
+    states:
+      Alive:
+        Base: running
+      Critical:
+        Base: crit
+      Dead:
+        Base: dead
+  - type: Puller
+  - type: Butcherable
+    butcheringType: Spike
+    spawned:
+    - id: FoodMeatXeno
+      amount: 5
+  - type: GhostRole
+    allowMovement: true
+    allowSpeech: true
+    makeSentient: true
+    name: ghost-role-information-xeno-name
+    description: ghost-role-information-xeno-description
+    rules: ghost-role-information-xeno-rules
+    raffle:
+      settings: default
+  - type: GhostTakeoverAvailable
+  - type: TypingIndicator
+    proto: alien
+  - type: Temperature
+    heatDamageThreshold: 360
+    coldDamageThreshold: -150
+    currentTemperature: 310.15
+  - type: Tag
+    tags:
+      - CannotSuicide
+      - DoorBumpOpener
+      - FootstepSound
+  - type: NoSlip
+  - type: Perishable #Ummmm the acid kills a lot of the bacteria or something
+    molsPerSecondPerUnitMass: 0.0005
+  - type: Speech
+    speechVerb: LargeMob
+  - type: ThermalVision
+    lightRadius: 15
+    color: "#808080"
+    activateSound: null
+    deactivateSound: null
+
+- type: entity
   name: Alternate
   description: The pure form of a killing machine, had enough trying to make you end yourself, he's doing it for you. Nothing Is Worth The Risk.
-  parent: MobXeno
+  parent: BaseMobAlternate
   id: MobAlternate
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/alternate.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/alternate.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 P e p e . <josephpereira413@gmail.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/alternate_alt.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/alternate_alt.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 P e p e . <josephpereira413@gmail.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   name: Alternate
   suffix: Whisperer

--- a/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/alternate_alt.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/alternate_alt.yml
@@ -2,7 +2,7 @@
   name: Alternate
   suffix: Whisperer
   description: Nothing Is Worth The Risk.
-  parent: MobXeno
+  parent: BaseMobAlternate
   id: MobAlternateAlt
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/alternate_alt.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/alternate_alt.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 P e p e . <josephpereira413@gmail.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/unnamed_thumper.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/unnamed_thumper.yml
@@ -2,7 +2,7 @@
   name: '???'
   suffix: Unnamed, Thumper
   description: "The manifestation of my being will watch over you, when you sleep in bed, and you wake up, you won't be able to move any part of you."
-  parent: MobXeno
+  parent: BaseMobAlternate
   id: MobUnnamedThumper
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/unnamed_thumper.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/unnamed_thumper.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 P e p e . <josephpereira413@gmail.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   name: '???'
   suffix: Unnamed, Thumper

--- a/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/unnamed_thumper.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/unnamed_thumper.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 P e p e . <josephpereira413@gmail.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/wendigo.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/wendigo.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 P e p e . <josephpereira413@gmail.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   name: Wendigo
   description: A manhunter entity of the dark woods. Although its main diet is humanoids, it won't pass a meal at anything that comes across it.

--- a/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/wendigo.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/wendigo.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: Wendigo
   description: A manhunter entity of the dark woods. Although its main diet is humanoids, it won't pass a meal at anything that comes across it.
-  parent: MobXeno
+  parent: BaseMobAlternate
   id: MobWendigo
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/wendigo.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/wendigo.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 P e p e . <josephpereira413@gmail.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR
Goob deletou os xenos do wizden e nós usamos eles como base pro Alternate, Wendigo e etc. Esse PR trás de volta a base com um nome condizente.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Alternate gains devour ability with self-healing, improved door interaction (faster prying/door bump), thermal vision, and no-slip.
  - Adjusted Alternate movement speed and melee damage profile.

- Refactor
  - Unified Alternate, Wendigo, and Thumper under a shared behavior set for more consistent creature behavior.

- Chores
  - Added license headers to related files.
  - Updated audio assets for Alternate (streamlined sound set).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->