### PR TITLE
Aumenta a resistência a radiação de paredes reforçadas e cortinas anti-rad

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -197,7 +197,7 @@
     containers:
     - board
   - type: RadiationBlocker
-    resistance: 4
+    resistance: 10 #Gabystation increase rad resistance
 
 - type: entity
   id: ShuttersRadiationOpen

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -197,7 +197,7 @@
     containers:
     - board
   - type: RadiationBlocker
-    resistance: 10 #Gabystation increase rad resistance
+    resistance: 8 #Gabystation increase rad resistance
 
 - type: entity
   id: ShuttersRadiationOpen

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -859,7 +859,7 @@
   - type: StaticPrice
     price: 250
   - type: RadiationBlocker
-    resistance: 5
+    resistance: 10 #Gabystation increase rad resistance
   - type: Fixtures
     fixtures:
       fix1:
@@ -974,7 +974,7 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: RadiationBlocker
-    resistance: 5
+    resistance: 10
   - type: RustRequiresPathStage # Goobstation
     pathStage: 7 # Toxic blade
 

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -974,7 +974,7 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: RadiationBlocker
-    resistance: 10
+    resistance: 10 #Gabystation increase rad resistance
   - type: RustRequiresPathStage # Goobstation
     pathStage: 7 # Toxic blade
 


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## Sobre a PR
<!-- O que ela muda? -->
Deixa a resistencia de radiação de paredes reforçadas e cortinas anti-rad no mesmo valor que janelas de plasma reforçadas.

## Por quê? / Balanceamento
<!-- Discuta do por que da existencia da PR. (opcional | recomendado) -->
A parte principal ou que circula a contenção de singularidade de diversos departamentos de engenhaira fica completamente irradiada na maioria dos mapas (ex: origin, box, marathon, meta) por causa que a radiação da singularidade vaza pelas paredes e cortinas anti-rad, em niveis que mesmo com trajes anti-rad ou hardsuits de engenheiro fica quase impossivel transitar pelo espaço devido á radiação excessiva, mesmo que sejam construidas medidas adicionais de mitigação (Por exemplo, janelas de plasma ou cortinas anti-rad extras) o nivel de radiação ainda é consideravel. essas são áreas comuns do departamento, no caso do origin é um corredor com muito equipamento e o acesso pro TEG, no box meta e marathon são áreas dos funcionários e com vendedores de equipamento. do jeito que está é impossivel ficar 5 minutos nessas áreas sem que o dano comece a ficar crítico, mesmo com hardsuit e traje adequado.

## Detalhes Tecnicos
<!-- Mudanças do codigo para uma review mais facil (opcional). -->

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->
Antes: (Estrutura padrão do PA)
<img width="797" height="480" alt="image" src="https://github.com/user-attachments/assets/25bed36f-4d36-4d8c-a151-fed647a60568" />

Depois: (O contador do outro lado está em 0)
<img width="845" height="482" alt="image" src="https://github.com/user-attachments/assets/3a83fa1c-fa25-4454-bdeb-bcc752f22c64" />


## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [ ] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione uma entrada para changelog do servidor, bote o emoji :cl: e siga com as mudanças assim como o exemplo.
:cl: em branco fara com que seu nome na changelog apareça como do github, adicione um nome depois do emoji para mudar seu nome na changelog. -->

:cl:
- tweak: Aumenta resistência à radiação de paredes reforçadas e cortinas anti-rad. 
