### PR TITLE
conserta categoria de caixa de circuitos de gygax e durand

### DIFF
--- a/Resources/Prototypes/_Gabystation/Catalog/Cargo/cargo_arsenal.yml
+++ b/Resources/Prototypes/_Gabystation/Catalog/Cargo/cargo_arsenal.yml
@@ -9,7 +9,7 @@
     state: gygax
   product: CrateGygaxBoards
   cost: 40000
-  category: cargo-product-category-name-arsenal
+  category: cargoproduct-category-name-armory
   group: market
 
 - type: cargoProduct
@@ -19,5 +19,5 @@
     state: durand
   product: CrateDurandBoards
   cost: 60000
-  category: cargo-product-category-name-arsenal
+  category: cargoproduct-category-name-armory
   group: market

--- a/Resources/Prototypes/_Gabystation/Catalog/Cargo/cargo_arsenal.yml
+++ b/Resources/Prototypes/_Gabystation/Catalog/Cargo/cargo_arsenal.yml
@@ -9,7 +9,7 @@
     state: gygax
   product: CrateGygaxBoards
   cost: 40000
-  category: cargoproduct-category-name-arsenal
+  category: cargo-product-category-name-arsenal
   group: market
 
 - type: cargoProduct
@@ -19,5 +19,5 @@
     state: durand
   product: CrateDurandBoards
   cost: 60000
-  category: cargoproduct-category-name-arsenal
+  category: cargo-product-category-name-arsenal
   group: market


### PR DESCRIPTION
## Sobre a PR
faz a categoria ter o nome e local certo

## Por quê? / Balanceamento
woops.

## Detalhes Tecnicos
troquei de "arsenal" pra "armory"

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl: Heartbeat
- fix: Caixas de circuito de durand e gygax são categorizadas corretamente.