### PR TITLE
RCDs agora podem construir Airlocks por cima de Firelocks

### DIFF
--- a/Content.Shared/RCD/RCDPrototype.cs
+++ b/Content.Shared/RCD/RCDPrototype.cs
@@ -159,7 +159,8 @@ public enum RcdConstructionRule : byte
     MustBuildOnSubfloor,        // Can only be built on exposed subfloor (e.g. catwalks on lattice or hull plating)
     IsWindow,                   // The entity is a window and can be built on grilles
     IsCatwalk,                  // The entity is a catwalk
-    IsWallLight                 // Goobstation - The entity is wall light
+    IsWallLight,                 // Goobstation - The entity is wall light
+    IsAirlock                   // Gabystation - Entity is an airlock and can be built over firelocks
 }
 
 public enum RcdRotation : byte

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -549,6 +549,7 @@ public sealed class RCDSystem : EntitySystem
         var isWindow = prototype.ConstructionRules.Contains(RcdConstructionRule.IsWindow);
         var isCatwalk = prototype.ConstructionRules.Contains(RcdConstructionRule.IsCatwalk);
         var isWallLight = prototype.ConstructionRules.Contains(RcdConstructionRule.IsWallLight);
+        var isAirlock = prototype.ConstructionRules.Contains(RcdConstructionRule.IsAirlock);
 
         _intersectingEntities.Clear();
         _lookup.GetLocalEntitiesIntersecting(gridUid, position, _intersectingEntities, -0.05f, LookupFlags.Uncontained);
@@ -556,6 +557,10 @@ public sealed class RCDSystem : EntitySystem
         foreach (var ent in _intersectingEntities)
         {
             if (isWindow && HasComp<SharedCanBuildWindowOnTopComponent>(ent))
+                continue;
+
+            //Gabystation - Build airlocks on top of firelocks
+            if (isAirlock && HasComp<FirelockComponent>(ent))
                 continue;
 
             // Goobstation - No light spam

--- a/Resources/Prototypes/RCD/rcd.yml
+++ b/Resources/Prototypes/RCD/rcd.yml
@@ -173,6 +173,8 @@
   cost: 4
   delay: 4
   collisionMask: FullTileMask
+  rules:
+    - IsAirlock
   rotation: Camera
   fx: EffectRCDConstruct4
 
@@ -185,6 +187,8 @@
   cost: 4
   delay: 4
   collisionMask: FullTileMask
+  rules:
+    - IsAirlock
   rotation: Camera
   fx: EffectRCDConstruct4
 


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## Sobre a PR
<!-- O que ela muda? -->
Antes RCDs não conseguiam construir portas por cima de firelocks por causa que estavam bugados, fazendo com que o engenheiro tivesse que construir uma firelock com o RCD e depois a airlock por cima manualmente. Já que 90% de todas as portas da estação tem uma firelock por baixo, sempre que uma estragava era necessário que um engenheiro refizesse ela na mão, mesmo que o RCD tenha opção pra fazer airlocks.

## Por quê? / Balanceamento
<!-- Discuta do por que da existencia da PR. (opcional | recomendado) -->
bug chato

## Detalhes Tecnicos
<!-- Mudanças do codigo para uma review mais facil (opcional). -->

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [ ] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione uma entrada para changelog do servidor, bote o emoji :cl: e siga com as mudanças assim como o exemplo.
:cl: em branco fara com que seu nome na changelog apareça como do github, adicione um nome depois do emoji para mudar seu nome na changelog. -->
:cl:
- fix: RCDs agora podem construir portas por cima de firelocks.

