### PR TITLE
Adicionado buscas sem considerar acentuação no menu de construção

### DIFF
--- a/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
+++ b/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
@@ -27,6 +27,7 @@
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Ertanic <36124833+Ertanic@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 João Fernandez <joaorbfernandez@gmail.com>
 // SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 // SPDX-FileCopyrightText: 2025 YotaXP <yotaxp@gmail.com>
 // SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>

--- a/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
+++ b/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
@@ -26,6 +26,7 @@
 // SPDX-FileCopyrightText: 2024 plykiya <plykiya@protonmail.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Ertanic <36124833+Ertanic@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 João Fernandez <joaorbfernandez@gmail.com>
 // SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>

--- a/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
+++ b/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
@@ -40,6 +40,7 @@ using System.Numerics;
 using Content.Client.Lobby;
 using Content.Client.Stylesheets;
 using Content.Client.UserInterface.Systems.MenuBar.Widgets;
+using Content.Shared._Gabystation.Text; // Gabystation
 using Content.Shared.Construction.Prototypes;
 using Content.Shared.Whitelist;
 using Robust.Client.GameObjects;
@@ -297,6 +298,8 @@ namespace Content.Client.Construction.UI
             var isEmptyCategory = string.IsNullOrEmpty(category) || category == ForAllCategoryName;
             _selectedCategory = isEmptyCategory ? string.Empty : category;
 
+            search = TextHelpers.RemoveAccents(search); // Gabystation
+
             foreach (var recipe in _prototypeManager.EnumeratePrototypes<ConstructionPrototype>())
             {
                 if (recipe.Hide)
@@ -308,7 +311,7 @@ namespace Content.Client.Construction.UI
                     continue;
 
                 if (!string.IsNullOrEmpty(search) && (recipe.Name is { } name &&
-                                                      !name.Contains(search.Trim(),
+                                                      !TextHelpers.RemoveAccents(name).Contains(search.Trim(), // Gabystation
                                                           StringComparison.InvariantCultureIgnoreCase)))
                     continue;
 

--- a/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
+++ b/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
@@ -292,6 +292,11 @@ namespace Content.Client.Construction.UI
             }
         }
 
+        /// <summary>
+        /// Builds a list of construction recipes that match the provided search text and category, and returns them sorted by prototype name.
+        /// </summary>
+        /// <param name="args">A tuple where Item1 is the search text and Item2 is the selected category (empty or the "all" category selects all recipes).</param>
+        /// <returns>A list of ConstructionMenu.ConstructionMenuListData for recipes that are visible to the local player, match the search and category (favorites honored), and have a resolvable target prototype, sorted by prototype name.</returns>
         private List<ConstructionMenu.ConstructionMenuListData> GetAndSortRecipes((string, string) args)
         {
             var recipes = new List<ConstructionMenu.ConstructionMenuListData>();
@@ -669,6 +674,10 @@ namespace Content.Client.Construction.UI
             UpdateGhostPlacement();
         }
 
+        /// <summary>
+        /// Refreshes the currently selected recipe's information when a construction guide becomes available.
+        /// </summary>
+        /// <param name="e">The prototype ID of the construction whose guide became available.</param>
         private void SystemGuideAvailable(object? sender, string e)
         {
             if (!CraftingAvailable)


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## Sobre a PR
Faltou colocar o filtro de buscar sem considerar acentuação no menu de construção.

## Anexos
![Large GIF (432x344)](https://github.com/user-attachments/assets/2522b11b-280b-4c22-94f8-2d4df2900ccc)

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione uma entrada para changelog do servidor, bote o emoji :cl: e siga com as mudanças assim como o exemplo.
:cl: em branco fara com que seu nome na changelog apareça como do github, adicione um nome depois do emoji para mudar seu nome na changelog. -->
:cl:
- add: Buscas sem considerar acentuação no menu de construção
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
