### PR TITLE
Revert "Fashion tax beret and wintercoat (#6165)"

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -220,6 +220,7 @@
     - Recyclable
     - WhitelistChameleon
 
+# TODO: Make a single ClothingHeadHatArmoreredBeret in goob namespace so all these items dont need to have armor values listed seperately, since they wont have seperate armor values ANYWAY!
 - type: entity
   parent: [ClothingHeadHatBeret, BaseSecurityContraband] #goobstation - contraband marking
   id: ClothingHeadHatBeretSecurity
@@ -238,6 +239,21 @@
     - CorgiWearable
     - HamsterWearable
     - WhitelistChameleon
+  - type: Armor # Goob
+    coverage:
+    - Head
+    traumaDeductions:
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.2
+      VeinsDamage: 0
+      NerveDamage: 0
+    modifiers:
+      coefficients:
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.8
 
 - type: entity
   parent: [ClothingHeadHatBeret, BaseSecurityContraband] #goobstation - contraband marking
@@ -253,6 +269,21 @@
     tags:
     - ClothMade
     - WhitelistChameleon
+  - type: Armor # Goob
+    coverage:
+    - Head
+    traumaDeductions:
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.2
+      VeinsDamage: 0
+      NerveDamage: 0
+    modifiers:
+      coefficients:
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.8
 
 - type: entity
   parent: ClothingHeadHatBeret
@@ -348,6 +379,21 @@
     - Recyclable
     - HamsterWearable
     - WhitelistChameleon
+  - type: Armor # Goob
+    coverage:
+    - Head
+    traumaDeductions:
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.2
+      VeinsDamage: 0
+      NerveDamage: 0
+    modifiers:
+      coefficients:
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.8
 
 - type: entity
   parent: [ClothingHeadHatBeretRND, BaseSecurityContraband] # Goob edit
@@ -359,6 +405,21 @@
     sprite: Clothing/Head/Hats/beret_warden.rsi
   - type: Clothing
     sprite: Clothing/Head/Hats/beret_warden.rsi
+  - type: Armor # Goob
+    coverage:
+    - Head
+    traumaDeductions:
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.2
+      VeinsDamage: 0
+      NerveDamage: 0
+    modifiers:
+      coefficients:
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.8
   - type: Tag
     tags:
     - PetWearable
@@ -389,6 +450,21 @@
     sprite: Clothing/Head/Hats/beret_brigmedic.rsi
   - type: Clothing
     sprite: Clothing/Head/Hats/beret_brigmedic.rsi
+  - type: Armor # Goob
+    coverage:
+    - Head
+    traumaDeductions:
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.2
+      VeinsDamage: 0
+      NerveDamage: 0
+    modifiers:
+      coefficients:
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.8
   - type: Tag
     tags:
     - PetWearable
@@ -468,6 +544,21 @@
     - Recyclable
     - HamsterWearable
     - WhitelistChameleon
+  - type: Armor # Goob
+    coverage:
+    - Head
+    traumaDeductions:
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.2
+      VeinsDamage: 0
+      NerveDamage: 0
+    modifiers:
+      coefficients:
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.8
 
 - type: entity
   parent: ClothingHeadBase
@@ -494,6 +585,21 @@
     sprite: Clothing/Head/Hats/centcom.rsi
   - type: Clothing
     sprite: Clothing/Head/Hats/centcom.rsi
+  - type: Armor # Goob
+    coverage:
+    - Head
+    traumaDeductions:
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.2
+      VeinsDamage: 0
+      NerveDamage: 0
+    modifiers:
+      coefficients:
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.8
   - type: Tag
     tags:
     - PetWearable
@@ -550,6 +656,21 @@
     - Recyclable
     - HamsterWearable
     - WhitelistChameleon
+  - type: Armor # Goob
+    coverage:
+    - Head
+    traumaDeductions:
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.2
+      VeinsDamage: 0
+      NerveDamage: 0
+    modifiers:
+      coefficients:
+        Blunt: 0.8
+        Slash: 0.8
+        Piercing: 0.8
+        Heat: 0.8
 
 - type: entity
   parent: [ ClothingHeadBase, BaseSecurityContraband ] # Goob edit
@@ -561,6 +682,21 @@
     sprite: Clothing/Head/Hats/greyfedora.rsi
   - type: Clothing
     sprite: Clothing/Head/Hats/greyfedora.rsi
+  - type: Armor # Goob
+    coverage:
+    - Head
+    traumaDeductions:
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.2
+      VeinsDamage: 0
+      NerveDamage: 0
+    modifiers:
+      coefficients:
+        Blunt: 0.8
+        Slash: 0.8
+        Piercing: 0.8
+        Heat: 0.8
   - type: Tag
     tags:
     - PetWearable
@@ -618,6 +754,21 @@
     - Recyclable
     - HamsterWearable
     - WhitelistChameleon
+  - type: Armor # Goob
+    coverage:
+    - Head
+    traumaDeductions:
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.2
+      VeinsDamage: 0
+      NerveDamage: 0
+    modifiers:
+      coefficients:
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.8
 
 - type: entity
   parent: ClothingHeadBase
@@ -940,6 +1091,21 @@
     sprite: Clothing/Head/Hats/warden.rsi
   - type: StealTarget
     stealGroup: ClothingHeadHatWarden
+  - type: Armor # Goob
+    coverage:
+    - Head
+    traumaDeductions:
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.2
+      VeinsDamage: 0
+      NerveDamage: 0
+    modifiers:
+      coefficients:
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.8
   - type: Tag
     tags:
     - PetWearable
@@ -1396,6 +1562,21 @@
     flavorKind: station-event-random-sentience-flavor-inanimate
     weight: 0.0002 # 5,000 times less likely than 1 regular animal
   - type: BlockMovement
+  - type: Armor # Goob
+    coverage:
+    - Head
+    traumaDeductions:
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.2
+      VeinsDamage: 0
+      NerveDamage: 0
+    modifiers:
+      coefficients:
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.8
 
 - type: entity
   parent: [ ClothingHeadBase, BaseCentcommContraband ]
@@ -1417,6 +1598,21 @@
     - Recyclable
     - WhitelistChameleon
     - HamsterWearable
+  - type: Armor # Goob
+    coverage:
+    - Head
+    traumaDeductions:
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.2
+      VeinsDamage: 0
+      NerveDamage: 0
+    modifiers:
+      coefficients:
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.8
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/Entities/Clothing/Head/soft.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/soft.yml
@@ -292,6 +292,21 @@
     sprite: Clothing/Head/Soft/secsoft.rsi
   - type: Clothing
     sprite: Clothing/Head/Soft/secsoft.rsi
+  - type: Armor # Goob
+    coverage:
+    - Head
+    traumaDeductions:
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.2
+      VeinsDamage: 0
+      NerveDamage: 0
+    modifiers:
+      coefficients:
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.8
 
 - type: entity
   parent: [ClothingHeadHeadHatBaseFlipped, ClothingHeadHatSecsoft]

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hats.yml
@@ -38,6 +38,25 @@
     tags:
     - ClothMade
     - WhitelistChameleon # We do a little bit of trolling.
+  - type: Armor
+    coverage:
+    - Head
+    traumaDeductions:
+      Dismemberment: 0.3
+      OrganDamage: 0.3
+      BoneDamage: 0.3
+      VeinsDamage: 0
+      NerveDamage: 0
+    modifiers:
+      coefficients:
+        Blunt: 0.3
+        Slash: 0.3
+        Piercing: 0.3
+        Heat: 0.3
+        Radiation: 0.75
+        Caustic: 0.75
+  - type: ExplosionResistance
+    damageCoefficient: 0.75
 
 - type: entity
   parent: [ClothingHeadBase, BaseCentcommContraband]
@@ -53,6 +72,25 @@
     tags:
     - ClothMade
     - WhitelistChameleon
+  - type: Armor
+    coverage:
+    - Head
+    traumaDeductions:
+      Dismemberment: 0.3
+      OrganDamage: 0.3
+      BoneDamage: 0.3
+      VeinsDamage: 0
+      NerveDamage: 0
+    modifiers:
+      coefficients:
+        Blunt: 0.3
+        Slash: 0.3
+        Piercing: 0.3
+        Heat: 0.3
+        Radiation: 0.75
+        Caustic: 0.75
+  - type: ExplosionResistance
+    damageCoefficient: 0.75
 
 - type: entity
   parent: [ClothingHeadBase, BaseCentcommContraband]
@@ -68,6 +106,25 @@
     tags:
     - ClothMade
     - WhitelistChameleon
+  - type: Armor
+    coverage:
+    - Head
+    traumaDeductions:
+      Dismemberment: 0.3
+      OrganDamage: 0.3
+      BoneDamage: 0.3
+      VeinsDamage: 0
+      NerveDamage: 0
+    modifiers:
+      coefficients:
+        Blunt: 0.3
+        Slash: 0.3
+        Piercing: 0.3
+        Heat: 0.3
+        Radiation: 0.75
+        Caustic: 0.75
+  - type: ExplosionResistance
+    damageCoefficient: 0.75
 
 - type: entity
   parent: [ClothingHeadBase, BaseCentcommContraband]
@@ -83,6 +140,25 @@
     tags:
     - ClothMade
     - WhitelistChameleon # We do a little bit of trolling.
+  - type: Armor
+    coverage:
+    - Head
+    traumaDeductions:
+      Dismemberment: 0.3
+      OrganDamage: 0.3
+      BoneDamage: 0.3
+      VeinsDamage: 0
+      NerveDamage: 0
+    modifiers:
+      coefficients:
+        Blunt: 0.3
+        Slash: 0.3
+        Piercing: 0.3
+        Heat: 0.3
+        Radiation: 0.75
+        Caustic: 0.75
+  - type: ExplosionResistance
+    damageCoefficient: 0.75
 
 - type: entity
   parent: [ClothingHeadBase, BaseCentcommContraband]
@@ -98,6 +174,25 @@
     tags:
     - ClothMade
     - WhitelistChameleon
+  - type: Armor
+    coverage:
+    - Head
+    traumaDeductions:
+      Dismemberment: 0.3
+      OrganDamage: 0.3
+      BoneDamage: 0.3
+      VeinsDamage: 0
+      NerveDamage: 0
+    modifiers:
+      coefficients:
+        Blunt: 0.3
+        Slash: 0.3
+        Piercing: 0.3
+        Heat: 0.3
+        Radiation: 0.75
+        Caustic: 0.75
+  - type: ExplosionResistance
+    damageCoefficient: 0.75
 
 - type: entity
   parent: [ClothingHeadBase, BaseFoldable, BaseCentcommContraband]
@@ -123,6 +218,25 @@
     - state: icon-up
       map: ["foldedLayer"]
       visible: false
+  - type: Armor
+    coverage:
+    - Head
+    traumaDeductions:
+      Dismemberment: 0.3
+      OrganDamage: 0.3
+      BoneDamage: 0.3
+      VeinsDamage: 0
+      NerveDamage: 0
+    modifiers:
+      coefficients:
+        Blunt: 0.3
+        Slash: 0.3
+        Piercing: 0.3
+        Heat: 0.3
+        Radiation: 0.75
+        Caustic: 0.75
+  - type: ExplosionResistance
+    damageCoefficient: 0.75
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/helmets.yml
@@ -156,6 +156,22 @@
   id: ClothingHeadHatCowboyBrownRobust
   name: authentic brown cowboy hat
   description: "\"This station ain't big enough for the two of us.\""
+  components:
+    - type: Armor
+      coverage:
+      - Head
+      traumaDeductions:
+        Dismemberment: 0.2
+        OrganDamage: 0.2
+        BoneDamage: 0.2
+        VeinsDamage: 0
+        NerveDamage: 0
+      modifiers:
+        coefficients:
+          Blunt: 0.7
+          Slash: 0.7
+          Piercing: 0.7
+          Heat: 0.8
 
 # Shitchap
 - type: entity


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## Sobre a PR
Reverte o commit 9dce40e119461a55901858dc73c0e982562fae5a.

## Por quê? / Balanceamento
Não acho justo remover a proteção de TODOS os chapéus do jogo, principalmente, as boinas da Segurança. E as mudanças nos casacos de inverno já foram revertidos no Goob de qualquer forma.

## Detalhes Tecnicos
Todos os chapéus e boinas que perderam proteção voltam a ter seus valores antigos. A mudança nos casacos de inverno também foi revertida.

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione uma entrada para changelog do servidor, bote o emoji :cl: e siga com as mudanças assim como o exemplo.
:cl: em branco fara com que seu nome na changelog apareça como do github, adicione um nome depois do emoji para mudar seu nome na changelog. -->
:cl: SrKolobanov
- fix: Chapéus e boinas voltam a ter seus valores de proteção antigos.
