### PR TITLE
Nova tag para rules dos game directors

### DIFF
--- a/Content.Goobstation.Server/StationEvents/GameDirectorSystem.cs
+++ b/Content.Goobstation.Server/StationEvents/GameDirectorSystem.cs
@@ -3,9 +3,12 @@
 // SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
+// SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 // SPDX-FileCopyrightText: 2025 Milon <milonpl.git@proton.me>
 // SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>
+// SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 // SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
 // SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>

--- a/Content.Goobstation.Server/StationEvents/GameDirectorSystem.cs
+++ b/Content.Goobstation.Server/StationEvents/GameDirectorSystem.cs
@@ -40,6 +40,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Prometheus;
+using Content.Server._Gabystation;
 
 namespace Content.Goobstation.Server.StationEvents;
 
@@ -356,7 +357,7 @@ public sealed class GameDirectorSystem : GameRuleSystem<GameDirectorComponent>
         void IndexAndStartGameMode(string pick)
         {
             var pickProto = _prototypeManager.Index(pick);
-            if(!pickProto.TryGetComponent<GameRuleComponent>(out var pickGameRule, _factory) ||
+            if (!pickProto.TryGetComponent<GameRuleComponent>(out var pickGameRule, _factory) ||
                pickGameRule.MinPlayers > count)
             {
                 LogMessage("Not enough players for roundstart antags selected...");
@@ -365,7 +366,9 @@ public sealed class GameDirectorSystem : GameRuleSystem<GameDirectorComponent>
             LogMessage("Choosing roundstart antag");
             LogMessage($"Roundstart antag chosen: {pick}");
             RoundstartAntagsSelectedTotal.WithLabels(pick).Inc();
-            GameTicker.AddGameRule(pick);
+            var rule = GameTicker.AddGameRule(pick);
+
+            _tag.AddTag(rule, GabyConstants.GameDirectorRuleTag); // GabyStation
         }
     }
 

--- a/Content.Goobstation.Server/StationEvents/GameDirectorSystem.cs
+++ b/Content.Goobstation.Server/StationEvents/GameDirectorSystem.cs
@@ -350,9 +350,11 @@ public sealed class GameDirectorSystem : GameRuleSystem<GameDirectorComponent>
             LogMessage($"Roundstart antag chosen: {pick2}");
 
             RoundstartAntagsSelectedTotal.WithLabels(pick).Inc();
-            GameTicker.AddGameRule(pick);
+            var rule1 = GameTicker.AddGameRule(pick);
+            _tag.AddTag(rule1, GabyConstants.GameDirectorRuleTag);
             RoundstartAntagsSelectedTotal.WithLabels(pick2).Inc();
-            GameTicker.AddGameRule(pick2);
+            var rule2 = GameTicker.AddGameRule(pick2);
+            _tag.AddTag(rule2, GabyConstants.GameDirectorRuleTag);
         }
 
         return;

--- a/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
+++ b/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
@@ -1,6 +1,8 @@
+// SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
+// SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 // SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
+++ b/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>

--- a/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
+++ b/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
@@ -31,6 +31,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
+using Content.Server._Gabystation;
 
 namespace Content.Goobstation.Server.StationEvents.SecretPlus;
 
@@ -319,6 +320,7 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
     private void StartRule(Entity<SecretPlusComponent> scheduler, string rule, bool doStart = true, int? players = null)
     {
         var ruleUid = _ticker.AddGameRule(rule);
+        _tag.AddTag(ruleUid, GabyConstants.GameDirectorRuleTag); // GabyStation
 
         scheduler.Comp.ChaosScore += GetChaosScore(ruleUid, players)!.Value;
 

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
@@ -10,6 +10,7 @@
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aviu00 <aviu00@protonmail.com>
+// SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 // SPDX-FileCopyrightText: 2025 SlamBamActionman <83650252+SlamBamActionman@users.noreply.github.com>

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
@@ -11,7 +11,9 @@
 // SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aviu00 <aviu00@protonmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 // SPDX-FileCopyrightText: 2025 SlamBamActionman <83650252+SlamBamActionman@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 TemporalOroboros <TemporalOroboros@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
@@ -22,9 +22,11 @@ using Content.Server.Station.Systems;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Maps;
 using Content.Shared.Random.Helpers;
+using Content.Shared.Tag;
 using Robust.Shared.Collections;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
 

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.cs
@@ -14,6 +14,8 @@
 // SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 deltanedas <@deltanedas:kde.org>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+// SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.cs
@@ -78,6 +78,10 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
             }
             else
             {
+                ChatManager.SendAdminAnnouncement(Loc.GetString("preset-not-enough-ready-players-end-rule",
+                    ("readyPlayersCount", args.Players.Length),
+                    ("minimumPlayers", minPlayers),
+                    ("presetName", ToPrettyString(uid))));
                 ForceEndSelf(uid, gameRule);
             }
         }

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.cs
@@ -20,9 +20,13 @@
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Chat.Managers;
 using Content.Shared.GameTicking.Components;
+using Content.Shared.Tag;
 using Robust.Server.GameObjects;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
+using Content.Goobstation.Server.StationEvents;
+using Content.Server._Gabystation;
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -36,6 +40,7 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
     // Not protected, just to be used in utility methods
     [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
     [Dependency] private readonly MapSystem _map = default!;
+    [Dependency] private readonly TagSystem _tag = default!; // GabyStation
 
     public override void Initialize()
     {
@@ -60,7 +65,7 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
             if (args.Players.Length >= minPlayers)
                 continue;
 
-            if (gameRule.CancelPresetOnTooFewPlayers)
+            if (!_tag.HasTag(uid, GabyConstants.GameDirectorRuleTag) && gameRule.CancelPresetOnTooFewPlayers)
             {
                 ChatManager.SendAdminAnnouncement(Loc.GetString("preset-not-enough-ready-players",
                     ("readyPlayersCount", args.Players.Length),

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.cs
@@ -14,6 +14,7 @@
 // SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 deltanedas <@deltanedas:kde.org>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 // SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 // SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 //

--- a/Content.Server/_Gabystation/GabyConstants.cs
+++ b/Content.Server/_Gabystation/GabyConstants.cs
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 // SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Server/_Gabystation/GabyConstants.cs
+++ b/Content.Server/_Gabystation/GabyConstants.cs
@@ -1,0 +1,11 @@
+using Content.Shared.Tag;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Gabystation;
+
+// A existência disso é terrível...
+public sealed class GabyConstants
+{
+    // Não sei onde colocar isso. Os GameRuleSystem<T> são genéricos, não da pra por neles.
+    public static readonly ProtoId<TagPrototype> GameDirectorRuleTag = "GameDirectorRule";
+}

--- a/Content.Server/_Gabystation/GabyConstants.cs
+++ b/Content.Server/_Gabystation/GabyConstants.cs
@@ -9,7 +9,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Server._Gabystation;
 
 // A existência disso é terrível...
-public sealed class GabyConstants
+public static class GabyConstants
 {
     // Não sei onde colocar isso. Os GameRuleSystem<T> são genéricos, não da pra por neles.
     public static readonly ProtoId<TagPrototype> GameDirectorRuleTag = "GameDirectorRule";

--- a/Content.Server/_Gabystation/GabyConstants.cs
+++ b/Content.Server/_Gabystation/GabyConstants.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared.Tag;
 using Robust.Shared.Prototypes;
 

--- a/Resources/Locale/en-US/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-ticker.ftl
@@ -37,24 +37,24 @@ game-ticker-get-info-text = Hi and welcome to [color=white]Space Station 14![/co
                             The current map is: [color=white]{$mapName}[/color]
                             The current game mode is: [color=white]{$gmTitle}[/color]
                             >[color=yellow]{$desc}[/color]
-game-ticker-get-info-preround-text = Olá e bem-vindo à [color=#667C4D]Gaby Station![/color]
-                            A rodada atual é: [color=white]#{$roundId}[/color]
-                            O número atual de jogadores é: [color=white]{$playerCount}[/color] ([color=white]{$readyCount}[/color] {$readyCount ->
-                                [one] está
-                                *[other] estão
-                            } prontos)
-                            O mapa atual é: [color=white]{$mapName}[/color]
-                            O modo de jogo atual é: [color=white]{$gmTitle}[/color]
+game-ticker-get-info-preround-text = Hi and welcome to [color=white]Space Station 14![/color]
+                            The current round is: [color=white]#{$roundId}[/color]
+                            The current player count is: [color=white]{$playerCount}[/color] ([color=white]{$readyCount}[/color] {$readyCount ->
+                                [one] is
+                                *[other] are
+                            } ready)
+                            The current map is: [color=white]{$mapName}[/color]
+                            The current game mode is: [color=white]{$gmTitle}[/color]
                             >[color=yellow]{$desc}[/color]
-game-ticker-no-map-selected = [color=yellow]Mapa ainda não selecionado![/color]
-game-ticker-player-no-jobs-available-when-joining = Ao tentar entrar no jogo, nenhum cargo estava disponível.
+game-ticker-no-map-selected = [color=yellow]Map not yet selected![/color]
+game-ticker-player-no-jobs-available-when-joining = When attempting to join to the game, no jobs were available.
 
-# Exibido no chat para administradores quando um jogador entra
-player-join-message = Jogador {$name} entrou.
-player-first-join-message = Jogador {$name} entrou pela primeira vez.
+# Displayed in chat to admins when a player joins
+player-join-message = Player {$name} joined.
+player-first-join-message = Player {$name} joined for the first time.
 
-# Exibido no chat para administradores quando um jogador sai
-player-leave-message = Jogador {$name} saiu.
+# Displayed in chat to admins when a player leaves
+player-leave-message = Player {$name} left.
 
 latejoin-arrival-announcement = {$character} ({$job}) has arrived at the station!
 latejoin-arrival-announcement-special = {$job} {$character} on deck!
@@ -64,9 +64,9 @@ latejoin-arrivals-direction-time = A shuttle transferring you to your station wi
 latejoin-arrivals-dumped-from-shuttle = A mysterious force prevents you from leaving with the arrivals shuttle.
 latejoin-arrivals-teleport-to-spawn = A mysterious force teleports you off the arrivals shuttle. Have a safe shift!
 
-preset-not-enough-ready-players = Não é possível iniciar {$presetName}. São necessários {$minimumPlayers} jogadores, mas temos apenas {$readyPlayersCount}.
-preset-no-one-ready = Não é possível iniciar {$presetName}. Nenhum jogador está pronto.
+preset-not-enough-ready-players = Can't start {$presetName}. Requires {$minimumPlayers} players but we have {$readyPlayersCount}.
+preset-no-one-ready = Can't start {$presetName}. No players are ready.
 
-game-run-level-PreRoundLobby = Lobby pré-rodada
-game-run-level-InRound = Em rodada
-game-run-level-PostRound = Pós-rodada
+game-run-level-PreRoundLobby = Pre-round lobby
+game-run-level-InRound = In round
+game-run-level-PostRound = Post round

--- a/Resources/Locale/pt-BR/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/pt-BR/game-ticking/game-ticker.ftl
@@ -37,7 +37,8 @@ latejoin-arrivals-direction-time = Uma nave que o transferirá para sua estaçã
 latejoin-arrivals-dumped-from-shuttle = Uma força misteriosa impede você de sair com a nave de chegadas.
 latejoin-arrivals-teleport-to-spawn = Uma força misteriosa teletransporta você para fora da nave de chegadas. Tenha um turno seguro!
 
-preset-not-enough-ready-players = Não é possível iniciar {$presetName}. São necessários {$minimumPlayers} de jogadores prontos, mas temos apenas {$readyPlayersCount}.
+preset-not-enough-ready-players = A rodada será cancelado pois não é possível iniciar {$presetName}. São necessários {$minimumPlayers} jogadores prontos, mas temos apenas {$readyPlayersCount}.
+preset-not-enough-ready-players-end-rule = Cancelando {$presetName}, são necessários {$minimumPlayers} jogadores prontos, mas temos apenas {$readyPlayersCount}.
 preset-no-one-ready = Não é possível iniciar {$presetName}. Nenhum jogador está pronto.
 
 game-run-level-PreRoundLobby = Lobby pré-rodada

--- a/Resources/Prototypes/_Gabystation/tags.yml
+++ b/Resources/Prototypes/_Gabystation/tags.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Gabystation/tags.yml
+++ b/Resources/Prototypes/_Gabystation/tags.yml
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: Tag
   id: GameDirectorRule

--- a/Resources/Prototypes/_Gabystation/tags.yml
+++ b/Resources/Prototypes/_Gabystation/tags.yml
@@ -1,0 +1,2 @@
+- type: Tag
+  id: GameDirectorRule


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR
Os rounds não serão mais cancelados nos modos de jogo game director e secret plus.

## Detalhes técnicos
Antes, ao iniciar o round, o jogo verificava todos os antagonistas selecionados (na verdade, as rules) e, se a quantidade de ready's não fosse o suficiente, ele cancelava a rodada. Como os game directors (os secrets plus são game directors) não levam em conta a quantidade de ready's ao decidir o round start antag, pode acontecer dele selecionar antags que sejam impossíveis de rodar ou, na maioria dos casos, a pop não bate o pré-requisito de prontos.

No caso dos secret plus, os round start antags são decididos 20 segundos antes do round iniciar, junto com o carregamento do mapa da estação. Nesse momento não se tem a informação da quantidade de readys e por isso não podemos levá-la em conta. Talvez outra solução seja parar de rodar as rules 20 segundo antes e adicioná-las ao iniciar o round.

A solução proposta é marcar todos as rules criadas por um game director para, ao iniciar o round, se não bater o pré requisito de prontos, simplesmente deletá-la ao invés de cancelar a rodada. Isso me parece plausível pois como se trata de um game director, haverão mais antagonistas no decorrer do round. A pop ainda tem motivação para dar os prontos, visto que com prontos os roundstart antag são garantidos.

A implementação me parece correta e acredito não ter esquecido nada. No pior dos casos, o sistema se mantém como era antes.

**Changelog**
:cl:
- tweak: Os rounds não devem reiniciar por falta de prontos! Mesmo assim, quanto mais prontos, mais antags diferentes e divertidos.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Game Director and Secret+ round-start rules now include metadata so they behave and are handled distinctly at startup.
- Bug Fixes
  - Rules that should run at low population no longer get unintentionally cancelled; affected presets now produce a clear end-rule announcement when ended instead.
- Chores
  - License headers updated across files.
- Localization
  - English and Portuguese game-ticker messages and new late-join keys added/updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->