### PR TITLE
buff spray painter

### DIFF
--- a/Content.Shared/SprayPainter/Components/SprayPainterAmmo.cs
+++ b/Content.Shared/SprayPainter/Components/SprayPainterAmmo.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.SprayPainter.Components;

--- a/Content.Shared/SprayPainter/Components/SprayPainterAmmo.cs
+++ b/Content.Shared/SprayPainter/Components/SprayPainterAmmo.cs
@@ -13,5 +13,5 @@ public sealed partial class SprayPainterAmmoComponent : Component
     /// The value by which the charge in the spray painter will be recharged.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public int Charges = 15;
+    public int Charges = 30; //Gaby
 }

--- a/Content.Shared/SprayPainter/Components/SprayPainterAmmo.cs
+++ b/Content.Shared/SprayPainter/Components/SprayPainterAmmo.cs
@@ -17,5 +17,5 @@ public sealed partial class SprayPainterAmmoComponent : Component
     /// The value by which the charge in the spray painter will be recharged.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public int Charges = 30; //Gaby
+    public int Charges = 15;
 }

--- a/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
@@ -51,8 +51,8 @@
     qualities:
     - Painting
   - type: LimitedCharges
-    maxCharges: 15
-    lastCharges: 15
+    maxCharges: 30 # Gaby
+    lastCharges: 30 # Gaby
   - type: PhysicalComposition
     materialComposition:
       Steel: 100

--- a/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
@@ -80,6 +80,7 @@
   description: A cartridge of highly compressed paint, commonly used in spray painters.
   components:
   - type: SprayPainterAmmo
+    charges: 30 # GabyStation
   - type: Sprite
     sprite: Objects/Tools/spray_painter.rsi
     state: ammo


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## Sobre a PR
Aumenta a carga do spray de tinta e da munição.

## Por quê? / Balanceamento
A quantidade de tinta no spray e na munição mal dava para pintar alguma coisa antes de acabar.

## Detalhes Tecnicos
Apenas mudanças simples.

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [ ] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione uma entrada para changelog do servidor, bote o emoji :cl: e siga com as mudanças assim como o exemplo.
:cl: em branco fara com que seu nome na changelog apareça como do github, adicione um nome depois do emoji para mudar seu nome na changelog. -->

:cl:

- tweak: Agora spray de tinta tem mais cargas.

