### PR TITLE
[BOUNTY] Healium Buff

### DIFF
--- a/Resources/Prototypes/_Goobstation/Reagents/gases.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/gases.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Goob Station Contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # /tg/ gases
 
 - type: reagent

--- a/Resources/Prototypes/_Goobstation/Reagents/gases.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/gases.yml
@@ -283,7 +283,7 @@
         conditions:
         - !type:ReagentThreshold
           reagent: Healium
-          max: 24
+          max: 12
         scaleByQuantity: true
         ignoreResistances: true
         damage:

--- a/Resources/Prototypes/_Goobstation/Reagents/gases.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/gases.yml
@@ -233,9 +233,9 @@
         ignoreResistances: true
         damage:
           groups:
-            Burn: -2
-            Toxin: -5
-            Brute: -2
+            Burn: -8
+            Toxin: -10
+            Brute: -6
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -244,9 +244,9 @@
         ignoreResistances: true
         damage:
           groups:
-            Burn: -20
+            Burn: -40
             Toxin: -50
-            Brute: -20
+            Brute: -30
       - !type:PopupMessage
         conditions:
         - !type:ReagentThreshold
@@ -288,20 +288,22 @@
         ignoreResistances: true
         damage:
           groups:
-            Burn: -2
-            Toxin: -5
-            Brute: -2
+            Burn: -12
+            Toxin: -15
+            Brute: -9
+            Airloss: -6
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           reagent: Healium
-          min: 24
+          min: 12
         ignoreResistances: true
         damage:
           groups:
-            Burn: -20
+            Burn: -40
             Toxin: -50
-            Brute: -20
+            Brute: -30
+            Airloss: -20
       - !type:PopupMessage
         conditions:
         - !type:ReagentThreshold

--- a/Resources/Prototypes/_Goobstation/Reagents/gases.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/gases.yml
@@ -338,6 +338,25 @@
         - !type:ReagentThreshold
           reagent: Healium
           min: 4
+      # Convert Healium into CO2 and N2O - Dumont
+      - !type:ModifyLungGas
+        conditions:
+        - !type:OrganType
+          type: Cybernetic
+          shouldHave: false
+        ratios:
+          CarbonDioxide: 0.5
+          NitrousOxide: 0.5
+          Healium: -1.0
+      - !type:ModifyLungGas
+        conditions:
+        - !type:OrganType
+          type: Cybernetic
+          shouldHave: true
+        ratios:
+          CarbonDioxide: 0.25
+          NitrousOxide: 0.25
+          Healium: -0.5
 
 - type: reagent
   id: Nitrium

--- a/Resources/Prototypes/_Goobstation/Reagents/gases.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/gases.yml
@@ -287,7 +287,7 @@
         conditions:
         - !type:ReagentThreshold
           reagent: Healium
-          max: 12
+          max: 24
         scaleByQuantity: true
         ignoreResistances: true
         damage:
@@ -300,7 +300,7 @@
         conditions:
         - !type:ReagentThreshold
           reagent: Healium
-          min: 12
+          min: 24
         ignoreResistances: true
         damage:
           groups:


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## Sobre a PR
<!-- O que ela muda? -->
Melhora o healium, um gás especial atmosférico de dificil fabricação no qual os efeitos não valiam a pena o esforço.

## Por quê? / Balanceamento
<!-- Discuta do por que da existencia da PR. (opcional | recomendado) -->
Solução: Healium agora recupera 4x mais dano bruto e queimadura (0,5 -> 2) tornando-o mais interessante para a Med quando em solução, a cura de hiperdosagem continua bruta e queimadura também aumentando em 50% bruto (20 -> 30) e 2x queimadura (20 -> 40).

Gás: Healium agora recupera 6x mais dano bruto e queimadura, também curando dano de falta de ar quando respirado em forma gasosa, sendo 50% mais forte doque solução, hiperdosagem também ocorre mais cedo precisando de 12u ao invés de 24u, com efeitos de hiperdosagem como os da solução porém com adição de falta de ar sendo 10 asfixia e 10 perda de sangue.

Esse gás é de complexa produção, com qualquer quantidade decente sendo necessário uma produção de Frezon apenas para reagir com N2 desperdiçando o Frezon e gerando N2O, isso apenas para alimentar a reação de criação de BZ que precisa de infraestrutura dedicada de alto volume e consome Plasma adicional, com isso é necessário controlar uma segunda reação exotérmica que consome ambos BZ e ainda mais Frezon para então ter Healium.

Healium gás, por ser respirado é recebido uma dose bem menor, por isso o efeito mais forte, além de ser mais dificil de conter, armazenar e usar do que apenas uma pílula ou seringa. 

Embora a forma gasosa cure airloss, ela não é capaz de vencer o dano de asfixia por não respirar em condições normais. Caso supercondensado ela pode regenerar o suficiente para dispensar Oxigênio, porém começa a ter efeitos negativos de tontura. Por padrão qualquer dose acima de 8u causa sonolência, então seria necessário alto investimento e habilidade para tirar vantagem do buff para combate, servindo principalmente como uma alternativa da Med "entubando" um paciente para se recuperar.

## Detalhes Tecnicos
<!-- Mudanças do codigo para uma review mais facil (opcional). -->
Mudança yml simples.

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->
<img width="456" height="342" alt="image" src="https://github.com/user-attachments/assets/1bc35f9f-8c02-4dd1-bbfe-8eaccd9f908a" />

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl:
- tweak: Healium buffado, agora ele é uma opção versátil decente para a Med.
