### PR TITLE
Atualização regra de roleplay 13

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR12SecComStandard.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR12SecComStandard.xml
@@ -25,7 +25,7 @@
   - Um Oficial da Segurança aceita um suborno para ignorar um crime ou deixar um criminoso fugir da prisão.
   - O Capitão envia uma arte ASCII nos anúncios da estação do Trollface.
   - O Capitão declara que todo contrabando agora é permitido.
-  - O Comando ou a Segurança permite o uso de contrabandos, mesmo que fora de emergências.
+  - O Comando ou a Segurança permitir o uso de contrabandos fora de emergências.
   - Um agente do Sindicato matou três Oficiais de Segurança, então o HoS oferece um acordo em que ele irá mandar todas as armas da Armory pro espaço se o agente parar de matar pessoas.
   - O Capitão vai à Armory e se arma sem nenhum motivo em específico.
   - Os membros do Comando decidem rebaixar o Capitão para ganhar mais poder para si mesmos, ou em retaliação de uma decisão que eles não concordaram, invés de ser pela decisão ter sido realmente prejudicial à estação.

--- a/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR13SpaceLaw.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR13SpaceLaw.xml
@@ -2,7 +2,9 @@
   # Regra de Roleplay 13 - Seguranças e Comandos devem seguir a Space Law e Procedimentos Operacional Padrão.
   Todo membro do Comando e Segurança que não sejam antagonistas devem obedecer a  [textlink="Space Law" link="SpaceLaw"]. Isso inclui não-antagonistas que são promovidos ou ganham a posição durante o round. Isso também inclui não-antagonistas que estão desempenhando o papel de segurança.
 
-  Isso proíbe o uso de itens do Sindicato fora de situações emergenciais, incluindo o uso de Uplinks pelo Comando ou Segurança. Isso também proíbe a preparação de itens do Sindicato para casos de emergência.
+  Isso proíbe o uso de itens do Sindicato conforme a Space Law dita, incluindo o uso de Uplinks pelo Comando ou Segurança. Isso também proíbe a preparação de itens do Sindicato para casos de emergência.
+
+  Em caso de situações emergenciais, como um alerta gamma ou a aplicação da lei marcial, onde a Space Law é suspensa, o uso de itens do sindicato é permitido para os membros do comando e segurança.
 
   ## Exemplos
   Aceitável:

--- a/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR13SpaceLaw.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR13SpaceLaw.xml
@@ -4,7 +4,7 @@
 
   Isso proíbe o uso de itens do Sindicato conforme a Space Law dita, incluindo o uso de Uplinks pelo Comando ou Segurança. Isso também proíbe a preparação de itens do Sindicato para casos de emergência.
 
-  Em caso de situações emergenciais, como um alerta gamma ou a aplicação da lei marcial, onde a Space Law é suspensa, o uso de itens do sindicato é permitido para os membros do comando e segurança.
+  Em caso de situações de suspensão da Space Law, como um alerta gamma ou a aplicação da lei marcial, o uso de itens do sindicato é permitido para os membros do comando e segurança.
 
   ## Exemplos
   Aceitável:


### PR DESCRIPTION
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## Sobre a PR
Atualização da Regra de Roleplay 13 - Seguranças e Comandos devem seguir a Space Law e Procedimentos Operacional Padrão.

## Por quê? / Balanceamento
Atualização regra de roleplay 13 para transparecer melhor o uso de itens do sindicato por parte do comando e dos seguranças.

## Detalhes Tecnicos
alterada o .ftl em "Gaby-Station\Resources\ServerInfo\Guidebook\ServerRules\RoleplayRules\RuleR13SpaceLaw.xml" na linha 5 que diz agora "Isso proíbe o uso de itens do Sindicato conforme a Space Law dita, incluindo o uso de Uplinks pelo Comando ou Segurança. Isso também proíbe a preparação de itens do Sindicato para casos de emergência." e adiciona a linha 7 que diz " Em caso de situações de suspensão da Space Law, como um alerta gamma ou a aplicação da lei marcial, o uso de itens do sindicato é permitido para os membros do comando e segurança.".



## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl: Administração
- tweak: Atualização regra de roleplay 13.

