### PR TITLE
Fix ao ID de prisoneiro (o trabalho)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -221,6 +221,34 @@
     job: Passenger
 
 - type: entity
+  parent: IDCardStandard
+  id: PrisonerIDCardJob
+  name: prisoner ID card
+  description: A generically printed ID card for scummy prisoners.
+  components:
+  - type: Sprite
+    layers:
+    - state: orange
+  - type: Item
+    heldPrefix: orange
+  - type: Access
+    tags:
+    - GenpopEnter
+  - type: GenpopIdCard
+  - type: IdCard
+    jobTitle: job-name-prisoner
+    jobIcon: JobIconPrisoner
+    canMicrowave: false
+  - type: Tag
+    tags:
+    - DoorBumpOpener
+    - WhitelistChameleon
+    - WhitelistChameleonIdCard
+    - Recyclable
+  - type: StaticPrice # these are infinitely producible.
+    price: 0
+
+- type: entity
   parent: PassengerIDCard
   id: TechnicalAssistantIDCard
   name: technical assistant ID card

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -234,7 +234,6 @@
   - type: Access
     tags:
     - GenpopEnter
-  - type: GenpopIdCard
   - type: IdCard
     jobTitle: job-name-prisoner
     jobIcon: JobIconPrisoner

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -222,7 +222,7 @@
 
 - type: entity
   parent: IDCardStandard
-  id: PrisonerIDCardJob
+  id: PrisonerIDCardJob # GabyStation
   name: prisoner ID card
   description: A generically printed ID card for scummy prisoners.
   components:

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Devices/pda.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   parent: BasePDA
   id: PrisonerPDA

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Devices/pda.yml
@@ -10,6 +10,6 @@
         !type:String
         harmony-pda-prisoner
   - type: Pda
-    id: IDCard
+    id: PrisonerIDCardJob
   - type: Icon
     state: harmony-pda-prisoner

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Devices/pda.yml
@@ -10,6 +10,6 @@
         !type:String
         harmony-pda-prisoner
   - type: Pda
-    id: PrisonerIDCard
+    id: IDCard
   - type: Icon
     state: harmony-pda-prisoner


### PR DESCRIPTION
## Sobre a PR
Faz o ID de prisoneiro funcionar igual a um ID normal.

## Por quê? / Balanceamento
Vez após vez, eu vejo a mesma coisa acontecer:
- Prisoneiro chega na estação
- É levado a genpop pela sec
- Ele sai, pois ele tem o acesso de leavegenpop pois o tempo de prisão não foi definido.
E pra que?
Essa PR faz com que o ID de prisoneiro seja igual a um ID normal, permitindo trocar o acesso, e removendo o acesso a leavegenpop.

## Detalhes Tecnicos
Fiz um tipo de ID novo que é uma copia do ID de prisoneiro mas não tem o componente de ser um ID da genpop, e muda o PDA de prisoneiro pra ter esse ID.
Nota: Eu TENTEI fazer com que ele tem acesso a enter genpop mas simplesmente não funcionou. 

## Anexos
<img width="739" height="406" alt="image" src="https://github.com/user-attachments/assets/c1275712-dae6-46a3-937c-4d47ac6b4166" />
^Agora pode trocar o acesso do ID deles, se eles pedirem liberdade condicional. Antes, precisava trocar o ID completamente.

## Requirimentos
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl:
- tweak: Agora você pode alterar o acesso do ID do prisoneiro (o trabalho.)
- fix: Prisoneiros não tem mais acesso pra sair da genpop.