### PR TITLE
Nerf mariposas

### DIFF
--- a/Content.Goobstation.Shared/Dash/DashActionSystem.cs
+++ b/Content.Goobstation.Shared/Dash/DashActionSystem.cs
@@ -7,12 +7,14 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Goobstation.Shared.Emoting;
+using Content.Shared._EinsteinEngines.Flight.Events;
 using Content.Shared.Actions;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Gravity;
 using Content.Shared.Movement.Components;
+using Content.Shared.Popups;
 using Content.Shared.Throwing;
 
 namespace Content.Goobstation.Shared.Dash;
@@ -24,6 +26,8 @@ public sealed class DashActionSystem : EntitySystem
     [Dependency] private readonly ThrowingSystem _throwing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedStaminaSystem _stamina = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -73,5 +77,15 @@ public sealed class DashActionSystem : EntitySystem
     private void OnComponentShutdown(EntityUid uid, DashActionComponent comp, ref ComponentShutdown args)
     {
         _actions.RemoveAction(comp.ActionUid);
+    }
+
+    // Gabystation
+    private void OnDashFlightAttempt(Entity<DashActionComponent> ent, ref FlightAttemptEvent ev)
+    {
+        if (!HasComp<ThrownItemComponent>(ent))
+            return;
+
+        _popup.PopupClient(Loc.GetString("no-flight-while-dashing"), ent.Owner, ent.Owner, PopupType.Medium);
+        ev.Cancel();
     }
 }

--- a/Content.Goobstation.Shared/Dash/DashActionSystem.cs
+++ b/Content.Goobstation.Shared/Dash/DashActionSystem.cs
@@ -36,6 +36,8 @@ public sealed class DashActionSystem : EntitySystem
 
         SubscribeLocalEvent<DashActionComponent, ComponentInit>(OnComponentInit);
         SubscribeLocalEvent<DashActionComponent, ComponentShutdown>(OnComponentShutdown);
+        
+        SubscribeLocalEvent<DashActionComponent, FlightAttemptEvent>(OnDashFlightAttempt);
     }
 
     private void OnDashAction(DashActionEvent args)

--- a/Resources/Locale/en-US/_EinsteinEngines/flight/flight_system.ftl
+++ b/Resources/Locale/en-US/_EinsteinEngines/flight/flight_system.ftl
@@ -8,3 +8,4 @@
 no-flight-while-restrained = You can't fly right now.
 no-flight-while-zombified = You can't use your wings right now.
 no-flight-while-lying = You can't fly right now.
+no-flight-while-dashing = You can't use your wings right now.


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR
Agora as moths não são mais capazes de voar durante o dash. O contrário já não era possível (dashar enquanto voa).

## Por quê? / Balanceamento
É bem roubado você cruzar um corredor inteiro em segundos. Á pedido da administração.

**Changelog**
:cl:
- remove: Moths não podem mais voar ao fim do dash.