### PR TITLE
Conserta sprite de mão do escudo de bala

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -267,6 +267,7 @@
         suitstorage:
         - state: metal-backpack
     - type: Item
+      sprite: _Goobstation/Objects/Shields/riotbulletshield.rsi
       heldPrefix: ballistic
     - type: Blocking
       passiveBlockModifier:


### PR DESCRIPTION
## Sobre a PR
Faz o sprite de mão do escudo de bala anti motim funcionar.

## Detalhes Tecnicos
Idiotas do goob esqueceram de adicionar que o sprite do escudo esta em um lugar diferente. Adicionar a linha do sprite pro item consertou.

## Anexos


https://github.com/user-attachments/assets/e426d8e3-c74b-4331-bb37-df056952c3be



## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl: Heartbeat
- fix: O escudo de bala anti motim agora tem um sprite quando está sendo segurado.
