### PR TITLE
Beepsky - Bugs e etc

### DIFF
--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Specific/PickNearbyWantedOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Specific/PickNearbyWantedOperator.cs
@@ -13,6 +13,8 @@ using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using System.Threading;
 using System.Threading.Tasks;
+using Content.Shared.Stealth;
+using Content.Shared.Stealth.Components;
 
 namespace Content.Server.NPC.HTN.PrimitiveTasks.Operators.Specific;
 
@@ -22,6 +24,7 @@ public sealed partial class PickNearbyWantedOperator : HTNOperator
     private EntityLookupSystem _lookup = default!;
     private PathfindingSystem _pathfinding = default!;
     private SharedAudioSystem _audio = default!;
+    private SharedStealthSystem _stealth = default!;
 
     [DataField]
     public float MaxPoints = 10f;
@@ -44,12 +47,19 @@ public sealed partial class PickNearbyWantedOperator : HTNOperator
     [DataField]
     public string? TargetFoundSoundKey;
 
+    [DataField("checkStealth")]
+    public bool CheckStealth = false;
+
+    [DataField("stealthPercent")]
+    public float StealthPercent = -0.75f;
+
     public override void Initialize(IEntitySystemManager sysManager)
     {
         base.Initialize(sysManager);
         _lookup = sysManager.GetEntitySystem<EntityLookupSystem>();
         _pathfinding = sysManager.GetEntitySystem<PathfindingSystem>();
         _audio = sysManager.GetEntitySystem<SharedAudioSystem>();
+        _stealth = sysManager.GetEntitySystem<SharedStealthSystem>();
     }
 
     public override async Task<(bool Valid, Dictionary<string, object>? Effects)> Plan(NPCBlackboard blackboard, CancellationToken cancelToken)
@@ -65,6 +75,12 @@ public sealed partial class PickNearbyWantedOperator : HTNOperator
 
         foreach (var entity in _lookup.GetEntitiesInRange(owner, range))
         {
+            if (CheckStealth && _entManager.TryGetComponent<StealthComponent>(entity, out var stealth))
+            {
+                if (_stealth.GetVisibility(entity, stealth) <= StealthPercent)
+                    continue;
+            }
+
             if (!criminalRecordQuery.TryGetComponent(entity, out var criminalRecord) || criminalRecord.Points < MaxPoints)
                 continue;
 

--- a/Content.Shared/Security/Systems/CriminalStatusSystem.cs
+++ b/Content.Shared/Security/Systems/CriminalStatusSystem.cs
@@ -16,6 +16,7 @@ using Robust.Shared.Prototypes;
 using System.Linq;
 using Robust.Shared.GameObjects;
 using Content.Shared.PDA;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Security.Systems;
 
@@ -188,7 +189,7 @@ public sealed class CriminalStatusSystem : EntitySystem
 
     private void PointDelay(EntityUid uid, float points)
     {
-        EnsureComp<TimerComponent>(uid).Spawn(Delay, () =>
+        Timer.Spawn(Delay, () =>
         {
             if (TryComp<CriminalRecordComponent>(uid, out var currentRecord))
                 currentRecord.Points = Math.Max(0, currentRecord.Points - points);

--- a/Resources/Prototypes/NPCs/secbot.yml
+++ b/Resources/Prototypes/NPCs/secbot.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: htnCompound
   id: SecbotCompound
   branches:

--- a/Resources/Prototypes/NPCs/secbot.yml
+++ b/Resources/Prototypes/NPCs/secbot.yml
@@ -22,6 +22,7 @@
             targetKey: StunTarget
             targetMoveKey: TargetCoordinates
             targetFoundSoundKey: TargetFoundSound
+            checkStealth: true
 
         - !type:HTNPrimitiveTask
           operator: !type:MoveToOperator


### PR DESCRIPTION
## Sobre a PR
Agora o terminal não lota de erros ao voltar para o lobby e o Beepsky não detecta pessoas quando completamente invisíveis.

## Por quê? / Balanceamento
É legal

## Anexos
"-"

## Requirimentos
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl:
- tweak: Agora o Beepsky não detecta pessoas completamente invisíveis.
