### PR TITLE
Corrige LoneOps não conseguindo declarar guerra

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -866,7 +866,7 @@
     earliestStart: 35
     weight: 6.0 # Goobstation - was 5.5
     minimumPlayers: 20 # Goobstation - was 20
-    duration: 1
+    duration: null
     maxOccurrences: 1 # Gabystation - loneops apenas uma vez por round
     chaos: # Goobstation
       Hostile: 200


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR
É o que tá no título. Os LoneOps não conseguiam declarar guerra pq a função que ouve o evento só procurava por rules ativas (que faz sentido). Mas, numa mudança de três anos atrás, colocaram para o evento durar 1 milissegundo, então ele era adicionado, inciava e era desativado logo em seguida.

## Detalhes técnicos
O campo `duration` do componente `StationEventComponent` é um campo anulável que
- se é nulo, indica que o evento não tem duração e nunca vai acabar pela passagem de tempo;
- se não é nulo, então usa esse valor como a duração em milissegundos.

A correção foi mudar o campo de 1 para `null`.

## Anexos
[2026-04-19_17.35.54.webm](https://github.com/user-attachments/assets/5df7449a-0c3f-47f2-aae6-9abc59e05cce)

## Requirimentos
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl:
- fix: Corrigido bug que fazia os LoneOps não conseguirem declarar guerra.

