### PR TITLE
Faça máquinas de venda vitais serem grátis

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -2611,6 +2611,7 @@
   components:
   - type: VendingMachine
     pack: TankDispenserEVAInventory
+    paidItems: false # GabyStation -> Economy    
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/tankdispenser.rsi #TODO add visualiser for remaining tanks as layers
     state: dispenser

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -403,6 +403,7 @@
   components:
   - type: VendingMachine
     pack: AmmoVendInventory
+    paidItems: false # GabyStation -> Economy
     offState: off
     brokenState: broken
     normalState: normal-unshaded
@@ -429,6 +430,7 @@
   components:
   - type: VendingMachine
     pack: BoozeOMatInventory
+    paidItems: false # GabyStation -> Economy
     offState: off
     brokenState: broken
     normalState: normal-unshaded
@@ -498,6 +500,7 @@
   components:
   - type: VendingMachine
     pack: PTechInventory
+    paidItems: false # GabyStation -> Economy
     offState: off
     brokenState: broken
     normalState: normal-unshaded
@@ -1097,6 +1100,7 @@
   components:
   - type: VendingMachine
     pack: MagiVendInventory
+    paidItems: false # GabyStation -> Economy
     offState: off
     brokenState: broken
     normalState: normal-unshaded
@@ -1300,6 +1304,7 @@
     normalState: normal-unshaded
     ejectState: eject-unshaded
     denyState: deny-unshaded
+    paidItems: false # GabyStation -> Economy
   - type: DatasetVocalizer
     dataset: SecTechAds
   - type: SpeakOnUIClosed
@@ -1344,6 +1349,7 @@
   - type: VendingMachine
     pack: MegaSeedServitorInventory
     offState: off
+    paidItems: false # GabyStation -> Economy
     brokenState: broken
     normalState: normal-unshaded
     ejectState: eject-unshaded
@@ -1428,6 +1434,7 @@
   components:
   - type: VendingMachine
     pack: SustenanceInventory
+    paidItems: false # GabyStation -> Economy    
     dispenseOnHitChance: 0.25
     dispenseOnHitThreshold: 2
     offState: off
@@ -2508,6 +2515,7 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+    paidItems: false # GabyStation -> Economy
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/centdrobe.rsi
     layers:
@@ -2625,6 +2633,7 @@
   components:
   - type: VendingMachine
     pack: TankDispenserEngineeringInventory
+    paidItems: false # GabyStation -> Economy
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/tankdispenser.rsi #TODO add visualiser for remaining tanks as layers
     layers:
@@ -2644,6 +2653,7 @@
     normalState: normal
     denyState: deny
     ejectDelay: 2
+    paidItems: false # GabyStation -> Economy
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/chemvend.rsi
     layers:


### PR DESCRIPTION
## Sobre a PR
Faz o sustenance vendor, chemvend, vendedor de tanques de gás, vendedor de sementes, booze-o-mat e sectéc serem grátis de usar

## Por quê? / Balanceamento
Sustenance vendor: É pra prisoneiro, eles normalmente não tem nanobank.
Chemvend: Quimicos são infinitos agora, é so uma incoveniencia ser pago.
Vendedor de tanques de gás: Idiota fazer ser pago, pois normalmente mappers colocam esses vendedores para os engenheiros pegarem tanques de plasma pra singu, ser pago significa que não da pra fazer a singu rapidamente.
Booze-O-Mat: Foda não poder fazer mais bebidas pois ninguem paga pelas bebidas do bar e todo copo custa 10 spesos e você recebe 25 spesos de salário.
Vendedor de sementes: Pra QUE. Deixa os botanistas COMPRAR AS SEMENTES DELES. Além do fato que normalmente tem uma na prisão pros prisoneiros usarem também.
Sectéc: Não faz muito sentido fazer seguranças pagar pelas algemas deles, e custa tipo 100+ spesos comprar um escudo. Estou aberto a discussão sobre se faz sentido deixar pago ou não.

## Detalhes Tecnicos
eu so adicionei paid items: false aos que eu disse, testei no jogo e está funcionando.

## Anexos
<img width="240" height="113" alt="image" src="https://github.com/user-attachments/assets/36439d4e-6abe-44c7-ae6f-668e0b9c9205" />


## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl: Heartbeat
- tweak: Várias maquinas de venda não são pagas mais. 
- tweak: Prisoneiros não morrem por não poder comprar comida mais.
