### PR TITLE
fix: corrige loneops muitos tc

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -885,6 +885,7 @@
     warDeclarationMinOps: 1 # <--- GabyStation - Adicionado aqui para permitir guerra com 1 jogador
     warNukieArriveDelay: 300 # <--- GabyStation - Adicionado para manter o Lone preso por 5 minutos.
     warTcAmountPerNukie: 60 # GabyStation
+    warTcPerPlayer: 5  # GabyStation
   - type: AntagSelection
     definitions:
     - spawnerPrototype: SpawnPointLoneNukeOperative


### PR DESCRIPTION
## Sobre a PR
Ao declarar guerra os LoneOps estavam ganhando MUITOS TC's. O problema é que ao declarar guerra o jogo da tc's baseado na quantidade de jogadores e esquecemos de mudar esse valor.

Muda a quantidade de tc's por player de 20 para 5 (diminui um pouco de 33.33%).

**Changelog**
:cl:
- fix: Corrigido LoneOps ganhar 300 TC ao declarar guerra.
