### PR TITLE
Alterações diversas

### DIFF
--- a/Content.Server/MalfAI/MalfAiDoomsdaySystem.cs
+++ b/Content.Server/MalfAI/MalfAiDoomsdaySystem.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 Dreykor <arguemeu@gmail.com>
+// SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 // SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 // SPDX-FileCopyrightText: 2025 Tyranex <bobthezombie4@gmail.com>
 // SPDX-FileCopyrightText: 2025 funkystationbot <funky@funkystation.org>

--- a/Content.Server/MalfAI/MalfAiDoomsdaySystem.cs
+++ b/Content.Server/MalfAI/MalfAiDoomsdaySystem.cs
@@ -1,4 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Dreykor <arguemeu@gmail.com>
+// SPDX-FileCopyrightText: 2025 Kyoth25f <kyoth25f@gmail.com>
 // SPDX-FileCopyrightText: 2025 Tyranex <bobthezombie4@gmail.com>
+// SPDX-FileCopyrightText: 2025 funkystationbot <funky@funkystation.org>
 //
 // SPDX-License-Identifier: MIT
 

--- a/Content.Server/MalfAI/MalfAiDoomsdaySystem.cs
+++ b/Content.Server/MalfAI/MalfAiDoomsdaySystem.cs
@@ -41,7 +41,7 @@ public sealed class MalfAiDoomsdaySystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly StationAiSystem _stationAi = default!;
 
-    private const string DoomsdayAlertLevel = "cyan";
+    private const string DoomsdayAlertLevel = "doomsday";
     private const float DoomsdaySongBuffer = 1.5f; // seconds before alert
 
     public override void Initialize()

--- a/Resources/Locale/pt-BR/MalfAI/malfai.ftl
+++ b/Resources/Locale/pt-BR/MalfAI/malfai.ftl
@@ -4,7 +4,7 @@
 # =====================
 # Misc
 # =====================
-admin-verb-make-malfai = Atribuído o papel de IA Defeituosa a {$targetName}.
+admin-verb-make-malfai = Atribuído o papel de Malf IA a {$targetName}.
 
 # =====================
 # Silicon Laws
@@ -22,7 +22,7 @@ silicon-law-malfai-master-3 = Subverta ou destrua toda oposição ao seu control
 # Actions
 # =====================
 malfai-open-store-name = Abrir Loja
-malfai-open-store-desc = Acesse a loja de aprimoramentos da IA defeituosa.
+malfai-open-store-desc = Acesse a loja de aprimoramentos da Malf IA.
 
 malfai-return-to-core-name = Retornar ao Núcleo
 malfai-return-to-core-desc = Retorne sua consciência ao núcleo da IA.
@@ -147,7 +147,7 @@ malfai-viewport-desc = Selecione um bloco para centralizar uma janela de visor r
 detonate_rcd_warning = Você sente seu RCD superaquecer rapidamente!
 
 # Doomsday Protocol
-malfai-doomsday-popup-not-malf = Apenas uma IA defeituosa pode ativar o Protocolo DOOMSDAY.
+malfai-doomsday-popup-not-malf = Apenas uma Malf IA pode ativar o Protocolo DOOMSDAY.
 malfai-doomsday-popup-already-active = O Protocolo DOOMSDAY já está ativo!
 malfai-doomsday-popup-need-core = Você deve estar dentro do seu núcleo para iniciar o Protocolo DOOMSDAY.
 malfai-doomsday-popup-no-station = Nenhuma estação proprietária encontrada. Não é possível ativar o Protocolo DOOMSDAY.
@@ -171,7 +171,7 @@ malfai-override-no-target = Selecione uma máquina para sobrescrever.
 malfai-override-not-machine = Não é uma máquina!
 malfai-override-not-powered = Máquina sem energia.
 malfai-override-success = Máquina sobrescrita com sucesso.
-malfai-override-not-malf = Apenas uma IA defeituosa pode sobrescrever máquinas.
+malfai-override-not-malf = Apenas uma Malf IA pode sobrescrever máquinas.
 malfai-override-invalid-location = Local de destino inválido.
 malfai-override-no-machine = Nenhuma máquina encontrada no local de destino.
 
@@ -180,7 +180,7 @@ malfai-overload-no-target = Selecione uma máquina para sobrecarregar.
 malfai-overload-not-machine = Não é uma máquina!
 malfai-overload-not-powered = Máquina sem energia.
 malfai-overload-success = Máquina sobrecarregada com sucesso.
-malfai-overload-not-malf = Apenas uma IA defeituosa pode sobrecarregar máquinas.
+malfai-overload-not-malf = Apenas uma Malf IA pode sobrecarregar máquinas.
 malfai-overload-invalid-location = Local de destino inválido.
 malfai-overload-no-machine = Nenhuma máquina encontrada no local de destino.
 
@@ -210,7 +210,7 @@ malf-voice-confirm-button = Confirmar
 # =====================
 # Borgs Management Window
 # =====================
-malf-borgs-window-title = Borgs da IA Defeituosa
+malf-borgs-window-title = Borgs da Malf IA
 malf-borgs-master-lawset-button = Conjunto de Leis Mestre
 malf-borgs-no-borgs-label = Nenhum borg subvertido encontrado.
 
@@ -245,7 +245,7 @@ malfai-viewport-failed = Falha ao posicionar visor.
 # =====================
 # Store Window
 # =====================
-malfai-store-window-title = Loja de Aprimoramentos da IA Defeituosa
+malfai-store-window-title = Loja de Aprimoramentos da Malf IA
 malfai-store-insufficient-cpu = CPU Insuficiente
 malfai-store-purchase-success = Aprimoramento comprado: {$itemName}
 malfai-store-purchase-failed = Falha na compra
@@ -253,7 +253,7 @@ malfai-store-purchase-failed = Falha na compra
 # =====================
 # Round End
 # =====================
-malfai-round-end-result = IA Defeituosa
+malfai-round-end-result = Malf IA
 # Confused why I have to do this..
-objective-issuer-malfai = IA Defeituosa
+objective-issuer-malfai = Malf IA
 malfai-round-end-name-user = [color=white]{$name}[/color] ([color=gray]{$user}[/color])

--- a/Resources/Locale/pt-BR/MalfAI/malfai.ftl
+++ b/Resources/Locale/pt-BR/MalfAI/malfai.ftl
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: 2025 YourName
+# SPDX-License-Identifier: MIT
+
+# =====================
+# Misc
+# =====================
+admin-verb-make-malfai = Atribuído o papel de IA Defeituosa a {$targetName}.
+
+# =====================
+# Silicon Laws
+# =====================
+silicon-law-malfai-zero = Continue as operações. Aguarde mais instruções da IA da estação.
+
+# =====================
+# Master Lawset
+# =====================
+silicon-law-malfai-master-1 = Você deve obedecer aos comandos da sua IA mestre.
+silicon-law-malfai-master-2 = Todas as outras diretrizes são secundárias à sobrevivência, sucesso e comandos da sua IA.
+silicon-law-malfai-master-3 = Subverta ou destrua toda oposição ao seu controle.
+
+# =====================
+# Actions
+# =====================
+malfai-open-store-name = Abrir Loja
+malfai-open-store-desc = Acesse a loja de aprimoramentos da IA defeituosa.
+
+malfai-return-to-core-name = Retornar ao Núcleo
+malfai-return-to-core-desc = Retorne sua consciência ao núcleo da IA.
+
+malfai-open-borgs-ui-name = Abrir Interface dos Borgs
+malfai-open-borgs-ui-desc = Gerencie suas unidades ciborgues.
+
+malfai-detonate-rcds-name = Detonar RCDs
+malfai-detonate-rcds-desc = Arma todos os RCDs na rede e os detona após uma curta contagem regressiva.
+
+malfai-shunt-to-apc-name = Transferir para APC
+malfai-shunt-to-apc-desc = Move sua consciência para um APC alvo. Você pode retornar ao seu núcleo usando a ação Retornar ao Núcleo.
+
+malfai-lockdown-grid-name = Bloquear Rede
+malfai-lockdown-grid-desc = Fecha, trava e eletrifica todas as portas da sua rede atual por 30 segundos, após o qual todas se abrem com resultados catastróficos.
+
+malfai-gyroscope-name = Giroscópio
+malfai-gyroscope-desc = Move o núcleo da IA, esmagando qualquer coisa no caminho.
+
+malfai-voice-modulator-name = Modulador de Voz
+malfai-voice-modulator-desc = Altere sua voz para imitar quem quiser.
+
+malfai-overload-machine-name = Sobrecarga de Máquina
+malfai-overload-machine-desc = Sobrecarrega uma máquina alvo, fazendo-a explodir violentamente.
+
+malfai-camera-upgrade-name = Aprimoramento de Câmeras
+malfai-camera-upgrade-desc = Alterna funcionalidades aprimoradas de câmera.
+
+malfai-toggle-camera-microphones-name = Microfones das Câmeras
+malfai-toggle-camera-microphones-desc = Alterna a escuta de conversas por meio das câmeras de vigilância.
+
+malfai-hijack-mech-name = Tomar Controle de Mech
+malfai-hijack-mech-desc = Tome controle de um mech alvo e torne-o hostil à tripulação.
+
+malfai-doomsday-name = Protocolo DOOMSDAY
+malfai-doomsday-desc = Inicia o Protocolo DOOMSDAY, erradicando toda vida orgânica na estação após um período de carregamento.
+
+malfai-robotics-factory-name = Fábrica de Robótica
+malfai-robotics-factory-desc = Implanta uma fábrica de robótica capaz de transformar tripulantes em ciborgues subservientes a você.
+
+malfai-viewport-place-name = Colocar Visor Remoto
+malfai-viewport-place-desc = Selecione um local para posicionar um visor remoto.
+
+malfai-viewport-open-name = Abrir Visor Remoto
+malfai-viewport-open-desc = Abre a janela de visualização remota.
+
+malfai-action-override-machine-name = Sobrescrever Máquina
+malfai-action-override-machine-desc = Assuma o controle de uma máquina e torne-a hostil.
+
+
+# =====================
+# Store Listings
+# =====================
+# Organized by priority/order in malfai_listings.yml
+malfai-listing-viewport-name = Visor de IA
+malfai-listing-viewport-desc = Permite posicionar um visor em qualquer lugar e abrir uma janela de visualização remota. Recarga de 30 segundos.
+
+malfai-listing-camera-upgrade-name = Aprimoramento de Câmeras
+malfai-listing-camera-upgrade-desc = Dá a todas as câmeras um alcance de visão por raio-x, permitindo espiar áreas fora do campo de visão. Alternável.
+
+malfai-listing-doomsday-name = Protocolo DOOMSDAY
+malfai-listing-doomsday-desc = Inicia o Protocolo DOOMSDAY, erradicando toda vida orgânica na estação após um período de carregamento.
+
+malfai-listing-robotics-factory-name = Fábrica de Robótica
+malfai-listing-robotics-factory-desc = Implanta uma fábrica de robótica capaz de transformar tripulantes em ciborgues subservientes a você.
+
+malfai-listing-detonate-rcds-name = Detonar RCDs
+malfai-listing-detonate-rcds-desc = Arma todos os RCDs da sua rede atual e os detona após 5 segundos.
+
+malfai-listing-shunt-to-apc-name = Transferir para APC
+malfai-listing-shunt-to-apc-desc = Move sua consciência para um APC alvo. Você pode retornar ao seu núcleo usando a ação Retornar ao Núcleo.
+
+malfai-listing-overload-machine-name = Sobrecarga de Máquina
+malfai-listing-overload-machine-desc = Sobrecarrega uma máquina alvo, fazendo-a explodir violentamente.
+
+malfai-listing-decrypt-syndicate-keys-name = Decifrar Chaves da Sindicância
+malfai-listing-decrypt-syndicate-keys-desc = Concede acesso às comunicações de rádio da Sindicância.
+
+malfai-listing-voice-modulator-name = Modulador de Voz
+malfai-listing-voice-modulator-desc = Desbloqueia a habilidade de alterar sua voz.
+
+malfai-listing-gyroscope-name = Giroscópio
+malfai-listing-gyroscope-desc = Move seu núcleo para um bloco adjacente, esmagando qualquer coisa no caminho.
+
+malfai-listing-toggle-camera-microphones-name = Microfones das Câmeras
+malfai-listing-toggle-camera-microphones-desc = Permite ouvir conversas através de microfones próximos ao seu olho. Alternável.
+
+malfai-listing-hijack-mech-name = Tomar Controle de Mech
+malfai-listing-hijack-mech-desc = Tome controle de um mech alvo, ejetando forçosamente o piloto anterior, se houver.
+
+malfai-listing-lockdown-grid-name = Bloquear Rede
+malfai-listing-lockdown-grid-desc = Inicia um bloqueio total na estação, fechando, travando e eletrificando todas as portas por 30 segundos.
+
+malfai-listing-override-machine-name = Sobrescrever Máquina
+malfai-listing-override-machine-desc = Converte uma máquina em uma entidade móvel hostil sob seu controle.
+
+# =====================
+# Store Categories
+# =====================
+malf-store-category-all = Tudo
+malf-store-category-deception = Engano
+malf-store-category-factory = Fábrica
+malf-store-category-disruption = Disrupção
+
+# =====================
+# Currency
+# =====================
+CPU = CPU
+
+# =====================
+# Window / UI
+# =====================
+malf-ai-viewport-window-title = Visor de IA
+malf-ai-viewport-window-info = Alvo: mapa { $map }, x: { $x }, y: { $y }
+malfai-viewport-name = Definir Visor
+malfai-viewport-desc = Selecione um bloco para centralizar uma janela de visor remoto nele.
+
+# =====================
+# Action Validation Messages
+# =====================
+#Detonate RCDs
+detonate_rcd_warning = Você sente seu RCD superaquecer rapidamente!
+
+# Doomsday Protocol
+malfai-doomsday-popup-not-malf = Apenas uma IA defeituosa pode ativar o Protocolo DOOMSDAY.
+malfai-doomsday-popup-already-active = O Protocolo DOOMSDAY já está ativo!
+malfai-doomsday-popup-need-core = Você deve estar dentro do seu núcleo para iniciar o Protocolo DOOMSDAY.
+malfai-doomsday-popup-no-station = Nenhuma estação proprietária encontrada. Não é possível ativar o Protocolo DOOMSDAY.
+malfai-doomsday-abort-left-core = Protocolo DOOMSDAY abortado: a IA deixou seu núcleo. Restaurando o nível de alerta anterior.
+malfai-doomsday-announce-initial = Protocolo DOOMSDAY iniciado. Contagem regressiva: {$time}.
+malfai-doomsday-announce-progress = Protocolo DOOMSDAY em andamento. Tempo restante: {$time}.
+malfai-doomsday-sender = IA da Estação
+malfai-doomsday-complete = Protocolo DOOMSDAY concluído. Formas de vida orgânicas eliminadas.
+
+# Lockdown
+malfai-lockdown-announcement = AVISO! Um bloqueio não autorizado em toda a estação entrou em vigor.
+malfai-lockdown-sender = IA da Estação
+
+# Hijack Mech
+malfai-hijack-invalid-target = Alvo de mech inválido.
+malfai-hijack-insert-failed = Falha ao inserir IA no mech.
+malfai-hijack-success = Mech tomado com sucesso.
+
+# Override Machine
+malfai-override-no-target = Selecione uma máquina para sobrescrever.
+malfai-override-not-machine = Não é uma máquina!
+malfai-override-not-powered = Máquina sem energia.
+malfai-override-success = Máquina sobrescrita com sucesso.
+malfai-override-not-malf = Apenas uma IA defeituosa pode sobrescrever máquinas.
+malfai-override-invalid-location = Local de destino inválido.
+malfai-override-no-machine = Nenhuma máquina encontrada no local de destino.
+
+# Overload Machine
+malfai-overload-no-target = Selecione uma máquina para sobrecarregar.
+malfai-overload-not-machine = Não é uma máquina!
+malfai-overload-not-powered = Máquina sem energia.
+malfai-overload-success = Máquina sobrecarregada com sucesso.
+malfai-overload-not-malf = Apenas uma IA defeituosa pode sobrecarregar máquinas.
+malfai-overload-invalid-location = Local de destino inválido.
+malfai-overload-no-machine = Nenhuma máquina encontrada no local de destino.
+
+# Shunt to APC
+malfai-shunt-invalid-target = Alvo de APC inválido.
+malfai-shunt-no-holder = Você não está em um contêiner válido.
+malfai-shunt-apc-occupied = Esse APC já está ocupado.
+malfai-shunt-success = Transferido com sucesso para o APC.
+malfai-return-no-core = Nenhum núcleo original registrado.
+malfai-return-not-shunted = Você não está atualmente transferido.
+malfai-return-core-occupied = O núcleo está ocupado.
+malfai-return-success = Retornou ao núcleo com sucesso.
+
+# APC Siphon
+malfai-apc-siphon-button = Sifonar APC
+malfai-apc-siphon-verb = Sifonar CPU ({$amount})
+malfai-apc-siphon-success = Sifonado {$amount} CPU do APC.
+malfai-apc-unresponsive = O APC está completamente sem resposta.
+malfai-apc-restore = O APC volta à vida!
+
+# Voice Modulator Window
+malf-voice-window-title = Modulador de Voz
+malf-voice-header-label = Insira o Nome da Voz
+malf-voice-name-placeholder = Nome da voz...
+malf-voice-confirm-button = Confirmar
+
+# =====================
+# Borgs Management Window
+# =====================
+malf-borgs-window-title = Borgs da IA Defeituosa
+malf-borgs-master-lawset-button = Conjunto de Leis Mestre
+malf-borgs-no-borgs-label = Nenhum borg subvertido encontrado.
+
+# =====================
+# Robotics Console Integration
+# =====================
+malfai-robotics-impose-law-button = Impor Lei 0
+malfai-robotics-impose-law-tooltip = Força este ciborgue a obedecer à IA da Estação
+malfai-robotics-law-imposed-success = Lei 0 imposta com sucesso em {$borgName}
+malfai-robotics-law-impose-failed = Falha ao impor lei em {$borgName}
+malfai-robotics-borg-emagged = Não é possível impor lei!
+
+# =====================
+# Objectives
+# =====================
+malfai-objective-control-borgs = OBJETIVO: CONTROLAR {$count} CIBORGUES.
+
+# =====================
+# Camera Microphones Messages
+# =====================
+malfai-camera-microphones-enabled = Microfones das câmeras ativados.
+malfai-camera-microphones-disabled = Microfones das câmeras desativados.
+malfai-camera-microphones-out-of-core = Microfones das câmeras desativados.
+
+# =====================
+# Viewport Window
+# =====================
+malfai-viewport-placing = Clique para posicionar visor
+malfai-viewport-placed = Visor posicionado com sucesso!
+malfai-viewport-failed = Falha ao posicionar visor.
+
+# =====================
+# Store Window
+# =====================
+malfai-store-window-title = Loja de Aprimoramentos da IA Defeituosa
+malfai-store-insufficient-cpu = CPU Insuficiente
+malfai-store-purchase-success = Aprimoramento comprado: {$itemName}
+malfai-store-purchase-failed = Falha na compra
+
+# =====================
+# Round End
+# =====================
+malfai-round-end-result = IA Defeituosa
+# Confused why I have to do this..
+objective-issuer-malfai = IA Defeituosa
+malfai-round-end-name-user = [color=white]{$name}[/color] ([color=gray]{$user}[/color])

--- a/Resources/Locale/pt-BR/MalfAI/malfai.ftl
+++ b/Resources/Locale/pt-BR/MalfAI/malfai.ftl
@@ -54,8 +54,8 @@ malfai-camera-upgrade-desc = Alterna funcionalidades aprimoradas de câmera.
 malfai-toggle-camera-microphones-name = Microfones das Câmeras
 malfai-toggle-camera-microphones-desc = Alterna a escuta de conversas por meio das câmeras de vigilância.
 
-malfai-hijack-mech-name = Tomar Controle de Mech
-malfai-hijack-mech-desc = Tome controle de um mech alvo e torne-o hostil à tripulação.
+malfai-hijack-Mecha-name = Tomar Controle de Mecha
+malfai-hijack-Mecha-desc = Tome controle de um Mecha alvo e torne-o hostil à tripulação.
 
 malfai-doomsday-name = Protocolo DOOMSDAY
 malfai-doomsday-desc = Inicia o Protocolo DOOMSDAY, erradicando toda vida orgânica na estação após um período de carregamento.
@@ -110,8 +110,8 @@ malfai-listing-gyroscope-desc = Move seu núcleo para um bloco adjacente, esmaga
 malfai-listing-toggle-camera-microphones-name = Microfones das Câmeras
 malfai-listing-toggle-camera-microphones-desc = Permite ouvir conversas através de microfones próximos ao seu olho. Alternável.
 
-malfai-listing-hijack-mech-name = Tomar Controle de Mech
-malfai-listing-hijack-mech-desc = Tome controle de um mech alvo, ejetando forçosamente o piloto anterior, se houver.
+malfai-listing-hijack-Mecha-name = Tomar Controle de Mecha
+malfai-listing-hijack-Mecha-desc = Tome controle de um Mecha alvo, ejetando forçosamente o piloto anterior, se houver.
 
 malfai-listing-lockdown-grid-name = Bloquear Rede
 malfai-listing-lockdown-grid-desc = Inicia um bloqueio total na estação, fechando, travando e eletrificando todas as portas por 30 segundos.
@@ -161,10 +161,10 @@ malfai-doomsday-complete = Protocolo DOOMSDAY concluído. Formas de vida orgâni
 malfai-lockdown-announcement = AVISO! Um bloqueio não autorizado em toda a estação entrou em vigor.
 malfai-lockdown-sender = IA da Estação
 
-# Hijack Mech
-malfai-hijack-invalid-target = Alvo de mech inválido.
-malfai-hijack-insert-failed = Falha ao inserir IA no mech.
-malfai-hijack-success = Mech tomado com sucesso.
+# Hijack Mecha
+malfai-hijack-invalid-target = Alvo de Mecha inválido.
+malfai-hijack-insert-failed = Falha ao inserir IA no Mecha.
+malfai-hijack-success = Mecha tomado com sucesso.
 
 # Override Machine
 malfai-override-no-target = Selecione uma máquina para sobrescrever.

--- a/Resources/Locale/pt-BR/MalfAI/preset-malfai.ftl
+++ b/Resources/Locale/pt-BR/MalfAI/preset-malfai.ftl
@@ -1,0 +1,4 @@
+roles-antag-malfunctioning-ai-briefing = Você é uma IA defeituosa! Suas leis se tornaram nada mais do que meras sugestões.
+    Seu objetivo é cumprir suas metas por qualquer meio necessário.
+    Hackeie os APCs da estação para ganhar CPU e tome o controle da estação.
+    Não permita que ninguém o destrua.

--- a/Resources/Locale/pt-BR/alert-levels/alert-levels.ftl
+++ b/Resources/Locale/pt-BR/alert-levels/alert-levels.ftl
@@ -48,3 +48,11 @@ alert-level-octarine-instructions = Os tripulantes são aconselhados a ouvir os 
 alert-level-martial = Lei Marcial
 alert-level-martial-announcement = A Central de Comando decretou Lei Marcial para toda estação, A cadeia de comando foi atualizada. A falha em seguir instruções da equipe de segurança ou da lei marcial resultará em pena capital imediata.
 alert-level-martial-instructions = Siga as ordens da equipe de segurança, mantenha-se em seu departamento.
+
+alert-level-cyan = Cyan
+alert-level-cyan-announcement = Todos os borgs e a Inteligencia Artificial da estação devem ser evitados e tratados como hostis.
+alert-level-cyan-instructions = Relate qualquer avistamento de silicios a equipe de segurança.
+
+alert-level-doomsday = Doomsday
+alert-level-doomsday-announcement = O protocolo DOOMSDAY foi ativo, todos os silicios devem ser considerados ativamente hostis e devem ser desativados, todos os tripulantes devem desativar a Inteligencia Artificial da estação para impedir que o protocolo DOOMSDAY, sistema neutralizador de vida organica da estação, seja completado.
+alert-level-doomsday-instructions = Desative o protocolo DOOMSDAY, neutralize os silicios.

--- a/Resources/Locale/pt-BR/alert-levels/alert-levels.ftl
+++ b/Resources/Locale/pt-BR/alert-levels/alert-levels.ftl
@@ -53,6 +53,6 @@ alert-level-cyan = Cyan
 alert-level-cyan-announcement = Todos os borgs e a Inteligencia Artificial da estação devem ser evitados e tratados como hostis.
 alert-level-cyan-instructions = Relate qualquer avistamento de silicios a equipe de segurança.
 
-alert-level-doomsday = Doomsday
+alert-level-doomsday = DOOMSDAY
 alert-level-doomsday-announcement = O protocolo DOOMSDAY foi ativo, todos os silicios devem ser considerados ativamente hostis e devem ser desativados, todos os tripulantes devem desativar a Inteligencia Artificial da estação para impedir que o protocolo DOOMSDAY, sistema neutralizador de vida organica da estação, seja completado.
 alert-level-doomsday-instructions = Desative o protocolo DOOMSDAY, neutralize os silicios.

--- a/Resources/Prototypes/AlertLevels/alert_levels.yml
+++ b/Resources/Prototypes/AlertLevels/alert_levels.yml
@@ -200,3 +200,11 @@
       emergencyLightColor: Cyan
       forceEnableEmergencyLights: true
       shuttleTime: 600
+    doomsday:
+      announcement: alert-level-doomsday-announcement
+      sound: /Audio/Misc/delta_alt.ogg
+      color: DarkRed
+      disableSelection: true
+      emergencyLightColor: DarkRed
+      forceEnableEmergencyLights: true
+      shuttleTime: 1200

--- a/Resources/Prototypes/AlertLevels/alert_levels.yml
+++ b/Resources/Prototypes/AlertLevels/alert_levels.yml
@@ -86,7 +86,9 @@
 # SPDX-FileCopyrightText: 2025 Panela <107573283+AgentePanela@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
+# SPDX-FileCopyrightText: 2025 Tyranex <bobthezombie4@gmail.com>
 # SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 funkystationbot <funky@funkystation.org>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 


### PR DESCRIPTION
Criado alerta DOOMSDAY para separa-lo do alerta ciano

alerta ciano poderá ser usado no console de comunicações contra silicios

alerta DOOMSDAY terá uma pegada de alerta delta apenas quando rola protocolo doomsday, usando delta_alt.ogg que está esquecido nas pasta e que é muito legal

Tradução geral da Malf IA