### PR TITLE
retirado tunnel clown da rotação

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -211,7 +211,7 @@
     - id: MimeAssassinMidround # Goobstation - New Midrounds
     - id: DarkPriestMidround # Goobstation - New Midrounds
     - id: VoxRaidersMidround # Goobstation - New Midrounds
-    - id: TunnelClownMidround # Goobstation
+    #- id: TunnelClownMidround # Goobstation
     #- id: WraithMidround # Goobstation - Wraith
     #TODO when midrounds are "reviewed" by the chudmins add them back
     #TODO When Slasher is Ready - id: SlasherSpawn # Goobstation - The Slasher
@@ -607,7 +607,7 @@
     startAudio:
       path: /Audio/_Gabystation/Announcements/gasleak_saae.ogg
     endAnnouncement: station-event-gas-leak-end-announcement
-    endAudio: 
+    endAudio:
       path: /Audio/_Gabystation/Announcements/gasleak_off_saae.ogg
     weight: 8
     chaos:
@@ -669,7 +669,7 @@
     startAudio:
       path: /Audio/_Gabystation/Announcements/solarflare_on_saae.ogg
     endAnnouncement: station-event-solar-flare-end-announcement
-    endAudio: 
+    endAudio:
       path: /Audio/_Gabystation/Announcements/solarflare_off_saae.ogg
     duration: 120
     maxDuration: 240


### PR DESCRIPTION
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## Sobre a PR
removido tunnel clown da rotação de ghostroles midround

## Por quê? / Balanceamento
tunnel clown estava trazendo problemas demais para os rounds

## Detalhes Tecnicos
adicionado um "#" na linha 214 da file events.yml localizada em "Gaby-Station\Resources\Prototypes\GameRules\events.yml" para retirar o tunnel clown da rotação de ghostrole 

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl: Administração
- remove: tunnel clown removido da rotação de ghostroles de meio de round!

