### PR TITLE
Dar aumento para trabalhos importantes

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -158,7 +158,7 @@
   # - CargoSOP
   - Command
   goobcoins: 40 #Goob content
-  salary: 50 # Gaby content
+  salary: 75 # Gaby content
   access:
   - Cargo
   - Salvage

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -171,7 +171,7 @@
   # - CaptainSOP
   goobcoins: 50 #Goob content
   weight: 20
-  salary: 50 # Gaby content
+  salary: 100 # Gaby content
   startingGear: CaptainGear
   icon: "JobIconCaptain"
   joinNotifyCrew: true

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -169,7 +169,7 @@
   # - HeadOfPersonnelSOP
   - Writing
   goobcoins: 40 #Goob content
-  salary: 50 # Gaby content
+  salary: 80 # Gaby content
   weight: 20
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -165,7 +165,7 @@
   - Command
   # - EmergenciesSOP
   goobcoins: 40 #Goob content
-  salary: 50 # Gaby content
+  salary: 75 # Gaby content
   access:
   - Maintenance
   - Engineering

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -165,7 +165,7 @@
   - Chemicals
   - Virology
   goobcoins: 40 #Goob content
-  salary: 50 # Gaby content
+  salary: 75 # Gaby content
   weight: 10 #Goob Edit
   access:
   - Medical

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -159,7 +159,7 @@
   # - ResearchDirectorSOP
   # - ScienceSOP
   goobcoins: 40 #Goob content
-  salary: 50 # Gaby content
+  salary: 75 # Gaby content
   access:
   - Research
   - Command

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -182,7 +182,7 @@
   # - SecuritySOP
   # - AlertLevels
   goobcoins: 45 #Goob content
-  salary: 50 # Gaby content
+  salary: 75 # Gaby content
   access:
   - HeadOfSecurity
   - Command

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -168,7 +168,7 @@
   # - WardenSOP
   - KravMaga
   goobcoins: 35 #Goob content
-  salary: 50 # Gaby content
+  salary: 65 # Gaby content
   access:
   - Security
   - Brig

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Dignitary/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Dignitary/blueshield_officer.yml
@@ -53,7 +53,7 @@
   - Command
   # - Succession
   goobcoins: 45
-  salary: 50 # Gaby content
+  salary: 65 # Gaby content
   weight: 20
   startingGear: BlueshieldOfficerGear
   icon: "JobIconBlueshield"

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Dignitary/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Dignitary/blueshield_officer.yml
@@ -53,7 +53,7 @@
   - Command
   # - Succession
   goobcoins: 45
-  salary: 65 # Gaby content
+  salary: 75 # Gaby content
   weight: 20
   startingGear: BlueshieldOfficerGear
   icon: "JobIconBlueshield"

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Dignitary/nanotrasen_representative.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Dignitary/nanotrasen_representative.yml
@@ -109,7 +109,7 @@
       species:
       - Felinid
   weight: 20
-  salary: 50 # Gaby content
+  salary: 100 # Gaby content
   startingGear: NanotrasenRepresentativeGear
   icon: "JobIconNanotrasenRepresentative"
   requireAdminNotify: true

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Security/brigmedic.yml
@@ -15,6 +15,7 @@
   - !type:DepartmentTimeRequirement
     department: Security
     time: 18000 # 5 hrs
+  salary: 50 # Gaby content
   startingGear: BrigmedicGear
   icon: "JobIconBrigmedic"
   supervisors: job-supervisors-hos


### PR DESCRIPTION
## Sobre a PR
Altera salários para os membros de comando, warden, e o brigmed para refletir a importância maior deles na estação.

## Por quê? / Balanceamento
Por quê o Médico Chefe deveria receber a mesma quantidade que um químico? Por quê o Engenheiro Chefe deveria receber a mesma quantidade que um engenheiro? Não faz sentido, essa PR conserta isso.

## Detalhes Tecnicos
Eu alterei a parte de "salary" dos .yml dos trabalhos, e adicionei salário definido para o brigmed, que até agora tava sem salário definido e estava apenas usando o que parece ser o default de 25 spesos. Os salários novos são:
Capitão: 100 Spesos
NTR: 100 Spesos
HOP: 80 Spesos
Carcereiro: 65 Spesos
Clínico Brigadista: 50 spesos
Demais membros do comando: 75 spesos
Eu não testei TODAS as mudanças dos salários dentro do jogo pois isso demoraria horas, mas eu testei mudar pro NTR e o Brigmed e funcionaram perfeitamente.

## Anexos
<img width="348" height="72" alt="image" src="https://github.com/user-attachments/assets/dc02a2bf-b785-46fd-b89e-4abb48bba666" />


## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl: Heartbeat
- tweak: Membros de comando, warden e brigmed receberam um aumento.


