### PR TITLE
Balanceia implantes de EMP, liberdade e scram

### DIFF
--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -225,9 +225,9 @@
   id: ActionActivateEmpImplant
   name: Activate EMP
   description: Triggers a small EMP pulse around you
+  components:
   - type: LimitedCharges # Gabystation no fun
     maxCharges: 3
-  components:
   - type: Action
     checkCanInteract: false
     useDelay: 30

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -192,6 +192,8 @@
   name: Break Free
   description: Activating your freedom implant will free you from any hand restraints
   components:
+  - type: LimitedCharges # Gabystation no fun
+    maxCharges: 3
   - type: Action
     useDelay: 10 # Goob - useful freedom
     checkCanInteract: false
@@ -223,6 +225,8 @@
   id: ActionActivateEmpImplant
   name: Activate EMP
   description: Triggers a small EMP pulse around you
+  - type: LimitedCharges # Gabystation no fun
+    maxCharges: 3
   components:
   - type: Action
     checkCanInteract: false
@@ -239,9 +243,11 @@
   name: SCRAM!
   description: Randomly teleports you within a large distance.
   components:
+  - type: LimitedCharges # Gabystation no fun
+    maxCharges: 3
   - type: Action
     checkCanInteract: false
-    useDelay: 120
+    useDelay: 60 # Gabystation no fun
     itemIconStyle: BigAction
     priority: -20
     icon:


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## Sobre a PR
<!-- O que ela muda? -->
Arruma os implantes de EMP, liberdade e scram, limitando todos ao máximo de 3 usos.
## Por quê? / Balanceamento
<!-- Discuta do por que da existencia da PR. (opcional | recomendado) -->
Muita gente reclamando no discord
## Detalhes Tecnicos
<!-- Mudanças do codigo para uma review mais facil (opcional). -->
  - type: LimitedCharges
    maxCharges: 3 
    
    x3
## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione uma entrada para changelog do servidor, bote o emoji :cl: e siga com as mudanças assim como o exemplo.
:cl: em branco fara com que seu nome na changelog apareça como do github, adicione um nome depois do emoji para mudar seu nome na changelog. -->
:cl:
- tweak: Implantes de EMP, liberdade e scram limitados a 3 usos.
- tweak: Intervalo de ativação do scram diminuído.
