### PR TITLE
Alteração óculos administrator glasses

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -342,7 +342,7 @@
       NerveDamage: 0
 
 - type: entity
-  parent: [ClothingEyesBase, BaseCommandContraband]
+  parent: [ClothingEyesBase, BaseCommandContraband, ShowSecurityIcons, ShowMedicalIcons]
   id: ClothingEyesGlassesCommand
   name: administration glasses
   description: Upgraded sunglasses that provide flash immunity and show ID card status.


### PR DESCRIPTION

## Sobre a PR
Adiciona secHUD, medHUD, para administrator glasses (como o do capitão)

## Por quê? / Balanceamento
Evitar a necessidade do capitão de pegar um secHUD na própria sec. 

## Detalhes Tecnicos
Só adicionei as parents showSecurityIcons, showMedIcons ao parent do glasses 

## Anexos
<img width="604" height="489" alt="image" src="https://github.com/user-attachments/assets/1aa988e6-a1fd-4876-a6c0-78a980622bd4" />
<img width="530" height="219" alt="image" src="https://github.com/user-attachments/assets/4d40b9d2-9135-45e5-96b7-60ecc2db7be0" />


## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**

:cl:Pepe
- tweak: Óculos do capitão e semelhantes ganhou secHUD e medHUD.


