### PR TITLE
Lavaland buff

### DIFF
--- a/Resources/Prototypes/_Lavaland/Procedural/ruin_pools.yml
+++ b/Resources/Prototypes/_Lavaland/Procedural/ruin_pools.yml
@@ -1,10 +1,13 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2025 Aineias1 <142914808+Aineias1@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aineias1 <dmitri.s.kiselev@gmail.com>
+# SPDX-FileCopyrightText: 2025 Dreykor <160512778+Dreykor@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Dreykor <arguemeu@gmail.com>
 # SPDX-FileCopyrightText: 2025 FaDeOkno <143940725+FaDeOkno@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 # SPDX-FileCopyrightText: 2025 McBosserson <148172569+McBosserson@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Milon <plmilonpl@gmail.com>
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>

--- a/Resources/Prototypes/_Lavaland/Procedural/ruin_pools.yml
+++ b/Resources/Prototypes/_Lavaland/Procedural/ruin_pools.yml
@@ -32,23 +32,23 @@
     SyndicateBase: 1
     HierophantArena: 1
     RougeAI: 1
-    BiodomeBeach: 1 # 2 Gaby Station
-    BiodomeSnow: 1 # 2 Gaby Station
-    GolemShuttle: 1 # 2 Gaby Station
+    BiodomeBeach: 2
+    BiodomeSnow: 2
+    GolemShuttle: 2
     ToyShop: 1
-    Chemistry: 1 # 2 Gaby Station
-    LavaLake: 1 # 3 Gaby Station
+    Chemistry: 2
+    LavaLake: 3
     Graveyard: 1
-    SeedVault: 1
-    Hermit: 1
-    WaffleCo: 1
+    SeedVault: 2
+    Hermit: 5
+    WaffleCo: 2
     ArrivalsBack: 1
     ArrivalsFront: 1
-    CargoDebris: 1
+    CargoDebris: 2
     VulpLab: 1
-    Shelter: 1 # 4 Gaby Station
+    Shelter: 4
     Ratvar: 1
-    MiningPost: 1 # 3 Gaby Station
+    MiningPost: 3
     AbductorDebris: 1
     CultBase: 1
     FleshCave: 1
@@ -57,17 +57,17 @@
     RockCave: 1
     SlimeCave: 1
     Hunter: 1
-    Stash1: 1 # 2 Gaby Station
-    Stash2: 1 # 2 Gaby Station
-    Stash3: 1 # 2 Gaby Station
-    Stash4: 1 # 2 Gaby Station
+    Stash1: 2
+    Stash2: 2
+    Stash3: 2
+    Stash4: 2
 #WIZDEN RUINS (only peak ones, rest are trash) man
     CargoWreck: 1
     Murder: 1
-    EscapePod: 1 # 2 Gaby Station
-    Desk: 1 # 2 Gaby Station
-    Generator: 1 # 3 Gaby Station
+    EscapePod: 2
+    Desk: 2
+    Generator: 3
     Mug: 1
     Temple: 1
   dungeonRuins:
-    CommonRuin5x5: 15 # 60 Gaby Station
+    CommonRuin5x5: 60


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR
Quadruplica a quantidade de estruturas na lavaland. Esse PR desfaz os nerfs de performance na lavaland. O impacto de performance disso deve ser mínimo visto que agora as estruturas deixaram de ser grids separados.

**Changelog**
:cl:
- tweak: Espere ver mais muito mais estruturas na Lavaland.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Increased variety and frequency of Lavaland ruins, including more biodomes, shuttles, shelters, mining posts, generators, and stash sites.
  - Expanded dungeon ruin presence significantly for richer exploration.
  - More chances to encounter themed locations like Hermit, Waffle Co., Seed Vault, Cargo Debris, and Escape Pods.

- Chores
  - Updated contributor copyright headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->