### PR TITLE
Mais correções IA

### DIFF
--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -385,7 +385,7 @@ public sealed partial class MechSystem : SharedMechSystem
             var isStationAiBrainProto = false;
             if (TryComp<MetaDataComponent>(pilotEntity, out var meta) && meta.EntityPrototype != null)
             {
-                isStationAiBrainProto = meta.EntityPrototype.ID == "StationAiBrain";
+                isStationAiBrainProto = meta.EntityPrototype.ID == StationAiBrain;
             }
 
             if (hasStationAiHeld || isStationAiBrainProto)

--- a/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
+++ b/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
@@ -62,6 +62,8 @@ using Robust.Shared.Configuration;
 using Content.Shared.Implants.Components;
 using Content.Shared.Silicons.StationAi;
 using Content.Shared._Gabystation.MalfAi.Components;
+using Robust.Shared.Prototypes;
+using Content.Shared.Tag;
 
 namespace Content.Shared.Mech.EntitySystems;
 
@@ -88,6 +90,8 @@ public abstract partial class SharedMechSystem : EntitySystem
 
     // Goobstation: Local variable for checking if mech guns can be used out of them.
     private bool _canUseMechGunOutside;
+
+    protected static readonly ProtoId<TagPrototype> StationAiBrain = "StationAi";
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -413,7 +417,7 @@ public abstract partial class SharedMechSystem : EntitySystem
         var isStationAiBrainProto = false;
         var meta = MetaData(toInsert);
         if (meta.EntityPrototype != null)
-            isStationAiBrainProto = meta.EntityPrototype.ID == "StationAiBrain";
+            isStationAiBrainProto = meta.EntityPrototype.ID == StationAiBrain;
         var allowAi = isAiHeld || hasMalfMarker || isStationAiBrainProto;
         return IsEmpty(component) && (canMove || allowAi);
         // Funkystation - Malf Ai end

--- a/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
+++ b/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
@@ -91,7 +91,7 @@ public abstract partial class SharedMechSystem : EntitySystem
     // Goobstation: Local variable for checking if mech guns can be used out of them.
     private bool _canUseMechGunOutside;
 
-    protected static readonly ProtoId<TagPrototype> StationAiBrain = "StationAi";
+    protected static readonly EntProtoId StationAiBrain = "StationAiBrain";
 
     /// <inheritdoc/>
     public override void Initialize()

--- a/Resources/Prototypes/AlertLevels/alert_levels.yml
+++ b/Resources/Prototypes/AlertLevels/alert_levels.yml
@@ -197,7 +197,6 @@
       shuttleTime: 1200
     cyan:
       announcement: alert-level-cyan-announcement
-      selectable: false
       sound: /Audio/Misc/cyan.ogg
       color: Cyan
       emergencyLightColor: Cyan
@@ -205,6 +204,7 @@
       shuttleTime: 600
     doomsday:
       announcement: alert-level-doomsday-announcement
+      selectable: false
       sound: /Audio/Misc/delta_alt.ogg
       color: DarkRed
       disableSelection: true

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -127,9 +127,6 @@
   description: Components added / removed from an entity that gets inserted into an AI core.
   categories: [ HideSpawnMenu ]
   components:
-  - type: Tag
-    tags:
-      - StationAi
   - type: IntrinsicRadioReceiver
   - type: IntrinsicRadioTransmitter
     channels:

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -129,7 +129,7 @@
   components:
   - type: Tag
     tags:
-      - StationAiBrain
+      - StationAi
   - type: IntrinsicRadioReceiver
   - type: IntrinsicRadioTransmitter
     channels:

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -47,7 +47,7 @@
       - ZombieBlob
     pilotWhitelist:
       tags:
-      - StationAiBrain # For MalfAi
+      - StationAi # Funkystation - MalfAi
   - type: MechAir
   - type: AirFilter
     # everything except oxygen and nitrogen

--- a/Resources/Prototypes/_Funkystation/tags.yml
+++ b/Resources/Prototypes/_Funkystation/tags.yml
@@ -18,6 +18,4 @@
 
 - type: Tag
   id: SpecialWeapon
-
-- type: Tag
-  id: StationAiBrain
+  

--- a/Resources/Prototypes/_Funkystation/tags.yml
+++ b/Resources/Prototypes/_Funkystation/tags.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Space Station 14 Contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 #- type: Tag
 #  id: DawInstrumentMachineCircuitboard
 

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
@@ -273,7 +273,7 @@
       components:
         - HumanoidAppearance
       tags:
-        - StationAiBrain
+        - StationAi
   - type: MeleeWeapon
     hidden: true
     attackRate: 1
@@ -492,7 +492,7 @@
       components:
         - HumanoidAppearance
       tags:
-        - StationAiBrain
+        - StationAi
   - type: MeleeWeapon
     hidden: true
     attackRate: 1


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR
Em resumo, corrige os bugs que eu introduzi tentando tirar outros bugs... KSADHJJHSAHDS.

Volta o alerta ciano com selecionável, realmente remove o doomsday e corrige o intellicard.

Closes #431 

**Changelog**
:cl:
- add: O alerta ciano voltou ao computador de comunicações
- fix: Agora é de verdade! Não é mais possível decretar doomsday pelo computador de comunicações.
- fix: O intellicard foi corrigido.
