### PR TITLE
adiciona dano estrutural pra buckshot

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/hitscan.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   id: ImpactEffect
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/hitscan.yml
@@ -287,6 +287,7 @@
   damage:
     types:
       Piercing: 10
+      Structural: 15
   count: 6
   spread: 15
   bullet:


### PR DESCRIPTION
## Sobre a PR
Adiciona dano estrutural para munição buckshot .50.

## Por quê? / Balanceamento
Oficiais de segurança precisam de algo pra quebrar paredes e portas.

## Detalhes Tecnicos
15 de dano estrutural por cada pellet. Eu não adicionei a slug; foi intencional.

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl: Heartbeat
- tweak: Munição chumbo grosso .50 agora causa 15 de dano estrutural por pelota.
