### PR TITLE
[BOUNTY] Adiciona herético, culto cósmico e culto do sangue em midround

### DIFF
--- a/Resources/Locale/pt-BR/_Gabystation/BloodCult/roles/bloodcultist.ftl
+++ b/Resources/Locale/pt-BR/_Gabystation/BloodCult/roles/bloodcultist.ftl
@@ -1,0 +1,1 @@
+blood-cult-roundend-name = Cultista do Sangue de Meio da rodada

--- a/Resources/Locale/pt-BR/_Gabystation/CosmicCult/roles/cosmiccultist.ftl
+++ b/Resources/Locale/pt-BR/_Gabystation/CosmicCult/roles/cosmiccultist.ftl
@@ -1,0 +1,1 @@
+cosmic-cult-roundend-name  = Cultista Cósmico de Meio da rodada

--- a/Resources/Locale/pt-BR/_Gabystation/Heretic/roles/heretic.ftl
+++ b/Resources/Locale/pt-BR/_Gabystation/Heretic/roles/heretic.ftl
@@ -1,0 +1,1 @@
+roles-antag-hereticmidround-name = Herético de Meio da rodada

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -194,6 +194,7 @@
     #- id: RevenantSpawn  # GoobStation - removed till rework
     - id: SleeperAgents
     - id: HereticMidround # Gabystation
+    - id: CosmicCultMidround # Gabystation
     - id: ZombieOutbreak
     - id: LoneOpsSpawn
     - id: DerelictCyborgSpawn

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -193,6 +193,7 @@
     - id: ParadoxCloneSpawn
     #- id: RevenantSpawn  # GoobStation - removed till rework
     - id: SleeperAgents
+    - id: HereticMidround # Gabystation
     - id: ZombieOutbreak
     - id: LoneOpsSpawn
     - id: DerelictCyborgSpawn

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -195,7 +195,7 @@
     - id: SleeperAgents
     - id: HereticMidround # Gabystation
     - id: CosmicCultMidround # Gabystation
-    - id: BloodCultMidround # Gabystation
+    # - id: BloodCultMidround # Gabystation
     - id: ZombieOutbreak
     - id: LoneOpsSpawn
     - id: DerelictCyborgSpawn

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -195,6 +195,7 @@
     - id: SleeperAgents
     - id: HereticMidround # Gabystation
     - id: CosmicCultMidround # Gabystation
+    - id: BloodCultMidround # Gabystation
     - id: ZombieOutbreak
     - id: LoneOpsSpawn
     - id: DerelictCyborgSpawn

--- a/Resources/Prototypes/_Gabystation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Gabystation/GameRules/midround.yml
@@ -82,3 +82,47 @@
   - type: Tag
     tags:
       - MidroundAntag
+
+# Midround Cosmic Cultist
+- type: entity
+  parent: CosmicCult
+  id: CosmicCultMidround
+  components:
+  - type: StationEvent
+    earliestStart: 20
+    weight: 3
+    minimumPlayers: 30
+    maxOccurrences: 1
+    startAnnouncement: station-event-communication-interception
+    startAudio:
+      path: /Audio/Announcements/intercept.ogg
+    duration: null
+    occursDuringRoundEnd: false
+    chaos:
+      Hostile: 400
+      Medical: 400
+      Death: 400
+    eventType: HostilesSpawn
+  - type: GameRule
+    chaosScore: 1200
+  - type: AlertLevelInterceptionRule
+  - type: AntagSelection
+    selectionTime: PostPlayerSpawn
+    agentName: cosmic-cult-roundend-name 
+    definitions:
+    - prefRoles: [ CosmicAntagCultist ]
+      max: 4
+      min: 2
+      playerRatio: 15
+      blacklist:
+        components:
+        - CommandStaff
+        - AntagImmune
+        - BibleUser
+      lateJoinAdditional: true
+      jobBlacklist: [ Chaplain ]
+      mindRoles:
+      - MindRoleCosmicCult
+  - type: Tag
+    tags:
+      - MidroundAntag

--- a/Resources/Prototypes/_Gabystation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Gabystation/GameRules/midround.yml
@@ -126,3 +126,54 @@
   - type: Tag
     tags:
       - MidroundAntag
+
+# Midround Blood Cultist
+- type: entity
+  parent: BloodCult
+  id: BloodCultMidround
+  components:
+  - type: StationEvent
+    earliestStart: 20
+    weight: 3
+    minimumPlayers: 30
+    maxOccurrences: 1
+    startAnnouncement: station-event-communication-interception
+    startAudio:
+      path: /Audio/Announcements/intercept.ogg
+    duration: null
+    occursDuringRoundEnd: false
+    chaos:
+      Hostile: 300
+      Medical: 300
+      Death: 400
+    eventType: HostilesSpawn
+  - type: GameRule
+    chaosScore: 1000
+  - type: AlertLevelInterceptionRule
+  - type: AntagSelection
+    selectionTime: PostPlayerSpawn
+    agentName: blood-cult-roundend-name
+    definitions:
+    - prefRoles: [ BloodCultist ]
+      min: 2
+      max: 4
+      playerRatio: 15
+      blacklist:
+        components:
+        - CommandStaff
+        - AntagImmune
+        - BibleUser
+      startingGear: BloodCultistGear
+      lateJoinAdditional: true
+      jobBlacklist: [ Chaplain ]
+      briefing:
+        text: cult-start-briefing
+        color: CornflowerBlue
+        sound: "/Audio/_Funkystation/Ambience/Antag/cultist_start.ogg"
+      components:
+      - type: BloodCultist
+      mindRoles:
+      - MindRoleCultist
+  - type: Tag
+    tags:
+      - MidroundAntag

--- a/Resources/Prototypes/_Gabystation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Gabystation/GameRules/midround.yml
@@ -37,3 +37,48 @@
   - type: Tag
     tags:
       - MidroundAntag
+
+# Midround Heretics
+- type: entity
+  parent: Heretic
+  id: HereticMidround
+  components:
+  - type: StationEvent
+    earliestStart: 20
+    weight: 3
+    minimumPlayers: 30
+    maxOccurrences: 1
+    startAnnouncement: station-event-communication-interception
+    startAudio:
+      path: /Audio/Announcements/intercept.ogg
+    duration: null
+    occursDuringRoundEnd: false
+    chaos:
+      Hostile: 200
+      Medical: 150
+      Death: 200
+    eventType: HostilesSpawn
+  - type: GameRule
+    chaosScore: 500
+  - type: AlertLevelInterceptionRule
+  - type: AntagSelection
+    selectionTime: PostPlayerSpawn
+    agentName: heretic-roundend-name
+    definitions:
+    - prefRoles: [ Heretic ]
+      max: 2
+      min: 1
+      playerRatio: 15
+      blacklist:
+        components:
+        - CommandStaff
+        - AntagImmune
+        - BibleUser
+      startingGear: Heretictmidround
+      lateJoinAdditional: true
+      jobBlacklist: [ Chaplain ] # GOOBSTATION
+      mindRoles:
+      - MindRoleHeretic
+  - type: Tag
+    tags:
+      - MidroundAntag

--- a/Resources/Prototypes/_Gabystation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Gabystation/GameRules/midround.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   parent: Vampire
   id: VampireMidround

--- a/Resources/Prototypes/_Gabystation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Gabystation/GameRules/midround.yml
@@ -128,52 +128,52 @@
       - MidroundAntag
 
 # Midround Blood Cultist
-- type: entity
-  parent: BloodCult
-  id: BloodCultMidround
-  components:
-  - type: StationEvent
-    earliestStart: 20
-    weight: 3
-    minimumPlayers: 30
-    maxOccurrences: 1
-    startAnnouncement: station-event-communication-interception
-    startAudio:
-      path: /Audio/Announcements/intercept.ogg
-    duration: null
-    occursDuringRoundEnd: false
-    chaos:
-      Hostile: 300
-      Medical: 300
-      Death: 400
-    eventType: HostilesSpawn
-  - type: GameRule
-    chaosScore: 1000
-  - type: AlertLevelInterceptionRule
-  - type: AntagSelection
-    selectionTime: PostPlayerSpawn
-    agentName: blood-cult-roundend-name
-    definitions:
-    - prefRoles: [ BloodCultist ]
-      min: 2
-      max: 4
-      playerRatio: 15
-      blacklist:
-        components:
-        - CommandStaff
-        - AntagImmune
-        - BibleUser
-      startingGear: BloodCultistGear
-      lateJoinAdditional: true
-      jobBlacklist: [ Chaplain ]
-      briefing:
-        text: cult-start-briefing
-        color: CornflowerBlue
-        sound: "/Audio/_Funkystation/Ambience/Antag/cultist_start.ogg"
-      components:
-      - type: BloodCultist
-      mindRoles:
-      - MindRoleCultist
-  - type: Tag
-    tags:
-      - MidroundAntag
+# - type: entity
+#   parent: BloodCult
+#   id: BloodCultMidround
+#   components:
+#   - type: StationEvent
+#     earliestStart: 20
+#     weight: 3
+#     minimumPlayers: 30
+#     maxOccurrences: 1
+#     startAnnouncement: station-event-communication-interception
+#     startAudio:
+#       path: /Audio/Announcements/intercept.ogg
+#     duration: null
+#     occursDuringRoundEnd: false
+#     chaos:
+#       Hostile: 300
+#       Medical: 300
+#       Death: 400
+#     eventType: HostilesSpawn
+#   - type: GameRule
+#     chaosScore: 1000
+#   - type: AlertLevelInterceptionRule
+#   - type: AntagSelection
+#     selectionTime: PostPlayerSpawn
+#     agentName: blood-cult-roundend-name
+#     definitions:
+#     - prefRoles: [ BloodCultist ]
+#       min: 2
+#       max: 4
+#       playerRatio: 15
+#       blacklist:
+#         components:
+#         - CommandStaff
+#         - AntagImmune
+#         - BibleUser
+#       startingGear: BloodCultistGear
+#       lateJoinAdditional: true
+#       jobBlacklist: [ Chaplain ]
+#       briefing:
+#         text: cult-start-briefing
+#         color: CornflowerBlue
+#         sound: "/Audio/_Funkystation/Ambience/Antag/cultist_start.ogg"
+#       components:
+#       - type: BloodCultist
+#       mindRoles:
+#       - MindRoleCultist
+#   - type: Tag
+#     tags:
+#       - MidroundAntag

--- a/Resources/Prototypes/_Gabystation/Heretic/Entities/Objects/Specific/heretic.yml
+++ b/Resources/Prototypes/_Gabystation/Heretic/Entities/Objects/Specific/heretic.yml
@@ -1,0 +1,20 @@
+- type: entity
+  id: Inkofimaginination
+  name: Ink of imaginination
+  description: Call to the great minimal to bring forth true existence... A closing truth
+  parent: BaseItem
+  components:
+  - type: UnholyItem
+  - type: Sprite
+    sprite: _Goobstation/Heretic/book.rsi
+    state: icon
+  - type: Icon
+    sprite: _Goobstation/Heretic/book.rsi
+    state: icon
+  - type: SpawnItemsOnUse
+    items:
+      - id: EldritchInfluence
+      - id: EldritchInfluence
+  - type: Tag
+    tags:
+    - HereticItem

--- a/Resources/Prototypes/_Gabystation/Heretic/Entities/Objects/Specific/heretic.yml
+++ b/Resources/Prototypes/_Gabystation/Heretic/Entities/Objects/Specific/heretic.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   id: Inkofimaginination
   name: Ink of imaginination

--- a/Resources/Prototypes/_Gabystation/Heretic/Roles/Antags/heretic.yml
+++ b/Resources/Prototypes/_Gabystation/Heretic/Roles/Antags/heretic.yml
@@ -1,0 +1,5 @@
+- type: startingGear
+  id: Heretictmidround
+  storage:
+    back:
+    - Inkofimaginination

--- a/Resources/Prototypes/_Gabystation/Heretic/Roles/Antags/heretic.yml
+++ b/Resources/Prototypes/_Gabystation/Heretic/Roles/Antags/heretic.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: startingGear
   id: Heretictmidround
   storage:


### PR DESCRIPTION
## Sobre a PR
Apenas adiciona herético, culto cósmico e culto do sangue em midround.
Mais informação em "https://discord.com/channels/1296583940731179100/1473405406620549151"

## Por quê? / Balanceamento
"Os cultos quase nunca aparecem nas rodadas por que a gaby nao tem a pop suficiente pra ter normalmente ainda."

## Anexos
"-"

## Requirimentos
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl:
- tweak: Adiciona herético, culto cósmico e culto do sangue em midround.
