### PR TITLE
Remove acesso de bartender do diarista e muda o acesso do booze-o-mat pra serviço

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -451,7 +451,7 @@
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: AccessReader
-    access: [["Bar"]]
+    access: [["Service"]]
   - type: GuideHelp
     guides:
     - Bartender

--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -90,10 +90,9 @@
   access:
   - Service
   - Maintenance
-  - Bar
+#  - Bar Gabystation Não. Diarista ser um tider com uma espingarda é muito OP. Resulta em o unico motivo que pessoas pegam esse trabalho ser pra pegar espingarda.
   - Kitchen
-  extendedAccess:
-  - Hydroponics
+  - Hydroponics #Gabystation Isso tava em extended access porque?
   special: # goob
   - !type:AddImplantSpecial # Service workers can understand a chef's communications.
     implants: [ BasicSpaceItalianTranslatorImplant ]


### PR DESCRIPTION
## Sobre a PR
O diarista não tem mais acesso de bar, mas ainda pode servir drinques, pois agora o booze-o-mat é acessível pelo serviço inteiro. 
Eu também dei acesso de hidroponica pra eles, pois tipo, porque eles não teriam acesso a hidroponica?
## Por quê? / Balanceamento
O tider com acesso de serviço não merece um colete e uma espingarda.

## Detalhes Tecnicos
Yaml meu amado.

## Anexos


<img width="453" height="532" alt="Captura de tela 2026-03-21 202105" src="https://github.com/user-attachments/assets/564dcb78-3121-43ad-8863-8468d8cd2e13" />


https://github.com/user-attachments/assets/7df7b40d-82de-45f1-920f-8856c8d847d2




## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl: Heartbeat
- tweak: Diarista não tem mais acesso ao armário do bartender, mas o booze-o-mat agora é acessível por todo o serviço.
