### PR TITLE
syringe resistance to hardsuits and modsuits

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -375,6 +375,7 @@
   - type: Tag
     tags:
     - Hardsuit
+    - SyringeArmor
     - WhitelistChameleon
     - PlasmamanSafe # EE Plasmeme Change
   - type: ProtectedFromStepTriggers

--- a/Resources/Prototypes/_Goobstation/Changeling/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Entities/Clothing/OuterClothing/armor.yml
@@ -74,6 +74,9 @@
     cancel: true
   - type: StaminaResistance
     damageCoefficient: 0.4
+  - type: Tag
+    tags:
+    - SyringeArmor
   - type: HideClothingLayerClothing
     hiddenSlots:
     - jumpsuit

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/modsuit.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/modsuit.yml
@@ -43,6 +43,7 @@
   - type: Tag
     tags:
     - PlasmamanSafe
+    - SyringeArmor
   - type: IgniteFromGasImmunity
     parts:
     - BodyMiddle


### PR DESCRIPTION
## Sobre a PR
added the type SyringeArmor to modsuits and hardsuits 

## Por quê? / Balanceamento
to prevent character being shot with syringes by syringe guns filled with toxins and other substances, preventing powergaming from CMO players

## Detalhes Tecnicos
- type: Tag
    tags:
    - SyringeArmor
    
    added to base_clothingouter.yml on ClothingOuterHardsuitBase and modsuit.yml on ClothingOuterModsuitBase

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos a esta PR ou não precisa de imagens in-game.

**Changelog**
:cl:
- add: Os trajes agora são imunes a tiros de seringa.

