### PR TITLE
Rods agora não gibbam, causam 70 de dano

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -55,6 +55,12 @@
   - type: WarpPoint
     follow: true
     location: immovable rod
+    # Dumont edit #
+    shouldGib: false
+    damage:
+      types:
+        Blunt: 70
+    # Dumont edit end #
 
 # goob edit
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -30,6 +30,10 @@
   - type: ImmovableRod
     minSpeed: 15 # Goobstation
     maxSpeed: 15 # Goobstation
+    shouldGib: false
+    damage:
+      types:
+        Blunt: 70
   - type: Physics
     bodyType: Dynamic
     linearDamping: 0
@@ -55,12 +59,6 @@
   - type: WarpPoint
     follow: true
     location: immovable rod
-    # Dumont edit #
-    shouldGib: false
-    damage:
-      types:
-        Blunt: 70
-    # Dumont edit end #
 
 # goob edit
 - type: entity


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## Sobre a PR
Todas as immovableRod agora não gibbam mais mobs, e causam 70 de dano ao invez disso.

## Por quê? / Balanceamento
Ser atingido por 1 rod é um azar que não tem como se recuperar, um evento que te da RR e não é causado por nenhum jogador.
Os players merecem ter alguma chance de recuperação ao ser atingido por um Rod, principalmente os antagonistas.

## Detalhes Tecnicos
Na entidade base com o id:ImmovableRod, foi setado shouldGib: false e o damage: Blunt: 70.
Todos os outros rods herdam componentes da entidade base, e com isso, todos os rods vão deixar de gibbar mobs.

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione uma entrada para changelog do servidor, bote o emoji :cl: e siga com as mudanças assim como o exemplo.
:cl: em branco fara com que seu nome na changelog apareça como do github, adicione um nome depois do emoji para mudar seu nome na changelog. -->
:cl:
- tweak: Rods agora não gibbam mais, e no lugar, causam 70 de dano bruto ao acertar um mob.
