### PR TITLE
Conserta a capa do segurança chefe

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -79,6 +79,8 @@
   components:
   - type: Sprite
     sprite: Clothing/Neck/Cloaks/hos.rsi
+  - type: Clothing
+    sprite: Clothing/Neck/Cloaks/hos.rsi
   - type: StealTarget
     stealGroup: HeadCloak
 


### PR DESCRIPTION
## Sobre a PR
Faz a capa usar o sprite da capa invés de bodycam.

## Detalhes Tecnicos
Adicionar o parent de bodycam fudeu com o sprite de vestir especificamente pois todas as capas não tinham o componente de clothing. O ensemble e o manto estão funcionando ainda e não precisam de alteração nenhuma.

## Requirimentos
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl:
- fix: A capa do segurança chefe usa o sprite correto invés do sprite de bodycam.
