### PR TITLE
Permita qualquer um com acesso de logística pular bounty

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -1458,7 +1458,7 @@
     energy: 1.6
     color: "#b89f25"
   - type: AccessReader
-    access: [["Quartermaster"]]
+    access: [["Cargo"]] #Dumontstation what, do cargo techs not have the right to skip dumbass bounties if there's no QM?
   - type: GuideHelp
     guides:
     - CargoBounties


### PR DESCRIPTION
## Sobre a PR
Muda o acesso do computador de missão de logística de Quartermaster pra Cargo.

## Por quê? / Balanceamento
Algumas bounties são impossíveis na situação que a tripulação pode estar.
Se alguém ta pulando bounties que são fácil e tiver um QM, pede pro QM demitir ele. 
Técnicos de logística merecem a chance de poder avançar nas bounties se todas as atuais são impossíveis.

## Detalhes Tecnicos
Literalmente mudei UMA palavra.
Testei e tá funcionando.

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl: Heartbeat
- tweak: O computador de missão da logística agora permite qualquer um com acesso de logística pular missões.
