### PR TITLE
Genetics QOL - 2

### DIFF
--- a/Content.Client/_Wega/Genetics/Ui/DnaModifierWindow.xaml.cs
+++ b/Content.Client/_Wega/Genetics/Ui/DnaModifierWindow.xaml.cs
@@ -24,6 +24,8 @@ namespace Content.Client._Wega.Genetics.Ui;
 [GenerateTypedNameReferences]
 public sealed partial class DnaModifierWindow : FancyWindow
 {
+    private static readonly TimeSpan SingleBlockRadiationCooldown = TimeSpan.FromSeconds(0.75);
+
     [Dependency] private readonly IEntityManager _entManager = default!;
     [Dependency] private readonly IEntityNetworkManager _entNetworkManager = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
@@ -533,7 +535,7 @@ public sealed partial class DnaModifierWindow : FancyWindow
             _entNetworkManager.SendSystemNetworkMessage(new DnaModifierUpdateEvent(_console));
 
             Releveration1Button.Disabled = true;
-            _releveration1ButtonCooldown = _gameTiming.CurTime + TimeSpan.FromSeconds(2);
+            _releveration1ButtonCooldown = _gameTiming.CurTime + SingleBlockRadiationCooldown;
         }
     }
 
@@ -547,7 +549,7 @@ public sealed partial class DnaModifierWindow : FancyWindow
             _entNetworkManager.SendSystemNetworkMessage(new DnaModifierUpdateEvent(_console));
 
             Releveration2Button.Disabled = true;
-            _releveration2ButtonCooldown = _gameTiming.CurTime + TimeSpan.FromSeconds(2);
+            _releveration2ButtonCooldown = _gameTiming.CurTime + SingleBlockRadiationCooldown;
         }
     }
 

--- a/Content.Server/_Wega/Genetics/Systems/DnaModifierConsoleSystem.cs
+++ b/Content.Server/_Wega/Genetics/Systems/DnaModifierConsoleSystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Linq;
 using Content.Server.Administration;
 using Content.Server.DeviceLinking.Systems;

--- a/Content.Server/_Wega/Genetics/Systems/DnaModifierConsoleSystem.cs
+++ b/Content.Server/_Wega/Genetics/Systems/DnaModifierConsoleSystem.cs
@@ -960,17 +960,14 @@ namespace Content.Server.Genetics.System
             float changeStrength = Math.Clamp((intensity * duration) / 100f, 0f, 1f);
             changeStrength = (float)Math.Sqrt(changeStrength);
 
-            float threshold = 0.15f;
-            if (_random.NextFloat() <= threshold)
-                return baseValue.ToString("X1");
+            var maxStep = Math.Clamp((int)Math.Ceiling(15 * changeStrength), 1, 15);
+            var offset = _random.Next(1, maxStep + 1);
+            if (_random.Prob(0.5f))
+                offset *= -1;
 
-            float maxChange = 16 * changeStrength;
-            float direction = _random.NextFloat() > 0.5f ? 1 : -1;
-
-            int modifiedValue = (int)(baseValue + (direction * maxChange * _random.NextFloat())) % 16;
-
-            if (modifiedValue < 0) modifiedValue += 16;
-            else if (modifiedValue >= 16) modifiedValue -= 16;
+            int modifiedValue = (baseValue + offset) % 16;
+            if (modifiedValue < 0)
+                modifiedValue += 16;
 
             return modifiedValue.ToString("X1");
         }

--- a/Content.Shared/_Wega/Genetics/Systems/Connection/DnaClientSystem.cs
+++ b/Content.Shared/_Wega/Genetics/Systems/Connection/DnaClientSystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.Serialization;
 

--- a/Content.Shared/_Wega/Genetics/Systems/Connection/DnaClientSystem.cs
+++ b/Content.Shared/_Wega/Genetics/Systems/Connection/DnaClientSystem.cs
@@ -16,9 +16,15 @@ public sealed class DnaClientSystem : EntitySystem
 
     private void OnInit(Entity<DnaClientComponent> ent, ref ComponentInit args)
     {
+        if (TryComp<DnaServerComponent>(ent, out var localServer))
+        {
+            _dnaServer.RegisterClient((ent, localServer), (ent, ent.Comp));
+            return;
+        }
         foreach (var server in _dnaServer.GetServers())
         {
             _dnaServer.RegisterClient((server, server.Comp), (ent, ent.Comp));
+            return;
         }
     }
 

--- a/Resources/Prototypes/Entities/Structures/Machines/research.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/research.yml
@@ -113,7 +113,6 @@
           enum.PowerDeviceVisualLayers.Powered:
             True: {visible: true}
             False: {visible: false}
-  - type: DnaServer # Corvax-Wega-Genetic
   - type: AmbientOnPowered
   - type: AmbientSound
     volume: -9

--- a/Resources/Prototypes/_Wega/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_Wega/Entities/Structures/Machines/Computers/computers.yml
@@ -5,6 +5,7 @@
   description: "This interface is used to change the structure of DNA."
   components:
   - type: DnaClient
+  - type: DnaServer
   - type: DnaModifierConsole
   - type: DeviceList
   - type: DeviceNetwork

--- a/Resources/Prototypes/_Wega/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_Wega/Entities/Structures/Machines/Computers/computers.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   parent: BaseComputerAiAccess
   id: DnaModifierConsole


### PR DESCRIPTION
A genética estava muito chata no quesito tempo de espera. Antes, era necessário mudar o bloco várias vezes para alterar o hexadecimal, além de esperar 2 segundos para cada mudança. Com isso, na prática, só era possível conseguir resultados relevantes depois de cerca de 1 hora de round.

Agora, sempre que o bloco for irradiado, ele será alterado e não repetira, e o tempo de espera para irradiar foi reduzido para 0,75 segundos.



https://github.com/user-attachments/assets/1419331e-fede-4633-a4f2-e8557af55ca0



https://github.com/user-attachments/assets/aadc47be-1875-4121-a677-5a110198be5b




Changelog
🆑 Crono209
- tweak: Geneticista QOL.
- tweak: Os buffers dos computadores de geneticista foram separados.
- tweak: Agora é garantido que ao irradiar um bloco no computador de geneticista o valor dele vai mudar.

