### PR TITLE
Conserta a IA Malfuncional não aparecendo naturalmente.

### DIFF
--- a/Resources/Prototypes/_Funkystation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Funkystation/GameRules/roundstart.yml
@@ -56,6 +56,7 @@
     definitions:
     - prefRoles: [ MalfunctioningAI ]
       max: 1
+      chaosScore: 400
       allowNonHumans: true
       briefing:
         text: roles-antag-malfunctioning-ai-briefing
@@ -65,3 +66,6 @@
       - type: MalfunctioningAi
       mindRoles:
       - MindRoleMalfAi
+  - type: Tag
+    tags:
+      - RoundstartAntag


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## Sobre a PR
<!-- O que ela muda? -->
Agora o antagonista IA Malfuncional deve aparecer roundstart. É um fix bem simples que só adicionaum componente na gamerule, espero que corrija o erro.

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [ ] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione uma entrada para changelog do servidor, bote o emoji :cl: e siga com as mudanças assim como o exemplo.
:cl: em branco fara com que seu nome na changelog apareça como do github, adicione um nome depois do emoji para mudar seu nome na changelog. -->
:cl:
- fix: O antagonista IA Malfuncional agora pode aparecer naturalmente.
