### PR TITLE
Torna Revolucionarios e Xenos um modo mais comum de aparecer no Secret+ (E extras)

### DIFF
--- a/Resources/Locale/pt-BR/_Goobstation/set-selector/selectable-sets.ftl
+++ b/Resources/Locale/pt-BR/_Goobstation/set-selector/selectable-sets.ftl
@@ -145,7 +145,7 @@ selectable-set-syndicate-infiltration-name = Pacote Infiltração
 selectable-set-syndicate-infiltration-description =
     Um pacote que contém um kit de infiltração completo. Uma das maiores armas da guerra é a informação.
     Contém: 1 Cartão de Agente, Kit Camaleão, 1 Máscara de Voz, 1 Fake mindshield,
-    placa de comunicação da Central, bengala falsa,
+    placa de comunicação da Central, bengala falsa, 1 Modificador de DNA, 1 Access Breaker
     e uma chave de criptografia do sindicato e da estação.
 
 selectable-set-syndicate-piromaniac-name = Pacote Piromániaco

--- a/Resources/Prototypes/_Gabystation/Catalog/selectable_sets.yml
+++ b/Resources/Prototypes/_Gabystation/Catalog/selectable_sets.yml
@@ -90,6 +90,8 @@
   - ClothingBackpackChameleonFill
   - AgentIDCard
   - FakeMindShieldImplanter
+  - DnaScramblerImplanter
+  - AccessBreaker
 
 - type: selectableSet
   id: SyndicatePiromaniacSet

--- a/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
@@ -22,8 +22,8 @@
     Traitor: 0.20
     Changeling: 0.10
     Nukeops: 0.05
-    Revolutionary: 0.15 
-    XenomorphsInfestationRoundstart: 0.05
+    Revolutionary: 0.15 # GabyStation 0.05 -> 0.15
+    XenomorphsInfestationRoundstart: 0.05 # GabyStation
     Zombie: 0.04
     Heretic: 0.11
     BlobGameMode: 0.05

--- a/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
@@ -22,7 +22,8 @@
     Traitor: 0.20
     Changeling: 0.10
     Nukeops: 0.05
-    Revolutionary: 0.05
+    Revolutionary: 0.15 
+    XenomorphsInfestationRoundstart: 0.05
     Zombie: 0.04
     Heretic: 0.11
     BlobGameMode: 0.05

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -31,7 +31,8 @@
     Changeling: 0.10
     Heretic: 0.11
     CorporateAgent: 0.025
-    XenomorphsInfestationRoundstart: 0.02
+    Revolutionary: 0.15
+    XenomorphsInfestationRoundstart: 0.05
 
 # important note: those (and especially the above) weights aren't entirely accurate,
 # as secret+ can randomly decide it's not going to use this gamerule
@@ -46,14 +47,14 @@
     Changeling: 0.10
     Heretic: 0.11
     Nukeops: 0.05
-    Revolutionary: 0.05
+    Revolutionary: 0.15
     Zombie: 0.04 # in search of how to make a rule always run alone? just tag it with LoneRunRule like zombies are
     BlobGameMode: 0.05
     Wizard: 0.025
     CosmicCult: 0.05
     BloodCult: 0.05 # Gabystation change
     CorporateAgent: 0.025
-    XenomorphsInfestationRoundstart: 0.02
+    XenomorphsInfestationRoundstart: 0.05
     OopsAllThieves: 0.02
 
 # all roundstart antags
@@ -66,14 +67,14 @@
     Changeling: 0.10
     Heretic: 0.11
     Nukeops: 0.05
-    Revolutionary: 0.05
+    Revolutionary: 0.15
     Zombie: 0.04
     BlobGameMode: 0.05
     Wizard: 0.025
     CosmicCult: 0.05
     BloodCult: 0.05 # Gabystation change
     CorporateAgent: 0.025
-    XenomorphsInfestationRoundstart: 0.02
+    XenomorphsInfestationRoundstart: 0.05
 
 
 # ⠀⠀⠀⠀⠀⠀⠀⢀⡀⠴⠤⠤⠴⠄⡄⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -31,8 +31,8 @@
     Changeling: 0.10
     Heretic: 0.11
     CorporateAgent: 0.025
-    Revolutionary: 0.15
-    XenomorphsInfestationRoundstart: 0.05
+    Revolutionary: 0.15 # GabyStation
+    XenomorphsInfestationRoundstart: 0.05 # GabyStation 0.02 -> 0.05
 
 # important note: those (and especially the above) weights aren't entirely accurate,
 # as secret+ can randomly decide it's not going to use this gamerule
@@ -47,14 +47,14 @@
     Changeling: 0.10
     Heretic: 0.11
     Nukeops: 0.05
-    Revolutionary: 0.15
+    Revolutionary: 0.15 # GabyStation 0.05 -> 0.15
     Zombie: 0.04 # in search of how to make a rule always run alone? just tag it with LoneRunRule like zombies are
     BlobGameMode: 0.05
     Wizard: 0.025
     CosmicCult: 0.05
     BloodCult: 0.05 # Gabystation change
     CorporateAgent: 0.025
-    XenomorphsInfestationRoundstart: 0.05
+    XenomorphsInfestationRoundstart: 0.05 # GabyStation 0.02 -> 0.05
     OopsAllThieves: 0.02
 
 # all roundstart antags
@@ -67,14 +67,14 @@
     Changeling: 0.10
     Heretic: 0.11
     Nukeops: 0.05
-    Revolutionary: 0.15
+    Revolutionary: 0.15 # GabyStation 0.05 -> 0.15
     Zombie: 0.04
     BlobGameMode: 0.05
     Wizard: 0.025
     CosmicCult: 0.05
     BloodCult: 0.05 # Gabystation change
     CorporateAgent: 0.025
-    XenomorphsInfestationRoundstart: 0.05
+    XenomorphsInfestationRoundstart: 0.05 # GabyStation 0.02 -> 0.05
 
 
 # ⠀⠀⠀⠀⠀⠀⠀⢀⡀⠴⠤⠤⠴⠄⡄⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀


### PR DESCRIPTION
## Sobre a PR
Revs e Xenos mais comuns

também para não criar outra PR, fiz algumas correções simples em um kit do Sindicato que faltou coisa.
## Por quê? / Balanceamento
Xenos estão mal aparecendo no jogo assim como os revs, ja que existem muitos outros antags com porcetagens superiores

## Detalhes Tecnicos
YML

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**

:cl:
- tweak: Mudança no surgimento de revs e xenos (agora mais comuns).
- add: Adicionado access breaker e DNA scrambler no pacote infiltração.

