### PR TITLE
Genetics QoL

### DIFF
--- a/Content.Shared/_Wega/Genetics/Components/DnaModifierConsoleComponent.cs
+++ b/Content.Shared/_Wega/Genetics/Components/DnaModifierConsoleComponent.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 

--- a/Content.Shared/_Wega/Genetics/Components/DnaModifierConsoleComponent.cs
+++ b/Content.Shared/_Wega/Genetics/Components/DnaModifierConsoleComponent.cs
@@ -26,10 +26,10 @@ public sealed partial class DnaModifierConsoleComponent : Component
     public TimeSpan LastSubjectInjectTime;
 
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan InjectorCooldown = TimeSpan.FromMinutes(2);
+    public TimeSpan InjectorCooldown = TimeSpan.FromSeconds(30);
 
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan SubjectInjectCooldown = TimeSpan.FromMinutes(2);
+    public TimeSpan SubjectInjectCooldown = TimeSpan.FromSeconds(30);
 
     [DataField("clickSound"), ViewVariables(VVAccess.ReadWrite)]
     public SoundSpecifier ClickSound = new SoundPathSpecifier("/Audio/Machines/machine_switch.ogg");


### PR DESCRIPTION
Reduz o cooldown das injeções de 2 minutos para 30 segundos. Isso torna os Geneticistas mais úteis para ajudar a estação. Antes, o processo era muito lento e os pedidos de poderes demoravam entre 8 e 10 minutos para serem atendidos.


https://github.com/user-attachments/assets/af356534-0df7-452b-866f-bd2c7752195e

Changelog

🆑

add: Reduz cooldown das injeções.

