### PR TITLE
Modulador de voz e tradução pra máscara SWAT da sec

### DIFF
--- a/Resources/Locale/pt-BR/Entities/Clothing/Masks/masks.ftl
+++ b/Resources/Locale/pt-BR/Entities/Clothing/Masks/masks.ftl
@@ -1,6 +1,9 @@
 ent-ClothingMaskGas = máscara de gás
     .desc = Uma máscara que pode ser conectada a um tanque de oxigênio.
 
+ent-ClothingMaskGasSwat = Máscara de gás de SWAT
+    .desc = Uma máscara de gás elite para o Departamento de Segurança. Possui um modulador de voz para intimidação.
+
 ent-ClothingMaskGasSecurity = máscara de gás da segurança
     .desc = Equipamento padrão da segurança.
 
@@ -53,8 +56,4 @@ ent-ClothingMaskMuzzle = mordaça
 
 ent-ClothingMaskPlague = máscara de médico da peste
     .desc = Eu tenho um mal pressentimento sobre isso.
-    .suffix = Voice Mask
-
-ent-ClothingMaskGasSwat = Máscara de gás de SWAT
-    .desc = Uma máscara de gás elite para o Departamento de Segurança. Possui um modulador de voz para intimidação.
     .suffix = Voice Mask

--- a/Resources/Locale/pt-BR/Entities/Clothing/Masks/masks.ftl
+++ b/Resources/Locale/pt-BR/Entities/Clothing/Masks/masks.ftl
@@ -55,3 +55,5 @@ ent-ClothingMaskPlague = máscara de médico da peste
     .desc = Eu tenho um mal pressentimento sobre isso.
     .suffix = Voice Mask
 
+ent-ClothingMaskGasSwat = Máscara de gás de SWAT
+    .desc = Uma máscara de gás elite para o Departamento de Segurança. Possui um modulador de voz para intimidação.

--- a/Resources/Locale/pt-BR/Entities/Clothing/Masks/masks.ftl
+++ b/Resources/Locale/pt-BR/Entities/Clothing/Masks/masks.ftl
@@ -57,3 +57,4 @@ ent-ClothingMaskPlague = máscara de médico da peste
 
 ent-ClothingMaskGasSwat = Máscara de gás de SWAT
     .desc = Uma máscara de gás elite para o Departamento de Segurança. Possui um modulador de voz para intimidação.
+    .suffix = Voice Mask

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -685,6 +685,9 @@
         Heat: 0.9
   - type: IngestionBlocker # Goobstation
     blockSmokeIngestion: true
+  - type: SpeechSoundsReplacer
+    speechSounds: Chrono
+
 
 - type: entity
   parent: [ ClothingMaskGas, BaseSecurityCargoContraband ]

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -687,7 +687,9 @@
     blockSmokeIngestion: true
   - type: SpeechSoundsReplacer
     speechSounds: Chrono
-
+  - type: Hailer # Goobstation - Hailer
+  - type: IngestionBlocker # Goobstation
+    blockSmokeIngestion: true
 
 - type: entity
   parent: [ ClothingMaskGas, BaseSecurityCargoContraband ]

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -688,8 +688,6 @@
   - type: SpeechSoundsReplacer
     speechSounds: Chrono
   - type: Hailer # Goobstation - Hailer
-  - type: IngestionBlocker # Goobstation
-    blockSmokeIngestion: true
 
 - type: entity
   parent: [ ClothingMaskGas, BaseSecurityCargoContraband ]


### PR DESCRIPTION
## Sobre a PR
Adiciona a mesma voz que o traje dreadnought quando vestindo a máscara swat, junto com o componente de hailer e tradução pro item.

## Por quê? / Balanceamento
É maneiro. Normalmente é so o Chefe de Segurança que usa ela, pois ele vem com uma no armário, então combina com o resto das coisas dele.

## Detalhes Tecnicos
Adicionei esses dois componentes ao ClothingMaskGasSwat
- type: SpeechSoundsReplacer
    speechSounds: Chrono
- type: Hailer 
E também a tradução no masks.ftl: ent-ClothingMaskGasSwat = Máscara de gás de SWAT
    .desc = Uma máscara de gás elite para o Departamento de Segurança. Possui um modulador de voz para intimidação.
Testei no jogo, ta tudo funcionando.

## Anexos
<img width="381" height="162" alt="image" src="https://github.com/user-attachments/assets/fbd3cb3c-fb46-40c2-945f-c75c3b30af54" />

https://github.com/user-attachments/assets/d506013d-6b06-4b5a-ae29-0b792dd9714a




## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl: Heartbeat
- add: A máscara de gás SWAT agora modifica sua voz igual a dreadsuit.
