### PR TITLE
Corrige todos os erros de yaml 

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/BloodCultRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/BloodCultRuleComponent.cs
@@ -27,7 +27,6 @@ public sealed partial class BloodCultRuleComponent : Component
     /// <summary>
     ///	Possible Nar'Sie summon locations.
     /// </summary>
-    [DataField]
     public static List<string> PossibleVeilLocations = new List<string> {
         "DefaultStationBeaconCaptainsQuarters", "DefaultStationBeaconHOPOffice",
         "DefaultStationBeaconSecurity", "DefaultStationBeaconBrig",

--- a/Content.Server/GameTicking/Rules/Components/BloodCultRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/BloodCultRuleComponent.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2025 AgentePanela <agentepanela@gmail.com>
 // SPDX-FileCopyrightText: 2025 Dreykor <160512778+Dreykor@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
+// SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+// SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Skye <57879983+Rainbeon@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 kbarkevich <24629810+kbarkevich@users.noreply.github.com>
 //

--- a/Content.Shared/Vampire/VampireComponent.cs
+++ b/Content.Shared/Vampire/VampireComponent.cs
@@ -27,8 +27,7 @@ namespace Content.Shared.Vampire.Components;
 public sealed partial class VampireComponent : Component
 {
     //Static prototype references
-    [ValidatePrototypeId<StatusEffectPrototype>]
-    public static readonly string SleepStatusEffectProto = "StatusEffectForcedSleeping";
+    public static readonly EntProtoId SleepStatusEffectProto = "StatusEffectForcedSleeping";
     [ValidatePrototypeId<EmotePrototype>]
     public static readonly string ScreamEmoteProto = "Scream";
     [ValidatePrototypeId<CurrencyPrototype>]

--- a/Content.Shared/Vampire/VampireComponent.cs
+++ b/Content.Shared/Vampire/VampireComponent.cs
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: 2025 Dreykor <Dreykor12@gmail.com>
 // SPDX-FileCopyrightText: 2025 Dreykor <arguemeu@gmail.com>
 // SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
+// SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 // SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/Actions/vampire.yml
+++ b/Resources/Prototypes/Actions/vampire.yml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2024 Rinary <72972221+Rinary1@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Dreykor <160512778+Dreykor@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Dreykor <arguemeu@gmail.com>
 # SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/Actions/vampire.yml
+++ b/Resources/Prototypes/Actions/vampire.yml
@@ -7,37 +7,30 @@
 - type: entity
   id: ActionVampireOpenMutationsMenu
   name: Mutations menu
-  description: "Opens menu with vampires mutations."
+  description: Opens menu with vampires mutations.
   categories: [ HideSpawnMenu ]
   components:
-    - type: InstantAction
-      itemIconStyle: NoItem
-      icon:
-        sprite: Interface/Actions/actions_vampire.rsi
-        state: summonheirloom
-      event:
-        !type:VampireOpenMutationsMenu
-      useDelay: 5
+  - type: Action
+    itemIconStyle: NoItem
+    icon: { sprite: Interface/Actions/actions_vampire.rsi, state: summonheirloom }
+    useDelay: 5
+  - type: InstantAction
+    event: !type:VampireOpenMutationsMenu {}
 
 - type: entity
   id: ActionVampireToggleFangs
   name: Toggle Fangs
-  description: "Extend or retract your fangs. Walking around with your fangs out might reveal your true nature."
+  description: Extend or retract your fangs. Walking around with your fangs out might reveal your true nature.
   categories: [ HideSpawnMenu ]
   components:
-    - type: InstantAction
-      checkCanInteract: false
-      priority: 1
-      itemIconStyle: NoItem
-      icon:
-        sprite: Interface/Actions/actions_vampire.rsi
-        state: fangs_retracted
-      iconOn:
-        sprite: Interface/Actions/actions_vampire.rsi
-        state: fangs_extended
-      event:
-        !type:VampireToggleFangsEvent
-        definitionName: ToggleFangs
+  - type: Action
+    checkCanInteract: false
+    priority: 1
+    itemIconStyle: NoItem
+    icon: { sprite: Interface/Actions/actions_vampire.rsi, state: fangs_retracted }
+    iconOn: { sprite: Interface/Actions/actions_vampire.rsi, state: fangs_extended }
+  - type: InstantAction
+    event: !type:VampireToggleFangsEvent { definitionName: ToggleFangs }
 
 - type: entity
   id: ActionVampireGlare
@@ -45,21 +38,18 @@
   description: "Release a blinding flash from your eyes, stunning a unprotected mortal for 10 seconds. Activation Cost: 20 Essence. Cooldown: 60 Seconds"
   categories: [ HideSpawnMenu ]
   components:
-    - type: EntityTargetAction
-      whitelist:
-        components:
-          - Body
-      priority: 2
-      itemIconStyle: NoItem
-      icon:
-        sprite: Interface/Actions/actions_vampire.rsi
-        state: glare
-      sound: !type:SoundPathSpecifier
-        path: /Audio/Effects/Vampire/glare.ogg
-      event:
-        !type:VampireGlareEvent
-        definitionName: Glare
-      useDelay: 60
+  - type: Action
+    priority: 2
+    itemIconStyle: NoItem
+    icon: { sprite: Interface/Actions/actions_vampire.rsi, state: glare }
+    sound: !type:SoundPathSpecifier { path: /Audio/Effects/Vampire/glare.ogg }
+    useDelay: 60
+  - type: TargetAction
+  - type: EntityTargetAction
+    whitelist:
+      components:
+        - Body
+    event: !type:VampireGlareEvent { definitionName: Glare }
 
 - type: entity
   id: ActionVampireHypnotise
@@ -67,21 +57,19 @@
   description: "Stare deeply into a mortals eyes, forcing them to sleep for 60 seconds. Activation Cost: 20 Essence. Activation Delay: 5 Seconds. Cooldown: 5 Minutes"
   categories: [ HideSpawnMenu ]
   components:
-    - type: EntityTargetAction
-      whitelist:
-        components:
-          - HumanoidAppearance
-      canTargetSelf: false
-      interactOnMiss: false
-      priority: 2
-      itemIconStyle: NoItem
-      icon:
-        sprite: Interface/Actions/actions_vampire.rsi
-        state: hypnotise
-      event:
-        !type:VampireHypnotiseEvent
-        definitionName: Hypnotise
-      useDelay: 300
+  - type: Action
+    priority: 2
+    itemIconStyle: NoItem
+    icon: { sprite: Interface/Actions/actions_vampire.rsi, state: hypnotise }
+    useDelay: 300
+  - type: TargetAction
+    interactOnMiss: false
+  - type: EntityTargetAction
+    whitelist:
+      components:
+        - HumanoidAppearance
+    canTargetSelf: false
+    event: !type:VampireHypnotiseEvent { definitionName: Hypnotise }
 
 - type: entity
   id: ActionVampireScreech
@@ -89,19 +77,15 @@
   description: "Release a piercing scream, stunning unprotected mortals and shattering fragile objects nearby. Activation Cost: 20 Essence. Activation Delay: 5 Seconds. Cooldown: 5 Minutes"
   categories: [ HideSpawnMenu ]
   components:
-    - type: InstantAction
-      checkCanInteract: false
-      priority: 2
-      itemIconStyle: NoItem
-      icon:
-        sprite: Interface/Actions/actions_vampire.rsi
-        state: screech
-      sound: !type:SoundPathSpecifier
-        path: /Audio/Effects/Vampire/screech_tone.ogg
-      event:
-        !type:VampireScreechEvent
-        definitionName: Screech
-      useDelay: 60
+  - type: Action
+    checkCanInteract: false
+    priority: 2
+    itemIconStyle: NoItem
+    icon: { sprite: Interface/Actions/actions_vampire.rsi, state: screech }
+    sound: !type:SoundPathSpecifier { path: /Audio/Effects/Vampire/screech_tone.ogg }
+    useDelay: 60
+  - type: InstantAction
+    event: !type:VampireScreechEvent { definitionName: Screech }
 
 - type: entity
   id: ActionVampireBloodSteal
@@ -109,19 +93,15 @@
   description: "Wrench the blood from all bodies nearby - living or dead. Activation Cost: 20 Essence. Cooldown: 60 Seconds"
   categories: [ HideSpawnMenu ]
   components:
-    - type: InstantAction
-      checkCanInteract: false
-      priority: 2
-      itemIconStyle: NoItem
-      icon:
-        sprite: Interface/Actions/actions_vampire.rsi
-        state: bloodsteal
-      sound: !type:SoundPathSpecifier
-        path: /Audio/Effects/demon_consume.ogg
-      event:
-        !type:VampireBloodStealEvent
-        definitionName: BloodSteal
-      useDelay: 60
+  - type: Action
+    checkCanInteract: false
+    priority: 2
+    itemIconStyle: NoItem
+    icon: { sprite: Interface/Actions/actions_vampire.rsi, state: bloodsteal }
+    sound: !type:SoundPathSpecifier { path: /Audio/Effects/demon_consume.ogg }
+    useDelay: 60
+  - type: InstantAction
+    event: !type:VampireBloodStealEvent { definitionName: BloodSteal }
 
 - type: entity
   id: ActionVampireBatform
@@ -129,19 +109,15 @@
   description: "Assume for form of a bat. Fast, Hard to Hit, Likes fruit. Activation Cost: 20 Essence. Cooldown: 30 Seconds"
   categories: [ HideSpawnMenu ]
   components:
-    - type: InstantAction
-      checkCanInteract: false
-      priority: 2
-      itemIconStyle: NoItem
-      icon:
-        sprite: Interface/Actions/actions_vampire.rsi
-        state: batform
-      sound: !type:SoundPathSpecifier
-        path: /Audio/Effects/teleport_arrival.ogg
-      event:
-        !type:VampirePolymorphEvent
-        definitionName: PolymorphBat
-      useDelay: 30
+  - type: Action
+    checkCanInteract: false
+    priority: 2
+    itemIconStyle: NoItem
+    icon: { sprite: Interface/Actions/actions_vampire.rsi, state: batform }
+    sound: !type:SoundPathSpecifier { path: /Audio/Effects/teleport_arrival.ogg }
+    useDelay: 30
+  - type: InstantAction
+    event: !type:VampirePolymorphEvent { definitionName: PolymorphBat }
 
 - type: entity
   id: ActionVampireMouseform
@@ -149,19 +125,15 @@
   description: "Assume for form of a mouse. Fast, Small, Immune to doors. Activation Cost: 20 Essence. Cooldown: 30 Seconds"
   categories: [ HideSpawnMenu ]
   components:
-    - type: InstantAction
-      checkCanInteract: false
-      priority: 2
-      itemIconStyle: NoItem
-      icon:
-        sprite: Interface/Actions/actions_vampire.rsi
-        state: mouseform
-      sound: !type:SoundPathSpecifier
-        path: /Audio/Effects/teleport_arrival.ogg
-      event:
-        !type:VampirePolymorphEvent
-        definitionName: PolymorphMouse
-      useDelay: 30
+  - type: Action
+    checkCanInteract: false
+    priority: 2
+    itemIconStyle: NoItem
+    icon: { sprite: Interface/Actions/actions_vampire.rsi, state: mouseform }
+    sound: !type:SoundPathSpecifier { path: /Audio/Effects/teleport_arrival.ogg }
+    useDelay: 30
+  - type: InstantAction
+    event: !type:VampirePolymorphEvent { definitionName: PolymorphMouse }
 
 - type: entity
   id: ActionVampireCloakOfDarkness
@@ -169,17 +141,14 @@
   description: "Cloak yourself from mortal eyes, rendering you invisible while stationary. Activation Cost: 30 Essence. Upkeep: 1 Essence/Second Cooldown: 10 Seconds"
   categories: [ HideSpawnMenu ]
   components:
-    - type: InstantAction
-      checkCanInteract: false
-      priority: 2
-      itemIconStyle: NoItem
-      icon:
-        sprite: Interface/Actions/actions_vampire.rsi
-        state: cloakofdarkness
-      event:
-        !type:VampireCloakOfDarknessEvent
-        definitionName: CloakOfDarkness
-      useDelay: 10
+  - type: Action
+    checkCanInteract: false
+    priority: 2
+    itemIconStyle: NoItem
+    icon: { sprite: Interface/Actions/actions_vampire.rsi, state: cloakofdarkness }
+    useDelay: 10
+  - type: InstantAction
+    event: !type:VampireCloakOfDarknessEvent { definitionName: CloakOfDarkness }
 
 - type: entity
   id: ActionVampireUnholyStrength
@@ -187,14 +156,11 @@
   description: "Infuse your muscles with unholy power, granting enhanced strength and claws. Activation Cost: 20 Essence. Cooldown: 60 Seconds"
   categories: [ HideSpawnMenu ]
   components:
-    - type: InstantAction
-      checkCanInteract: false
-      priority: 2
-      itemIconStyle: NoItem
-      icon:
-        sprite: Interface/Actions/actions_vampire.rsi
-        state: unholystrength
-      event:
-        !type:VampireUnholyStrengthEvent
-        definitionName: UnholyStrength
-      useDelay: 60
+  - type: Action
+    checkCanInteract: false
+    priority: 2
+    itemIconStyle: NoItem
+    icon: { sprite: Interface/Actions/actions_vampire.rsi, state: unholystrength }
+    useDelay: 60
+  - type: InstantAction
+    event: !type:VampireUnholyStrengthEvent { definitionName: UnholyStrength }

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -124,6 +124,7 @@
 # SPDX-FileCopyrightText: 2024 Арт <123451459+JustArt1m@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 # SPDX-FileCopyrightText: 2025 Luna "YuNii" Henrich <yuniivrc+github@proton.me>

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -366,10 +366,11 @@
   description: View all of the character records
   categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     icon: { sprite: Structures/Machines/parts.rsi, state: box_0 }
     iconOn: Structures/Machines/parts.rsi/box_2.png
     keywords: [ "AI", "console", "interface" ]
     priority: -10
+  - type: InstantAction
     event: !type:ToggleIntrinsicUIEvent { key: enum.CharacterRecordConsoleKey.Key }
 # Edn CD - Character Records

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -69,7 +69,6 @@
 # SPDX-FileCopyrightText: 2024 Mr. 27 <45323883+Dutch-VanDerLinde@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 MureixloI <132683811+MureixloI@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 NakataRin <45946146+NakataRin@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 OrangeMoronage9622 <whyteterry0092@gmail.com>
 # SPDX-FileCopyrightText: 2024 PJBot <pieterjan.briers+bot@gmail.com>
 # SPDX-FileCopyrightText: 2024 Partmedia <kevinz5000@gmail.com>
@@ -99,7 +98,6 @@
 # SPDX-FileCopyrightText: 2024 WarMechanic <69510347+WarMechanic@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 beck-thompson <107373427+beck-thompson@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 deathride58 <deathride58@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 deltanedas <@deltanedas:kde.org>
 # SPDX-FileCopyrightText: 2024 dffdff2423 <dffdff2423@gmail.com>
 # SPDX-FileCopyrightText: 2024 eoineoineoin <github@eoinrul.es>
@@ -127,15 +125,22 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 # SPDX-FileCopyrightText: 2025 Luna "YuNii" Henrich <yuniivrc+github@proton.me>
 # SPDX-FileCopyrightText: 2025 Myra <vasilis@pikachu.systems>
+# SPDX-FileCopyrightText: 2025 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Princess Cheeseballs <66055347+Pronana@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Rouden <149893554+Roudenn@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ScarKy0 <106310278+ScarKy0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ScarKy0 <scarky0@onet.eu>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 Spatison <137375981+Spatison@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 chromiumboy <50505512+chromiumboy@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 lzk <124214523+lzk228@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 qrwas <aleksandr.vernigora93@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/Recipes/Construction/Graphs/clothing/armor.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/clothing/armor.yml
@@ -72,16 +72,12 @@
     - to: armor
       steps:
       - tag: MetalHydrogenArmor
-        name: metal hydrogen armor
-        icon:
-          sprite: Clothing/OuterClothing/Armor/metal_hydrogen_armor.rsi
-          state: icon
+        name: ent-ClothingOuterArmorMetalHydrogen
+        icon: { sprite: Clothing/OuterClothing/Armor/metal_hydrogen_armor.rsi, state: icon }
         doAfter: 1
       - tag: AtmosFireSuit
-        name: atmos fire suit
-        icon:
-          sprite: Clothing/OuterClothing/Suits/atmos_firesuit.rsi
-          state: icon
+        name: ent-ClothingOuterSuitAtmosFire
+        icon: { sprite: Clothing/OuterClothing/Suits/atmos_firesuit.rsi, state: icon }
         doAfter: 15
       - material: Cable
         amount: 2

--- a/Resources/Prototypes/Recipes/Construction/Graphs/clothing/armor.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/clothing/armor.yml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2023 Tunguso4ka <71643624+Tunguso4ka@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <41803390+Kyoth25f@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>
 #

--- a/Resources/Prototypes/Recipes/Construction/clothing.yml
+++ b/Resources/Prototypes/Recipes/Construction/clothing.yml
@@ -122,8 +122,6 @@
   targetNode: helmet
   category: construction-category-clothing
   objectType: Item
-  description: Advanced security gear. Protects the station from ne'er-do-wells.
-  icon: { sprite: Clothing/Head/Helmets/justice.rsi, state: icon }
 
 # Assmos - Metal Hydrogen
 - type: construction
@@ -132,8 +130,6 @@
   startNode: start
   targetNode: armor
   category: construction-category-clothing
-  description: A superb armor made with the toughest and rarest materials available to man.
-  icon: { sprite: Clothing/OuterClothing/Armor/metal_hydrogen_armor.rsi, state: icon }
   objectType: Item
 
 - type: construction
@@ -142,8 +138,6 @@
   startNode: start
   targetNode: helmet
   category: construction-category-clothing
-  description: A superb helmet made with the toughest and rarest materials available to man.
-  icon: { sprite: Clothing/Head/Helmets/metal_hydrogen_helmet.rsi, state: icon }
   objectType: Item
 
 - type: construction
@@ -152,6 +146,4 @@
   startNode: start
   targetNode: armor
   category: construction-category-clothing
-  description: An atmos fire suit bolstered by the defensive power of metal hydrogen using techniques passed down through generations of atmospheric technicians.
-  icon: { sprite: Clothing/OuterClothing/Armor/atmosian_armor.rsi, state: icon }
   objectType: Item

--- a/Resources/Prototypes/Recipes/Construction/clothing.yml
+++ b/Resources/Prototypes/Recipes/Construction/clothing.yml
@@ -13,6 +13,7 @@
 # SPDX-FileCopyrightText: 2025 ArtisticRoomba <145879011+ArtisticRoomba@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Ertanic <36124833+Ertanic@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <41803390+Kyoth25f@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 # SPDX-FileCopyrightText: 2025 Momo <Rsnesrud@gmail.com>
 # SPDX-FileCopyrightText: 2025 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -700,14 +700,6 @@
   category: construction-category-utilities
   placementMode: SnapgridCenter
   canBuildInImpassable: false
-  icon:
-    sprite: Structures/Piping/Atmospherics/pump.rsi
-    state: pumpHeat
-  layers:
-  - sprite: Structures/Piping/Atmospherics/pipe.rsi
-    state: pipeStraight
-  - sprite: Structures/Piping/Atmospherics/pump.rsi
-    state: pumpHeat
   conditions:
     - !type:NoUnstackableInTile
 

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -47,6 +47,7 @@
 # SPDX-FileCopyrightText: 2025 Ertanic <36124833+Ertanic@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 K-Dynamic <20566341+K-Dynamic@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <41803390+Kyoth25f@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 # SPDX-FileCopyrightText: 2025 Perry Fraser <perryprog@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>

--- a/Resources/Prototypes/Recipes/Construction/weapons.yml
+++ b/Resources/Prototypes/Recipes/Construction/weapons.yml
@@ -32,6 +32,7 @@
 # SPDX-FileCopyrightText: 2025 Ertanic <36124833+Ertanic@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <41803390+Kyoth25f@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>

--- a/Resources/Prototypes/Recipes/Construction/weapons.yml
+++ b/Resources/Prototypes/Recipes/Construction/weapons.yml
@@ -216,6 +216,4 @@
   startNode: start
   targetNode: icon
   category: construction-category-weapons
-  description: A lightweight crowbar with an extreme sharp fire axe head attached. It trades its heft as a weapon by making it easier to carry around when holstered to suits without having to sacrifice your backpack.
-  icon: { sprite: Objects/Weapons/Melee/metal_hydrogen_axe.rsi, state: icon }
   objectType: Item

--- a/Resources/Prototypes/_Funkystation/Actions/revs.yml
+++ b/Resources/Prototypes/_Funkystation/Actions/revs.yml
@@ -1,4 +1,6 @@
+# SPDX-FileCopyrightText: 2025 Dreykor <160512778+Dreykor@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 # SPDX-FileCopyrightText: 2025 Skye <57879983+Rainbeon@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Funkystation/Actions/revs.yml
+++ b/Resources/Prototypes/_Funkystation/Actions/revs.yml
@@ -8,12 +8,11 @@
   name: Declare Open Revolt
   description: Declares Open Revolt, allowing all Revolutionaries to see each other's Revolutionary status, at the cost of outing the name of all Head Revolutionaries.
   components:
-  - type: InstantAction
+  - type: Action
     itemIconStyle: NoItem
     checkCanInteract: false
-    icon:
-      sprite: /Textures/Interface/Misc/job_icons.rsi
-      state: HeadRevolutionary
-    event: !type:DeclareOpenRevoltEvent
+    icon: { sprite: /Textures/Interface/Misc/job_icons.rsi, state: HeadRevolutionary }
     startDelay: true
     useDelay: 600
+  - type: InstantAction
+    event: !type:DeclareOpenRevoltEvent {}

--- a/Resources/Prototypes/_Funkystation/BloodCult/Actions/spells.yml
+++ b/Resources/Prototypes/_Funkystation/BloodCult/Actions/spells.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Dreykor <160512778+Dreykor@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Funkystation/BloodCult/Actions/spells.yml
+++ b/Resources/Prototypes/_Funkystation/BloodCult/Actions/spells.yml
@@ -5,12 +5,11 @@
   description: Examine the state of the veil, and the strength of your cult.
   categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     checkCanInteract: false
     itemIconStyle: NoItem
-    icon:
-      sprite: _Funkystation/BloodCult/spells_cultist.rsi
-      state: study_veil
+    icon: { sprite: _Funkystation/BloodCult/spells_cultist.rsi, state: study_veil }
+  - type: InstantAction
     event: !type:EventCultistStudyVeil {}
   - type: Sprite
     sprite: _Funkystation/BloodCult/spells_cultist.rsi
@@ -28,12 +27,11 @@
   description: Send a message to your fellow cultists. Beware - the uninitiated can see you whispering the incantation.
   categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     checkCanInteract: false
     itemIconStyle: NoItem
-    icon:
-      sprite: _Funkystation/BloodCult/spells_cultist.rsi
-      state: commune
+    icon: { sprite: _Funkystation/BloodCult/spells_cultist.rsi, state: commune }
+  - type: InstantAction
     event: !type:BloodCultCommuneEvent {}
   - type: Sprite
     sprite: _Funkystation/BloodCult/spells_cultist.rsi
@@ -51,12 +49,11 @@
   description: Prepare a blood spell by carving it into your body. Up to 1 spell may be prepared without standing on an empowering rune.
   categories: [ HideSpawnMenu ]
   components:
-  - type: InstantAction
+  - type: Action
     checkCanInteract: false
     itemIconStyle: NoItem
-    icon:
-      sprite: _Funkystation/BloodCult/spells_cultist.rsi
-      state: spell_select
+    icon: { sprite: _Funkystation/BloodCult/spells_cultist.rsi, state: spell_select }
+  - type: InstantAction
     event: !type:BloodCultSpellsEvent {}
   - type: Sprite
     sprite: _Funkystation/BloodCult/spells_cultist.rsi
@@ -74,18 +71,17 @@
   description: Summon your ritual dagger.
   categories: [ HideSpawnMenu ]
   components:
+  - type: Action
+    itemIconStyle: NoItem
+    icon: { sprite: _Funkystation/BloodCult/spells_cultist.rsi, state: summon_dagger }
+  - type: InstantAction
+    event: !type:EventCultistSummonDagger {}
   - type: Icon
     sprite: _Funkystation/BloodCult/spells_cultist.rsi
     state: summon_dagger
   - type: Sprite
     sprite: _Funkystation/BloodCult/spells_cultist.rsi
     state: summon_dagger
-  - type: InstantAction
-    itemIconStyle: NoItem
-    icon:
-      sprite: _Funkystation/BloodCult/spells_cultist.rsi
-      state: summon_dagger
-    event: !type:EventCultistSummonDagger {}
   - type: CultistSpell
     abilityId: SummonDagger
     charges: 1
@@ -99,32 +95,24 @@
   description: A potent spell that will knock down, silence, and mark a target. Stabbing marked targets with your cult dagger will stun and re-silence them. EMPs Cyborgs.
   categories: [ HideSpawnMenu ]
   components:
+  - type: Action
+    itemIconStyle: NoItem
+    icon: { sprite: _Funkystation/BloodCult/spells_cultist.rsi, state: stun }
+    iconOn: { sprite: _Funkystation/BloodCult/spells_cultist.rsi, state: stun_selected }
+  - type: TargetAction
+    interactOnMiss: false
+  - type: EntityTargetAction
+    whitelist:
+      components:
+      - Body
+    canTargetSelf: false
+    event: !type:EventCultistStun {}
   - type: Icon
     sprite: _Funkystation/BloodCult/spells_cultist.rsi
     state: stun
   - type: Sprite
     sprite: _Funkystation/BloodCult/spells_cultist.rsi
     state: stun
-  - type: EntityTargetAction
-    whitelist:
-      components:
-      - Body
-    canTargetSelf: False
-    interactOnMiss: False
-    itemIconStyle: NoItem
-    icon:
-      sprite: _Funkystation/BloodCult/spells_cultist.rsi
-      state: stun
-    iconOn:
-      sprite: _Funkystation/BloodCult/spells_cultist.rsi
-      state: stun_selected
-    event: !type:EventCultistStun {}
-    #useDelay: 60  TIME DELAY BETWEEN ACTION USES
-    #deselectOnMiss: False
-    #targetingIndicator: True  # apparently defaults to using what is held in hand?
-    #entityIcon: <an "EntityUid?">  # overrides the icon
-    #sound: a SoundSpecifier. Should probably be used instead of castSound down below.
-    #iconOn:  # The sprite when selected. USE THIS.
   - type: CultistSpell
     abilityId: CultStun
     charges: 1
@@ -141,32 +129,24 @@
   description: A sinister spell used to convert plasteel into runed metal. # and airlocks into cult airlocks.
   categories: [ HideSpawnMenu ]
   components:
+  - type: Action
+    itemIconStyle: NoItem
+    icon: { sprite: _Funkystation/BloodCult/spells_cultist.rsi, state: twisted_construction }
+    iconOn: { sprite: _Funkystation/BloodCult/spells_cultist.rsi, state: twisted_construction }
+  - type: TargetAction
+    interactOnMiss: False
+  - type: EntityTargetAction
+    whitelist:
+      components:
+      - Stack
+    canTargetSelf: False
+    event: !type:EventCultistTwistedConstruction {}
   - type: Icon
     sprite: _Funkystation/BloodCult/spells_cultist.rsi
     state: twisted_construction
   - type: Sprite
     sprite: _Funkystation/BloodCult/spells_cultist.rsi
     state: twisted_construction
-  - type: EntityTargetAction
-    whitelist:
-      components:
-      - Stack
-    canTargetSelf: False
-    interactOnMiss: False
-    itemIconStyle: NoItem
-    icon:
-      sprite: _Funkystation/BloodCult/spells_cultist.rsi
-      state: twisted_construction
-    iconOn:
-      sprite: _Funkystation/BloodCult/spells_cultist.rsi
-      state: twisted_construction
-    event: !type:EventCultistTwistedConstruction {}
-    #useDelay: 60  TIME DELAY BETWEEN ACTION USES
-    #deselectOnMiss: False
-    #targetingIndicator: True  # apparently defaults to using what is held in hand?
-    #entityIcon: <an "EntityUid?">  # overrides the icon
-    #sound: a SoundSpecifier. Should probably be used instead of castSound down below.
-    #iconOn:  # The sprite when selected. USE THIS.
   - type: CultistSpell
     abilityId: CultTwistedConstruction
     charges: 1

--- a/Resources/Prototypes/_Funkystation/BloodCult/Actions/spells.yml
+++ b/Resources/Prototypes/_Funkystation/BloodCult/Actions/spells.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2025 Dreykor <160512778+Dreykor@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # actions
 - type: entity
   id: ActionCultistStudyVeil

--- a/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/alternate.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/alternate.yml
@@ -43,12 +43,6 @@
     - Xeno
   - type: Hands
   - type: ComplexInteraction
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/Xenos/burrower.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: running
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/alternate.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Mobs/NPCs/alternate.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2024 P e p e . <josephpereira413@gmail.com>
 # SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <41803390+Kyoth25f@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Harmony/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Harmony/Loadouts/role_loadouts.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 # SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 White <68350815+DoutorWhite@users.noreply.github.com>

--- a/Resources/Prototypes/_Harmony/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Harmony/Loadouts/role_loadouts.yml
@@ -3,7 +3,7 @@
   id: JobPermaPrisoner
   groups:
   - PermaPrisonerJumpsuit
-  - CommonBackpack
+  - CivilianBackpack
   - GroupTankHarness
   - Survival
   - Trinkets

--- a/Resources/Prototypes/_Harmony/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Harmony/Loadouts/role_loadouts.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
+# SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 White <68350815+DoutorWhite@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # Security
 - type: roleLoadout
   id: JobPermaPrisoner


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR
Os `StatusEffect`s e `Action`s foram reformulados. Esse PR atualiza os prototypes das actions e arruma umas receitas. De quebra o blood cult voltou a funcionar. Os vampiros não sei como funciona e acho que não está funcionando corretamente.

## Changelog

**Changelog**
:cl:
- fix: Corrigido culto de sangue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Standardized action UI and icons for Vampire, Blood Cult, and “Declare Open Revolt” abilities, with clearer toggles and targeting.

- Gameplay
  - Removed multiple clothing/weapon construction recipes (e.g., clown/mime hardsuits, bone armor/helmet, various HUD/glasses, slippers, quiver, metal-hydrogen gear, Atmosian armor).
  - Perma Prisoner loadout now uses a civilian backpack.

- UI/Visual
  - Improved construction entries’ labels/icons for Atmosian/metal-hydrogen armor steps.
  - Adjusted Heat Exchanger construction entry visuals.
  - Tweaked Admin Ghost Character Records action behavior (separate toggle).
  - Updated xenonid burrower visuals.

- Chores
  - License and header updates across several files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->