### PR TITLE
tweak: verifica se a luva/máscara são apropriadas

### DIFF
--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -56,6 +56,7 @@ using Content.Shared._Gabystation.CCVar;
 using Content.Shared.Silicons.Borgs.Components;
 using Content.Shared._EinsteinEngines.Silicon.Components;
 using Content.Shared._Shitmed.Surgery;
+using Content.Shared.Tag;
 
 namespace Content.Shared._Shitmed.Medical.Surgery;
 
@@ -72,6 +73,9 @@ public abstract partial class SharedSurgerySystem
     private float _sepsisLocationPenalty;
     private float _sepsisCrowdingPenalty;
     private float _crowdingCheckRange;
+
+    private static readonly ProtoId<TagPrototype> SurgicalMaskTag = "SurgicalMask";
+    private static readonly ProtoId<TagPrototype> SterilGlovesTag = "SterilGloves";
 
     private void InitializeSteps()
     {
@@ -752,9 +756,16 @@ public abstract partial class SharedSurgerySystem
 
         bool IsSanitazed(EntityUid ent)
         {
-            return HasComp<SanitizedComponent>(ent)
-                || _inventory.TryGetSlotEntity(ent, "gloves", out var _)
-                && _inventory.TryGetSlotEntity(ent, "mask", out var _);
+            if (HasComp<SanitizedComponent>(ent))
+                return true;
+
+            var isUsingGloves = _inventory.TryGetSlotEntity(ent, "gloves", out var gloveEnt)
+                && _tag.HasTag(gloveEnt.Value, SterilGlovesTag);
+
+            var isUsingMask = _inventory.TryGetSlotEntity(ent, "mask", out var maskEnt)
+                && _tag.HasTag(maskEnt.Value, SurgicalMaskTag);
+
+            return isUsingGloves && isUsingMask;
         }
     }
 

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
@@ -55,6 +55,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Configuration;
 using Content.Shared.Body.Organ;
+using Content.Shared.Tag;
 
 namespace Content.Shared._Shitmed.Medical.Surgery;
 
@@ -85,6 +86,7 @@ public abstract partial class SharedSurgerySystem : EntitySystem
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] protected readonly StatusEffectsSystem Status = default!;
+    [Dependency] private readonly TagSystem _tag = defaul!;
 
     private EntityQuery<BodyComponent> _bodyQuery;
     private EntityQuery<StackComponent> _stackQuery;

--- a/Resources/Prototypes/_Gabystation/tags.yml
+++ b/Resources/Prototypes/_Gabystation/tags.yml
@@ -31,3 +31,9 @@
 
 - type: Tag
   id: ModsuitHandUpgrade
+
+- type: Tag
+  id: SurgicalMask
+
+- type: Tag
+  id: SterilGloves


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR
Para evitar a contaminação de uma cirurgia basta ter algo equipado no lugar da máscara e algo nas luvas. Então, literalmente qualquer coisa, incluindo um cigarro ou máscara de solda, serve como máscara ou como luva própria para cirurgia.

Esse PR adiciona um novo marcador para garantir que apenas acessórios médicos sejam efetivos para combater a sepse.

## Detalhes técnicos
Adiciona duas novas tags: `SurgicalMask` e `SterilGloves`. As máscaras e luvas, respectivamente, devem ser marcadas com elas para que a cirurgia não cause sepse no paciente. Pessoas ao redor da cirurgia também precisam estar em conformidade para garantir a esterilidade. 

## Requerimentos
- [ ] Adicionar a tag nos itens devidos.

**Changelog**
:cl:
- tweak: Apenas acessórios médicos próprios previnem a contaminação de uma cirurgia. Use cigarros e máscaras de solda como máscara se quiser matar seus pacientes!