### PR TITLE
Câmera fotográfica - Ajustes e etc

### DIFF
--- a/Content.Client/_CorvaxGoob/RoundEnd/RoundEndSummaryWindow.cs
+++ b/Content.Client/_CorvaxGoob/RoundEnd/RoundEndSummaryWindow.cs
@@ -52,6 +52,33 @@ public sealed partial class RoundEndSummaryWindow
 
         foreach (var album in stationAlbumSystem.Albums)
         {
+            var stationAlbumAuthorHeaderContainer = new BoxContainer
+            {
+                Orientation = LayoutOrientation.Vertical,
+                HorizontalExpand = true,
+                VerticalExpand = true,
+                Margin = new Thickness(0, 5, 0, 5)
+            };
+
+            var stationAlbumAuthorHeaderPanel = new PanelContainer
+            {
+                StyleClasses = { StyleNano.StyleClassBackgroundBaseDark },
+                SetSize = new Vector2(556, 30),
+                HorizontalAlignment = HAlignment.Left
+            };
+
+            var stationAlbumAuthorHeaderLabel = new RichTextLabel();
+
+            string authorName = album.AuthorName == null ? Loc.GetString("round-end-summary-album-photo-no-author-name") : album.AuthorName;
+            string authorCKey = album.AuthorCkey == null ? Loc.GetString("round-end-summary-album-photo-no-author-ckey") : album.AuthorCkey;
+
+            stationAlbumAuthorHeaderLabel.SetMarkup(Loc.GetString("round-end-summary-album-photo-author", ("authorName", authorName), ("authorCKey", authorCKey)));
+
+            stationAlbumAuthorHeaderPanel.AddChild(stationAlbumAuthorHeaderLabel);
+            stationAlbumAuthorHeaderContainer.AddChild(stationAlbumAuthorHeaderPanel);
+
+            stationAlbumContainer.AddChild(stationAlbumAuthorHeaderContainer);
+
             var gridContainer = new GridContainer();
 
             gridContainer.Columns = 2;
@@ -108,33 +135,6 @@ public sealed partial class RoundEndSummaryWindow
             }
 
             stationAlbumContainer.AddChild(gridContainer);
-
-            var stationAlbumAuthorHeaderContainer = new BoxContainer
-            {
-                Orientation = LayoutOrientation.Vertical,
-                HorizontalExpand = true,
-                VerticalExpand = true,
-                Margin = new Thickness(0, 5, 0, 5)
-            };
-
-            var stationAlbumAuthorHeaderPanel = new PanelContainer
-            {
-                StyleClasses = { StyleNano.StyleClassBackgroundBaseDark },
-                SetSize = new Vector2(556, 30),
-                HorizontalAlignment = HAlignment.Left
-            };
-
-            var stationAlbumAuthorHeaderLabel = new RichTextLabel();
-
-            string authorName = album.AuthorName == null ? Loc.GetString("round-end-summary-album-photo-no-author-name") : album.AuthorName;
-            string authorCKey = album.AuthorCkey == null ? Loc.GetString("round-end-summary-album-photo-no-author-ckey") : album.AuthorCkey;
-
-            stationAlbumAuthorHeaderLabel.SetMarkup(Loc.GetString("round-end-summary-album-photo-author", ("authorName", authorName), ("authorCKey", authorCKey)));
-
-            stationAlbumAuthorHeaderPanel.AddChild(stationAlbumAuthorHeaderLabel);
-            stationAlbumAuthorHeaderContainer.AddChild(stationAlbumAuthorHeaderPanel);
-
-            stationAlbumContainer.AddChild(stationAlbumAuthorHeaderContainer);
         }
 
         stationAlbumContainerScrollbox.AddChild(stationAlbumContainer);

--- a/Resources/Locale/pt-BR/_corvaxgoob/round-end/round-end-summary-window.ftl
+++ b/Resources/Locale/pt-BR/_corvaxgoob/round-end/round-end-summary-window.ftl
@@ -1,4 +1,4 @@
-round-end-summary-window-photo-album-tab-title = Álbum de Fotos
+round-end-summary-window-photo-album-tab-title = Álbuns
 round-end-summary-album-photo-no-name = Sem título
 round-end-summary-album-photo-author = [color=white]Autor:[/color] [color=gold]{$authorName}[/color] ({$authorCKey})
 

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -231,6 +231,7 @@
   - PlushieKiiaraWami # Gabystation
   - PlushieKiiaraWarden # Gabystation
   - MP3PlayerWhite # Gabystation
+  - PhotoCamera # Gabystation
   - FoodSnackLollypopWrapped # Goobstation
   - FoodSnackLollypopWrappedRainbow # Goobstation
   - FoodSnackLollypopWrappedCarp # Goobstation

--- a/Resources/Prototypes/_Gabystation/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_Gabystation/Loadouts/Miscellaneous/trinkets.yml
@@ -54,3 +54,14 @@
   storage:
     back:
     - BookArteDaRobustez
+
+- type: loadout
+  id: PhotoCamera
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 180000 # 50 horas
+  storage:
+    back:
+    - PhotoCameraFilled


### PR DESCRIPTION
## Sobre a PR
Agora o nome do autor do álbum aparece acima das fotos e adiciona a câmera ao loadout.

## Por quê? / Balanceamento
Apenas deixa menos confuso ao olhar os álbuns de fim de round e deixa mais acessivo a câmera fotográfica.

## Anexos
"-"

## Requirimentos

- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**

:cl:
- tweak: Agora o nome do autor do album aparece acima das fotos.
- add: Adiciona câmera fotográfica ao loadout.
