### PR TITLE
Tweaks de energia e digitais de ipc

### DIFF
--- a/Content.Server/_EinsteinEngines/Silicon/Charge/Systems/SiliconChargeSystem.cs
+++ b/Content.Server/_EinsteinEngines/Silicon/Charge/Systems/SiliconChargeSystem.cs
@@ -25,8 +25,16 @@ using Content.Server.PowerCell;
 using Robust.Shared.Timing;
 using Robust.Shared.Configuration;
 using Robust.Shared.Utility;
+using Content.Shared.CCVar;
 using Content.Shared.PowerCell.Components;
+using Content.Shared.Mind;
 using Content.Shared.Alert;
+using Content.Server._EinsteinEngines.Silicon.Death;
+using Content.Server._EinsteinEngines.Power.Components;
+// Begin TheDen - IPC Dynamic Power draw
+using Content.Shared.Movement.Components;
+using Robust.Shared.Physics.Components;
+// End TheDen
 
 namespace Content.Server._EinsteinEngines.Silicon.Charge;
 
@@ -195,7 +203,7 @@ public sealed class SiliconChargeSystem : EntitySystem
             if (!_random.Prob(Math.Clamp(temperComp.CurrentTemperature / (upperThresh * 5), 0.001f, 0.9f)))
                 return hotTempMulti;
 
-            // Goobstation: Replaced by KillOnOverheatSystem
+            // GoobStation: Replaced by KillOnOverheatSystem
             //_flammable.AdjustFireStacks(silicon, Math.Clamp(siliconComp.FireStackMultiplier, -10, 10), flamComp);
             //_flammable.Ignite(silicon, silicon, flamComp);
             return hotTempMulti;

--- a/Content.Server/_EinsteinEngines/Silicon/Charge/Systems/SiliconChargeSystem.cs
+++ b/Content.Server/_EinsteinEngines/Silicon/Charge/Systems/SiliconChargeSystem.cs
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
 // SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Kayo Lima <67492897+Kavest0@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>
+// SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 // SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Server/_EinsteinEngines/Silicon/Charge/Systems/SiliconChargeSystem.cs
+++ b/Content.Server/_EinsteinEngines/Silicon/Charge/Systems/SiliconChargeSystem.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
 // SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 // SPDX-FileCopyrightText: 2025 Kayo Lima <67492897+Kavest0@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>
 // SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>

--- a/Content.Server/_EinsteinEngines/Silicon/Charge/Systems/SiliconChargeSystem.cs
+++ b/Content.Server/_EinsteinEngines/Silicon/Charge/Systems/SiliconChargeSystem.cs
@@ -41,6 +41,7 @@ public sealed class SiliconChargeSystem : EntitySystem
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly PowerCellSystem _powerCell = default!;
     [Dependency] private readonly AlertsSystem _alerts = default!;
+    [Dependency] private readonly SharedJetpackSystem _jetpack = default!; // TheDen - IPC Dynamic Power draw
     public override void Initialize()
     {
         base.Initialize();
@@ -89,7 +90,7 @@ public sealed class SiliconChargeSystem : EntitySystem
             // Check if the Silicon is an NPC, and if so, follow the delay as specified in the CVAR.
             if (siliconComp.EntityType.Equals(SiliconType.Npc))
             {
-                var updateTime = _config.GetCVar(GoobCVars.SiliconNpcUpdateTime);
+                var updateTime = _config.GetCVar(CCVars.SiliconNpcUpdateTime);
                 if (_timing.CurTime - siliconComp.LastDrainTime < TimeSpan.FromSeconds(updateTime))
                     continue;
 
@@ -123,7 +124,10 @@ public sealed class SiliconChargeSystem : EntitySystem
             // Maybe use something similar to refreshmovespeedmodifiers, where it's stored in the component.
             // Maybe it doesn't matter, and stuff should just use static drain?
             if (!siliconComp.EntityType.Equals(SiliconType.Npc)) // Don't bother checking heat if it's an NPC. It's a waste of time, and it'd be delayed due to the update time.
+            {
                 drainRateFinalAddi += SiliconHeatEffects(silicon, siliconComp, frameTime) - 1; // This will need to be changed at some point if we allow external batteries, since the heat of the Silicon might not be applicable.
+                drainRateFinalAddi += SiliconMovementEffects(silicon, siliconComp); // TheDen - IPC Dynamic Power draw // Removes between 90% and 0% of the total power draw.
+            }
 
             // Ensures that the drain rate is at least 10% of normal,
             // and would allow at least 4 minutes of life with a max charge, to prevent cheese.
@@ -202,5 +206,26 @@ public sealed class SiliconChargeSystem : EntitySystem
             return 0.5f + temperComp.CurrentTemperature / thermalComp.NormalBodyTemperature * 0.5f;
 
         return 0;
+    }
+
+    // TheDen - IPC Dynamic Power draw
+    private float SiliconMovementEffects(EntityUid silicon, SiliconComponent siliconComp)
+    {
+        // Calculate dynamic power draw.
+        if (!TryComp(silicon, out MovementSpeedModifierComponent? movement) ||
+            !TryComp(silicon, out PhysicsComponent? physics) ||
+            !TryComp(silicon, out InputMoverComponent? input))
+            return 0;
+
+        if (input.HeldMoveButtons == MoveButtons.None || _jetpack.IsUserFlying(silicon)) // If nothing is being held or jet packing
+        {
+            return siliconComp.DrainPerSecond * siliconComp.IdleDrainReduction * (-1); // Reduces draw by idle drain reduction
+        }
+
+        // LinearVelocity is relative to the parent
+        return Math.Clamp(
+            siliconComp.DrainPerSecond * ((physics.LinearVelocity.Length() / movement.CurrentSprintSpeed) - 1), // Power draw changes as a negative percentage of the movement
+            siliconComp.DrainPerSecond * siliconComp.IdleDrainReduction * (-1), // Should be a maximum of the idle drain reduction (negative)
+            0f); // Minimum reduction is no change to power draw
     }
 }

--- a/Content.Server/_EinsteinEngines/Silicon/Charge/Systems/SiliconChargeSystem.cs
+++ b/Content.Server/_EinsteinEngines/Silicon/Charge/Systems/SiliconChargeSystem.cs
@@ -90,7 +90,7 @@ public sealed class SiliconChargeSystem : EntitySystem
             // Check if the Silicon is an NPC, and if so, follow the delay as specified in the CVAR.
             if (siliconComp.EntityType.Equals(SiliconType.Npc))
             {
-                var updateTime = _config.GetCVar(CCVars.SiliconNpcUpdateTime);
+                var updateTime = _config.GetCVar(GoobCVars.SiliconNpcUpdateTime);
                 if (_timing.CurTime - siliconComp.LastDrainTime < TimeSpan.FromSeconds(updateTime))
                     continue;
 

--- a/Content.Shared/_EinsteinEngines/Silicon/Components/SiliconComponent.cs
+++ b/Content.Shared/_EinsteinEngines/Silicon/Components/SiliconComponent.cs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 // SPDX-FileCopyrightText: 2025 Kayo Lima <67492897+Kavest0@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 //

--- a/Content.Shared/_EinsteinEngines/Silicon/Components/SiliconComponent.cs
+++ b/Content.Shared/_EinsteinEngines/Silicon/Components/SiliconComponent.cs
@@ -74,6 +74,17 @@ public sealed partial class SiliconComponent : Component
     [DataField]
     public float DrainPerSecond = 50f;
 
+    // TheDen - Dynamic IPC Power Draw
+    /// <summary>
+    ///     How much less power is used while being idle.
+    /// </summary>
+    /// <remarks>
+    ///     Relative to the DrainPerSecond.
+    ///     0 is no reduction. 1 is 100% reduction. 0.5 is 50% reduction.
+    ///     Currently, 90% reduction is as high as we can go without changing code in C#
+    /// </remarks>
+    [DataField]
+    public float IdleDrainReduction = 0.6f;
 
     /// <summary>
     ///     The percentages at which the silicon will enter each state.

--- a/Content.Shared/_EinsteinEngines/Silicon/Components/SiliconComponent.cs
+++ b/Content.Shared/_EinsteinEngines/Silicon/Components/SiliconComponent.cs
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Kayo Lima <67492897+Kavest0@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
@@ -6,6 +6,7 @@
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
@@ -136,6 +136,7 @@
     entityType: enum.SiliconType.Player
     batteryPowered: true
     drainPerSecond: 1.5
+    idleDrainReduction: 0.6 # TheDen - 60% less power usage while idling, for IPC Dynamic Power Draw
     chargeThresholdMid: 0.80
     chargeThresholdLow: 0.35
     chargeThresholdCritical: 0.10
@@ -165,6 +166,7 @@
   - type: WeldingHealable
   - type: DamagedSiliconAccent
   - type: Uncloneable
+  - type: Fingerprint
   - type: Sprinter # Goob Change: slight nerf to speed because heavy robot, mass contest when
     sprintSpeedMultiplier: 1.2
   - type: Tag

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
@@ -11,6 +11,8 @@
 # SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 # SPDX-FileCopyrightText: 2025 John Willis <143434770+CerberusWolfie@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 JohnOakman <sremy2012@hotmail.fr>
+# SPDX-FileCopyrightText: 2025 Kayo Lima <67492897+Kavest0@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Kyoth25f <41803390+Kyoth25f@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 LuciferMkshelter <154002422+LuciferEOS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 PJB3005 <pieterjan.briers+git@gmail.com>
 # SPDX-FileCopyrightText: 2025 Rouden <149893554+Roudenn@users.noreply.github.com>


### PR DESCRIPTION
## Sobre a PR
Esta PR realiza duas mudanças nos IPCs:
- Reduz o consumo de energia enquanto estão parados.
- Permite que deixem impressões digitais.

## Por quê? / Balanceamento
Porte da PR [#453](https://github.com/funky-station/funky-station/pull/453) do funky e da PR [#3917](https://github.com/DeltaV-Station/Delta-v/pull/3917) do Delta-V

## Detalhes Técnicos
- Adicionado um modificador de consumo de energia que varia conforme a velocidade de movimento e se há entrada de comandos.
- Adicionado componente de impressões digitais aos ipcs.

**Changelog**
🆑 
- tweak: IPCs agora consomem menos energia quando parados.
- tweak: IPCs agora deixam impressões digitais.