### PR TITLE
Câmeras pras capas do HOS

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -72,7 +72,7 @@
     stealGroup: HeadCloak
 
 - type: entity
-  parent: [ClothingNeckBase, BaseCommandContraband]
+  parent: [ClothingNeckBase, BaseCommandContraband, SurveillanceWirelessCameraBodySecurity]
   id: ClothingNeckCloakHos
   name: head of security's cloak
   description: An exquisite dark and red cloak fitting for those who can assert dominance over wrongdoers. Take a stab at being civil in prosecution!

--- a/Resources/Prototypes/Entities/Clothing/Neck/mantles.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/mantles.yml
@@ -57,7 +57,7 @@
     sprite: Clothing/Neck/mantles/hopmantle.rsi
 
 - type: entity
-  parent: [ClothingNeckBase, BaseCommandContraband]
+  parent: [ClothingNeckBase, BaseCommandContraband, SurveillanceWirelessCameraBodySecurity]
   id: ClothingNeckMantleHOS
   name: head of security's mantle
   description: Shootouts with syndicate agents are just another Tuesday for this HoS. This mantle is a symbol of commitment to the station.
@@ -98,4 +98,4 @@
   - type: Sprite
     sprite: Clothing/Neck/mantles/mantle.rsi
   - type: Clothing
-    sprite: Clothing/Neck/mantles/mantle.rsi 
+    sprite: Clothing/Neck/mantles/mantle.rsi

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Neck/ensembles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Neck/ensembles.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Goob Station Contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   parent: [ClothingNeckBase, BaseCommandContraband]
   id: ClothingNeckEnsembleCaptain

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Neck/ensembles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Neck/ensembles.yml
@@ -150,7 +150,7 @@
           sprite: _Goobstation/Clothing/Neck/Ensembles/cmo.rsi
           state: mantlewings-icon
 - type: entity
-  parent: [ClothingNeckBase, BaseCommandContraband]
+  parent: [ClothingNeckBase, BaseCommandContraband, SurveillanceWirelessCameraBodySecurity]
   id: ClothingNeckEnsembleHeadOfSecurity
   name: head of security's ensemble
   description: Stained with the blood of tiders, and the tears of cadets. The word "shitsec" brings you joy, a tear to your eye.


### PR DESCRIPTION
## Sobre a PR
Adiciona uma câmera sem fio as capas do hos, igual a senior officer poncho.

## Por quê? / Balanceamento
Se os secs conseguem ter drip e ficar com câmera sem gastar espaço, porque o hos não pode?
também to recebendo gaby coin pra fazer sooo

## Detalhes Tecnicos
Eu adicionei o parent de câmera sem fio pra mantle, ensemble e capa.
Testei no jogo e tava funcionando.

## Anexos
Sem anexo dessa vez, to fazendo PR por parsec num laptop e não combina muito bem com gravação nvidia.

## Requirimentos
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl: Heartbeat
- tweak: A capa, mantle e ensemble do HOS agora tem uma câmera.
