### PR TITLE
Força oficiais a selecionar entre a MK58 ou a MK58 dourada

### DIFF
--- a/Resources/Locale/pt-BR/_Gabystation/entities/objects/consumable/Boxes/boxes.ftl
+++ b/Resources/Locale/pt-BR/_Gabystation/entities/objects/consumable/Boxes/boxes.ftl
@@ -1,7 +1,7 @@
 
 ent-GunKitMk58Pistol = Caixa de Mk 58
-     .desc = Uma caixa pequena contendo um Mk58 e um carregador. Vai se desmontar no momento em que você abrir.
+     .desc = Uma caixa pequena contendo uma Mk58 e um carregador. Vai se desmontar no momento em que você abrir.
 
 ent-GunKitGoldMk58Pistol = Caixa de Mk 58 dourada
-     .desc = Uma caixa pequena contendo um Mk58 dourada e um carregador. Vai se desmontar no momento em que você abrir.
+     .desc = Uma caixa pequena contendo uma Mk58 dourada e um carregador. Vai se desmontar no momento em que você abrir.
 

--- a/Resources/Locale/pt-BR/_Gabystation/entities/objects/consumable/Boxes/boxes.ftl
+++ b/Resources/Locale/pt-BR/_Gabystation/entities/objects/consumable/Boxes/boxes.ftl
@@ -1,0 +1,7 @@
+
+ent-GunKitMk58Pistol = Caixa de Mk 58
+     .desc = Uma caixa pequena contendo um Mk58 e um carregador. Vai se desmontar no momento em que você abrir.
+
+ent-GunKitGoldMk58Pistol = Caixa de Mk 58 dourada
+     .desc = Uma caixa pequena contendo um Mk58 dourada e um carregador. Vai se desmontar no momento em que você abrir.
+

--- a/Resources/Locale/pt-BR/_Gabystation/loadout.ftl
+++ b/Resources/Locale/pt-BR/_Gabystation/loadout.ftl
@@ -2,4 +2,6 @@ loadout-group-generic-jumpsuit = Macacão generico
 
 loadout-group-trinkets-job = Extra de Trabalho
 
+loadout-group-weapons-security = Armas de fogo de Segurança
+
 loadout-group-hos-lawbringerskin = Lawbringer Cosmética

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -818,6 +818,7 @@
   - TrinketsCommand #Gabystation
   - TrinketsSecurity #Gabystation
   - HoSLawbringerSkins # Gabystation
+  - WeaponsSecurityGun # Dumontstation
   - Trinkets
   - SecurityStar
   - Animals
@@ -842,6 +843,7 @@
   - SecurityShoes
   - SurvivalSecurity
   - TrinketsSecurity  #Gabystation
+  - WeaponsSecurityGun # Dumontstation
   - Trinkets
   - SecurityStar
   - Animals
@@ -866,6 +868,7 @@
   - SecurityBelt
   - SurvivalSecurity
   - TrinketsSecurity  #Gabystation
+  - WeaponsSecurityGun # Dumontstation
   - Trinkets
   - SecurityStar
   - Animals

--- a/Resources/Prototypes/Nyanotrasen/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Nyanotrasen/Loadouts/role_loadouts.yml
@@ -10,6 +10,7 @@
   - SecurityMelee
   - SurvivalSecurity
   - TrinketsSecurity
+  - WeaponsSecurityGun # Dumontstation
   - SecurityStar
   - Trinkets
   - Animals

--- a/Resources/Prototypes/Nyanotrasen/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Nyanotrasen/Loadouts/role_loadouts.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # Security
 - type: roleLoadout
   id: JobPrisonGuard

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -252,7 +252,7 @@
     id: BrigmedicPDA
     ears: ClothingHeadsetBrigmedic # EE parity like i was told to do
     belt: ClothingBeltMedicalEMTFilled
-    pocket1: WeaponPistolMk58 # EE parity, make corpsman able to carry weapons like the rest of security
+#    pocket1: WeaponPistolMk58 # EE parity, make corpsman able to carry weapons like the rest of security
     pocket2: WeaponDisabler # Goob
   storage:
     back:

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -214,11 +214,9 @@
     id: HoSPDA
     #gloves: ClothingHandsGlovesCombat - Goobstation, moved to loadouts
     ears: ClothingHeadsetAltSecurity
-    pocket1: WeaponPistolMk58
   storage:
     back:
     - Flash
-    - MagazinePistol
     - SecHypo # Goobstation
 
 - type: chameleonOutfit

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -128,11 +128,9 @@
   equipment:
     eyes: ClothingEyesGlassesSecurity
     ears: ClothingHeadsetAltSecurityRegular # Goobstation
-    pocket1: WeaponPistolMk58
   storage:
     back:
     - Flash
-    - MagazinePistol
     - SecHypo # Goobstation
 
 - type: chameleonOutfit

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -196,11 +196,9 @@
     eyes: ClothingEyesGlassesSecurityContraDetect # Goobstation
     id: WardenPDA
     ears: ClothingHeadsetAltWarden # Goobstation
-    pocket1: WeaponPistolMk58
   storage:
     back:
     - Flash
-    - MagazinePistol
     - SecHypo # Goobstation
     - ClothingMaskGasSecurity # Goobstation
 

--- a/Resources/Prototypes/_Gabystation/Entities/Objects/Consumable/Boxes/boxes.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Objects/Consumable/Boxes/boxes.yml
@@ -1,0 +1,42 @@
+
+- type: entity
+  parent: BaseItem
+  id: GunKitMk58Pistol
+  name: Mk58 pistol kit
+  description: A small box containing a Mk58 and a magazine. It'll fall apart the moment you open it.
+  components:
+  - type: SpawnItemsOnUse
+    items:
+    - id: WeaponPistolMk58
+    - id: MagazinePistol
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+  - type: Item
+    sprite: Objects/Storage/boxes.rsi
+    size: Normal
+  - type: Sprite
+    sprite: Objects/Storage/boxes.rsi
+    layers:
+      - state: box_security
+      - state: magazine
+
+- type: entity
+  parent: BaseItem
+  id: GunKitGoldMk58Pistol
+  name: golden mk58 pistol kit
+  description: A small box containing a golden Mk58 and a magazine. It'll fall apart the moment you open it.
+  components:
+  - type: SpawnItemsOnUse
+    items:
+    - id: WeaponPistolMk58Gold
+    - id: MagazinePistol
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+  - type: Item
+    sprite: Objects/Storage/boxes.rsi
+    size: Normal
+  - type: Sprite
+    sprite: Objects/Storage/boxes.rsi
+    layers:
+      - state: box_security
+      - state: magazine

--- a/Resources/Prototypes/_Gabystation/Entities/Objects/Consumable/Boxes/boxes.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Objects/Consumable/Boxes/boxes.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 
 - type: entity
   parent: BaseItem

--- a/Resources/Prototypes/_Gabystation/Loadouts/Jobs/Security/security.yml
+++ b/Resources/Prototypes/_Gabystation/Loadouts/Jobs/Security/security.yml
@@ -14,7 +14,13 @@
         time: 360000 #100 hrs
   storage:
     back:
-    - WeaponPistolMk58Gold
+    - GunKitGoldMk58Pistol
+
+- type: loadout
+  id: WeaponPistolMk58
+  storage:
+    back:
+    - GunKitMk58Pistol
 
 - type: loadout
   id: ClothingNeckRobusto

--- a/Resources/Prototypes/_Gabystation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Gabystation/Loadouts/loadout_groups.yml
@@ -66,12 +66,20 @@
   - GoldButchCleaver
 
 - type: loadoutGroup
+  id: WeaponsSecurityGun
+  name: loadout-group-weapons-security
+  minLimit: 1
+  maxLimit: 1
+  loadouts:
+  - WeaponPistolMk58Gold
+  - WeaponPistolMk58
+
+- type: loadoutGroup
   id: TrinketsSecurity
   name: loadout-group-trinkets-job
   minLimit: 0
   maxLimit: 2
   loadouts:
-  - WeaponPistolMk58Gold
   - ClothingNeckRobusto
   - ClothingNeckChoque
 

--- a/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts.yml
@@ -229,6 +229,8 @@
   - Animals
   - SecurityStar
   - GroupSpeciesBreathToolSecurity
+  - WeaponsSecurityGun #DumontStation
+  - TrinketsSecurity #Dumontstation
   # Goobstation - EE Plasmeme Change.
   - BrigmedicEnvirohelm
   - BrigmedicEnvirosuit
@@ -267,7 +269,7 @@
   - CivilianShoes # Gabystation
   - CivilianOuterClothing
   - CivilianBelt
-  
+
 # gives plasmaman a plasma breathing tank
 # other species get nothing
 - type: roleLoadout


### PR DESCRIPTION
## Sobre a PR
Remove a MK58 e pente que todos todos oficiais normalmente spawnam com, mas no loadout há uma nova aba: Armas de fogo de segurança, onde eles tem que escolher entre uma caixa de MK58 ou uma caixa de MK58 dourada.
Ambos vem com sua arma respectiva e um pente extra.
Eu também dei pro Brigmed trinkets de segurança, pq não?

## Por quê? / Balanceamento
Até agora, oficiais com mais de 100h estavam conseguindo começar com uma pistola extra, incluindo o detetive. É um dos únicos casos de tempo de jogo dando uma vantagem na gameplay excluindo desbloquear trabalhos.

## Detalhes Tecnicos
Removi a MK58 dourada dos extras de trabalho, fiz a aba nova de Armas de Fogo de segurança, removi a MK58 e pente extra de todos que tinham (exceto secclown, deixa ele tentar atirar e falhar, tbm ele n pode acessar loadout), adicionei a categoria nova para todos os que começavam com uma MK58. 
Exceto o detetive.
O detetive ja começa com a inspetor.
A caixa é 2x2 e pode ser usada para abrir. Quando aberta, ela spawna uma MK58 de seu tipo. e um pente.

## Anexos
<img width="781" height="649" alt="image" src="https://github.com/user-attachments/assets/d43fe687-1010-4915-bff6-2b6957fa257e" />

<img width="774" height="771" alt="image" src="https://github.com/user-attachments/assets/1c25a609-6b57-4a8d-958d-908d01844018" />

<img width="305" height="503" alt="image" src="https://github.com/user-attachments/assets/92695f56-53ae-4d0b-bbf1-dcbd68b07870" />

<img width="546" height="192" alt="image" src="https://github.com/user-attachments/assets/f898f605-30cf-468e-a6b0-a426b9f938de" />



## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl: Heartbeat
- remove: Detetive não pode mais começar com uma MK58 dourada.
- tweak: Agora oficiais não podem spawnar com ambas as versões da MK58. Verifiquem seu loadout!
- fix: O Clinico Brigadista agora pode selecionar um extra de trabalho de segurança e a MK58 dourada.