### PR TITLE
[Bounty] Retornar reflexo ao sabre do capitão

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -247,6 +247,9 @@
         Slash: 3
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
+  - type: Reflect # Gabystation edit
+    reflectProb: .3
+    spread: 90
   - type: Item
     storedSprite:
       state: storage


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## Sobre a PR
<!-- O que ela muda? -->
Adiciona o reflexo novamente igual oque já havia antes

## Por quê? / Balanceamento
<!-- Discuta do por que da existencia da PR. (opcional | recomendado) -->
SS13 é assim, reflexo aqui é inclusive menor doque o de lá, e honestamente todo mundo continuou com reflexo só o do capitão que removeu, bounty btw.
<img width="409" height="172" alt="image" src="https://github.com/user-attachments/assets/a760956c-f211-4a8c-8c57-7b37a58273ef" />

## Detalhes Tecnicos
<!-- Mudanças do codigo para uma review mais facil (opcional). -->
Apenas readicionei a chance de reflexo de 30% igual antes.

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl:
- tweak: Retornado reflexo do sabre de capitão.
