### PR TITLE
Balancea a medipen de luxo de minerador

### DIFF
--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Specific/Medical/hypospray.yml
@@ -106,7 +106,7 @@
   name: luxury medipen
   parent: ChemicalMedipen
   id: LuxuryMedipen
-  description: Cutting edge bluespace technology allowed Nanotrasen to compact 180u of volume into a single medipen. Contains rare and powerful chemicals used to aid in exploration of harsh environments. Chemicals relatively harmful and not as effective when used outside of low pressure.
+  description: Cutting edge bluespace technology allowed Nanotrasen to compact 120u of volume into a single medipen. Contains rare and powerful chemicals used to aid in exploration of harsh environments. Chemicals relatively harmful and not as effective when used outside of low pressure.
   components:
   - type: Sprite
     sprite: /Textures/_Lavaland/Objects/Specific/Medical/luxmedipen.rsi

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Specific/Medical/hypospray.yml
@@ -54,6 +54,54 @@
             Quantity: 10
 
 # doesn't get any better than this
+#- type: entity
+#  name: luxury medipen
+#  parent: ChemicalMedipen
+#  id: LuxuryMedipen
+#  description: Cutting edge bluespace technology allowed Nanotrasen to compact 180u of volume into a single medipen. Contains rare and powerful chemicals used to aid in exploration of harsh environments. Chemicals relatively harmful and not as effective when used outside of low pressure.
+#  components:
+#  - type: Sprite
+#    sprite: /Textures/_Lavaland/Objects/Specific/Medical/luxmedipen.rsi
+#    layers:
+#    - state: luxpen
+#      map: [ "enum.SolutionContainerLayers.Fill" ]
+#  - type: Appearance
+#  - type: SolutionContainerVisuals
+#    maxFillLevels: 1
+#    changeColor: false
+#    emptySpriteName: luxpen_empty
+#  - type: Hypospray
+#    solutionName: pen
+#    transferAmount: 180
+#    onlyAffectsMobs: false
+#    injectOnly: true
+#  - type: SolutionContainerManager
+#    solutions:
+#      pen:
+#        maxVol: 180
+#        reagents:
+#          - ReagentId: DexalinPlus
+#            Quantity: 20
+#          - ReagentId: Epinephrine # until Penthrite gets shitcoded in someday
+#            Quantity: 20
+#          - ReagentId: Oxandrolone
+#            Quantity: 20
+#          - ReagentId: SalicylicAcid
+#            Quantity: 20
+#          - ReagentId: Omnizine
+#            Quantity: 20
+#          - ReagentId: Leporazine
+#            Quantity: 20
+#          - ReagentId: TranexamicAcid
+#            Quantity: 20
+#          - ReagentId: Saline
+#            Quantity: 20
+#          - ReagentId: Luxurium
+#            Quantity: 20
+#Dumontstation note: WHAT THE FUCK? WHO DID THIS? dude i went here thinking i was just gonna have to make luxurium more specific or something but dude this is just the most insane healing item crew has access to, this needs to be completely remade
+
+
+#Nerfed pen- no longer has healing meds that can be used under normal conditions, now has miner's salve to compensate
 - type: entity
   name: luxury medipen
   parent: ChemicalMedipen
@@ -78,23 +126,23 @@
   - type: SolutionContainerManager
     solutions:
       pen:
-        maxVol: 180
+        maxVol: 120
         reagents:
-          - ReagentId: DexalinPlus
-            Quantity: 20
+#          - ReagentId: DexalinPlus
+#            Quantity: 20
           - ReagentId: Epinephrine # until Penthrite gets shitcoded in someday
             Quantity: 20
-          - ReagentId: Oxandrolone
-            Quantity: 20
-          - ReagentId: SalicylicAcid
-            Quantity: 20
-          - ReagentId: Omnizine
+#          - ReagentId: Oxandrolone
+#            Quantity: 20
+#          - ReagentId: SalicylicAcid
+#            Quantity: 20
+          - ReagentId: Omnizine # this is the only chem im allowing that heals under normal conditions because you just fucking die without it and then salvagers would use it to kill people easily
             Quantity: 20
           - ReagentId: Leporazine
             Quantity: 20
           - ReagentId: TranexamicAcid
             Quantity: 20
-          - ReagentId: Saline
-            Quantity: 20
           - ReagentId: Luxurium
+            Quantity: 20
+          - ReagentId: MinersSalve
             Quantity: 20

--- a/Resources/Prototypes/_Lavaland/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Lavaland/Reagents/medicine.yml
@@ -65,8 +65,8 @@
         - !type:ReagentThreshold
           min: 21
         - !type:PressureThreshold
-          min: 1
-          max: 50
+          min: 25 #1 is too low. PKAs use 25-51.
+          max: 51
           worksOnLavaland: true
         damage:
           types:
@@ -119,10 +119,10 @@
             Airloss: -1.5
         conditions:
           - !type:PressureThreshold
-            min: 1
-            max: 50
+            min: 25 #1 is too low. PKAs use 25-51.
+            max: 51
             worksOnLavaland: true
-      # Cuts the amount healed roughly by 50% when in normal pressure.
+      # Cuts the amount healed roughly by 50% when in normal pressure. Dumont note: 50% of one billion is still 500 million my guy. Shit wasn't enough to balance it.
 
 - type: reagent
   id: VitriumFroth

--- a/Resources/Prototypes/_Lavaland/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Lavaland/Reagents/medicine.yml
@@ -45,8 +45,8 @@
         amount: 1.5
         conditions:
         - !type:PressureThreshold
-          min: 1
-          max: 50
+          min: 25
+          max: 51
           worksOnLavaland: true
       - !type:HealthChange
         damage:
@@ -57,8 +57,8 @@
             Bloodloss: -1.25
         conditions:
         - !type:PressureThreshold
-          min: 1
-          max: 50
+          min: 25
+          max: 51
           worksOnLavaland: true
       - !type:HealthChange
         conditions:


### PR DESCRIPTION
## Sobre a PR
Remove a salic, oxand e dex+ dos quimicos da medipen. Adiciona miner's salvine pra compensar.
Também faz luxurium e miner's salvine apenas funcionar entre 25-51 KPA pra ser mais igual aos PKAs.

## Por quê? / Balanceamento
Essa medipen foi como uma caneta de cura pra uso na lavaland exclusivamente, tanto que ela vem com um quimico que te machuca se tiver em pressão normal.
... Então porque caralhos ela era uma das melhores medipens da tripulação?
<img width="653" height="365" alt="image" src="https://github.com/user-attachments/assets/b8a2db09-e946-41c8-80f6-2be455a0c5db" />
Ela ainda tem omnizina, é intencional, sem omnizina isso vira uma medipen de morte que é garantido matar.

## Detalhes Tecnicos
Yml. Eu deixei a versão original desativada em caso alguém quiser trocar de volta (mas eu VOU demandar uma explicação do balanceamento disso.)

## Anexos
Stats novos.
<img width="844" height="391" alt="image" src="https://github.com/user-attachments/assets/4d5cfc09-3ee9-4f67-95a8-bd8620e3c090" />


## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl: Heartbeat
- tweak: Luxury pen agora quase faz nada em pressão normal; A salic, oxand e dex+ dela foram removidos.
- tweak: Luxurium e Minersalvine agora funcionam apenas entre 25-51 KPA para combinar com PKAs.
