### PR TITLE
Conserta shrapnel payload

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/payload.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/payload.yml
@@ -69,7 +69,7 @@
         damage: 25
       behaviors:
       - !type:TriggerBehavior
-  - type: DeleteOnTrigger
+  # Removed DeleteOnTrigger cuz it deleted the payload before it could explode. It cannot explode twice, and other grenades with this system follow this logic.
   - type: ContainerContainer
     containers:
       cluster-payload: !type:Container


### PR DESCRIPTION
## Sobre a PR
Faz o Shrapnel Payload (granada de estilhaço de sec) funcionar.

## Detalhes Tecnicos
Ele tava sendo deletado antes de poder ativar. Removendo o "delete on trigger" faz ele funcionar. Ele não pode ativar duas vezes, então não tem problema. A Shrapnel Grenade do sindicato segue essa mesma lógica também.

## Anexos

https://github.com/user-attachments/assets/ac066725-5ff6-4917-83ae-c63040ecbb2e



## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl: Heartbeat
- fix: Carga de estilhaço do fabricador de segurança funciona agora.
