### PR TITLE
Fix Habilidades da Malf Ai

### DIFF
--- a/Content.Server/_Funkystation/Factory/Systems/AIBuildSystem.cs
+++ b/Content.Server/_Funkystation/Factory/Systems/AIBuildSystem.cs
@@ -17,6 +17,7 @@ using Content.Shared.SubFloor;
 using Content.Shared.Tag;
 using Content.Shared._Funkystation.Actions.Events;
 using Content.Shared.Charges.Systems;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server._Funkystation.Factory.Systems;
 
@@ -27,13 +28,15 @@ public sealed partial class AIBuildRequestEvent : EntityEventArgs
 {
     public EntityUid Requester { get; }
     public EntityCoordinates Target { get; }
-    public string Prototype { get; }
+    public EntProtoId Prototype { get; }
+    public EntProtoId? RefundAction { get; }
 
-    public AIBuildRequestEvent(EntityUid requester, EntityCoordinates target, string prototype)
+    public AIBuildRequestEvent(EntityUid requester, EntityCoordinates target, EntProtoId prototype, EntProtoId? refundAction)
     {
         Requester = requester;
         Target = target;
         Prototype = prototype;
+        RefundAction = refundAction;
     }
 }
 
@@ -83,7 +86,7 @@ public sealed partial class AIBuildSystem : EntitySystem
         }
 
         // Start building process with DoAfter
-        var doAfterEvent = new AIBuildDoAfterEvent(GetNetCoordinates(target), prototype);
+        var doAfterEvent = new AIBuildDoAfterEvent(GetNetCoordinates(target), prototype, args.RefundAction);
         var delay = TimeSpan.FromSeconds(3.0f); // 3 second build time
 
         // Try to get the AI's visible eye entity (RemoteEntity) for DoAfter display
@@ -119,6 +122,9 @@ public sealed partial class AIBuildSystem : EntitySystem
     private void OnBuildDoAfter(EntityUid uid, MalfunctioningAiComponent component, AIBuildDoAfterEvent args)
     {
         // Dumont Station: If DoAfter is cancelled, its supposed to refund the charge for the Robotics Factory action, so we add it back here.
+
+        // agora temos `args.RefundAction` aqui.
+
         if (args.Cancelled)
         {
             AddChargeRoboticsFactoryAction(uid);

--- a/Content.Server/_Funkystation/Factory/Systems/AIBuildSystem.cs
+++ b/Content.Server/_Funkystation/Factory/Systems/AIBuildSystem.cs
@@ -125,9 +125,9 @@ public sealed partial class AIBuildSystem : EntitySystem
 
         // agora temos `args.RefundAction` aqui.
 
-        if (args.Cancelled)
+        if (args.Cancelled && args.RefundAction is { } actionId)
         {
-            AddChargeRoboticsFactoryAction(uid);
+            _chargesSystem.RefundAction(uid, actionId);
             return;
         }
 
@@ -185,26 +185,6 @@ public sealed partial class AIBuildSystem : EntitySystem
 
         foreach (var action in toRemove)
             _actions.RemoveAction(action.AsNullable());
-    }
-
-    private void AddChargeRoboticsFactoryAction(EntityUid performer)
-    {
-        // Dumont Station: Add charge to Robotics Factory action (ActionMalfAiRoboticsFactory) from the performer.
-        // We search via ActionsComponent -> BaseActionComponent.BaseEvent type.
-        if (!TryComp<ActionsComponent>(performer, out var actionsComp))
-            return;
-
-        foreach (var action in _actions.GetActions(performer, actionsComp))
-        {
-            var baseEvent = _actions.GetEvent(action.Owner);
-
-            if (baseEvent is not null
-                && baseEvent is MalfAiRoboticsFactoryActionEvent)
-            {
-                _chargesSystem.AddCharges(action.Owner, 1);
-                break;
-            }
-        }
     }
 
     /// <summary>

--- a/Content.Server/_Funkystation/Factory/Systems/AIBuildSystem.cs
+++ b/Content.Server/_Funkystation/Factory/Systems/AIBuildSystem.cs
@@ -154,6 +154,7 @@ public sealed partial class AIBuildSystem : EntitySystem
                 owner.Controller = uid; // uid is the AI entity that received the DoAfter completion
             }
 
+            // a próxima função sempre da erro linha 189 do MapChunk.cs. o erro acontece pq ele tá tentando por o `spawned` no centro do tile sendo que ele já está. ainda não entendi pq ele já está.
             _xform.AnchorEntity(spawned);
 
             // On success, remove the Robotics Factory action from the Malf AI that built it.

--- a/Content.Server/_Funkystation/Factory/Systems/AIBuildSystem.cs
+++ b/Content.Server/_Funkystation/Factory/Systems/AIBuildSystem.cs
@@ -16,6 +16,7 @@ using Content.Shared._Gabystation.MalfAi.Components;
 using Content.Shared.SubFloor;
 using Content.Shared.Tag;
 using Content.Shared._Funkystation.Actions.Events;
+using Content.Shared.Charges.Systems;
 
 namespace Content.Server._Funkystation.Factory.Systems;
 
@@ -46,6 +47,7 @@ public sealed partial class AIBuildSystem : EntitySystem
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
     [Dependency] private readonly TagSystem _tag = default!;
+    [Dependency] private readonly SharedChargesSystem _chargesSystem = default!;
 
     private static readonly ISawmill Sawmill = Logger.GetSawmill("ai.build.system");
 
@@ -116,8 +118,12 @@ public sealed partial class AIBuildSystem : EntitySystem
     /// </summary>
     private void OnBuildDoAfter(EntityUid uid, MalfunctioningAiComponent component, AIBuildDoAfterEvent args)
     {
+        // Dumont Station: If DoAfter is cancelled, its supposed to refund the charge for the Robotics Factory action, so we add it back here.
         if (args.Cancelled)
+        {
+            AddChargeRoboticsFactoryAction(uid);
             return;
+        }
 
         var location = GetCoordinates(args.Location);
 
@@ -173,6 +179,26 @@ public sealed partial class AIBuildSystem : EntitySystem
 
         foreach (var action in toRemove)
             _actions.RemoveAction(action.AsNullable());
+    }
+
+    private void AddChargeRoboticsFactoryAction(EntityUid performer)
+    {
+        // Dumont Station: Add charge to Robotics Factory action (ActionMalfAiRoboticsFactory) from the performer.
+        // We search via ActionsComponent -> BaseActionComponent.BaseEvent type.
+        if (!TryComp<ActionsComponent>(performer, out var actionsComp))
+            return;
+
+        foreach (var action in _actions.GetActions(performer, actionsComp))
+        {
+            var baseEvent = _actions.GetEvent(action.Owner);
+
+            if (baseEvent is not null
+                && baseEvent is MalfAiRoboticsFactoryActionEvent)
+            {
+                _chargesSystem.AddCharges(action.Owner, 1);
+                break;
+            }
+        }
     }
 
     /// <summary>

--- a/Content.Server/_Funkystation/MalfAI/MalfAiOverloadSystem.cs
+++ b/Content.Server/_Funkystation/MalfAI/MalfAiOverloadSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Silicons.StationAi;
 using Robust.Shared.Map;
 using Content.Server.Silicons.StationAi;
 using Content.Shared._Gabystation.MalfAi.Components;
+using Content.Shared.VendingMachines;
 
 namespace Content.Server._Funkystation.MalfAI;
 
@@ -61,7 +62,8 @@ public sealed class MalfAiOverloadSystem : EntitySystem
         foreach (var entity in entitiesAtLocation)
         {
             // Match Override's targeting: operate only on actual machines
-            if (HasComp<MachineComponent>(entity))
+            // Dumont Station: Agora também afeta computadores e máquinas de venda
+            if (HasComp<MachineComponent>(entity) || HasComp<ComputerComponent>(entity) || HasComp<VendingMachineComponent>(entity))
             {
                 targetMachine = entity;
                 break;

--- a/Content.Server/_Funkystation/MalfAI/MalfAiOverrideSystem.cs
+++ b/Content.Server/_Funkystation/MalfAI/MalfAiOverrideSystem.cs
@@ -23,6 +23,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Content.Server.Silicons.StationAi;
 using Content.Shared._Gabystation.MalfAi.Components;
+using Content.Shared.VendingMachines;
 
 namespace Content.Server._Funkystation.MalfAI;
 
@@ -76,7 +77,7 @@ public sealed class MalfAiOverrideSystem : EntitySystem
 
         foreach (var entity in entitiesAtLocation)
         {
-            if (HasComp<MachineComponent>(entity))
+            if (HasComp<MachineComponent>(entity) || HasComp<ComputerComponent>(entity) || HasComp<VendingMachineComponent>(entity))
             {
                 targetMachine = entity;
                 break;

--- a/Content.Server/_Funkystation/MalfAI/Systems/MalfAiRoboticsFactorySystem.cs
+++ b/Content.Server/_Funkystation/MalfAI/Systems/MalfAiRoboticsFactorySystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Server._Funkystation.Factory.Systems;
 using Robust.Shared.Prototypes;
 using Content.Shared._Gabystation.MalfAi.Components;

--- a/Content.Server/_Funkystation/MalfAI/Systems/MalfAiRoboticsFactorySystem.cs
+++ b/Content.Server/_Funkystation/MalfAI/Systems/MalfAiRoboticsFactorySystem.cs
@@ -32,8 +32,8 @@ public sealed partial class MalfAiRoboticsFactorySystem : EntitySystem
         if (!args.Target.IsValid(EntityManager))
             return;
 
-        var ev = new AIBuildRequestEvent(malf.Owner, args.Target, RoboticsFactoryPrototype.Id);
-
+        var refundAction = MetaData(args.Action).EntityPrototype?.ID;
+        var ev = new AIBuildRequestEvent(malf.Owner, args.Target, RoboticsFactoryPrototype, refundAction);
         RaiseLocalEvent(ev);
 
         args.Handled = true; // consume the action

--- a/Content.Server/_Gabystation/MalfAi/MalfAiSystem.Abilities.cs
+++ b/Content.Server/_Gabystation/MalfAi/MalfAiSystem.Abilities.cs
@@ -4,6 +4,7 @@
 
 using System.Linq;
 using Content.Server.Construction.Components;
+using Content.Shared.VendingMachines;
 using Content.Server.Explosion.EntitySystems;
 using Content.Server.Popups;
 using Content.Server.Radio.Components;
@@ -55,7 +56,8 @@ public sealed partial class MalfAiSystem
 
         var coordinates = _transform.ToMapCoordinates(args.Target);
         var target = _lookup.GetEntitiesInRange(coordinates, 0.25f, LookupFlags.Uncontained)
-            .Where(HasComp<MachineComponent>).FirstOrNull();
+            // Foi feita uma alteração onde agora o overload também funciona em computadores e máquinas de venda, então é necessário verificar os três tipos de componentes.
+            .Where(entity => HasComp<MachineComponent>(entity) || HasComp<ComputerComponent>(entity) || HasComp<VendingMachineComponent>(entity)).FirstOrNull();
 
         if (target is not { } machine)
         {

--- a/Content.Server/_Gabystation/MalfAi/MalfAiSystem.Abilities.cs
+++ b/Content.Server/_Gabystation/MalfAi/MalfAiSystem.Abilities.cs
@@ -18,6 +18,7 @@ using Content.Shared.Popups;
 using Content.Shared.Power.EntitySystems;
 using Content.Shared.Silicons.StationAi;
 using Robust.Shared.Utility;
+using Content.Server._Funkystation.Factory.Systems;
 
 namespace Content.Server._Gabystation.MalfAi;
 

--- a/Content.Shared/Charges/Systems/SharedChargesSystem.cs
+++ b/Content.Shared/Charges/Systems/SharedChargesSystem.cs
@@ -24,6 +24,8 @@ using Content.Shared.Examine;
 using JetBrains.Annotations;
 using Robust.Shared.Timing;
 using Content.Goobstation.Maths.FixedPoint;
+using Content.Shared.Actions;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Charges.Systems;
 
@@ -31,6 +33,7 @@ public abstract class SharedChargesSystem : EntitySystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!; // TraumaStation
     [Dependency] protected readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedActionsSystem _actions = default!;
 
     /*
      * Despite what a bunch of systems do you don't need to continuously tick linear number updates and can just derive it easily.
@@ -276,5 +279,34 @@ public abstract class SharedChargesSystem : EntitySystem
         component.MaxCharges = charges;
         SetCharges(uid, Math.Clamp(charges, 0, component.MaxCharges));
         Dirty(uid, component);
+    }
+
+    /// <summary>
+    ///     Add a charge to an action if it can be recharged, otherwise add a new instance of the action.
+    /// </summary>
+    public void RefundAction(EntityUid performer, EntProtoId actionPrototypeId)
+    {
+        var found = false;
+
+        // procura por uma action que possa ser recarregada.
+        foreach (var action in _actions.GetActions(performer))
+        {
+            if (MetaData(action.Owner).EntityPrototype?.ID != actionPrototypeId.Id)
+                continue;
+
+            if (!TryComp<LimitedChargesComponent>(action.Owner, out var chargesComp))
+                continue; // se não pode ser recarregada, procura pela próxima.
+
+            var charges = GetCurrentCharges(action.Owner);
+            if (charges == chargesComp.MaxCharges)
+                continue; //se a carga já está no máximo, pule para a próxima
+
+            found = true; // encontramos uma que pode ser recarregada! recarrega e encerra.
+            AddCharges(action.Owner, 1);
+            break;
+        }
+
+        if (!found) // nenhuma action pôde ser recarregada. adiciona uma nova.
+          _actions.AddAction(performer, actionPrototypeId);
     }
 }

--- a/Content.Shared/_Funkystation/Factory/AIBuildDoAfterEvent.cs
+++ b/Content.Shared/_Funkystation/Factory/AIBuildDoAfterEvent.cs
@@ -2,6 +2,7 @@
 
 using Content.Shared.DoAfter;
 using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared._Funkystation.Factory;
@@ -14,14 +15,16 @@ public sealed partial class AIBuildDoAfterEvent : DoAfterEvent
 {
     public NetCoordinates Location;
     public string Prototype = default!;
+    public EntProtoId? RefundAction = null;
 
     public AIBuildDoAfterEvent() { }
 
-    public AIBuildDoAfterEvent(NetCoordinates location, string prototype)
+    public AIBuildDoAfterEvent(NetCoordinates location, string prototype, EntProtoId? refundAction)
     {
         Location = location;
         Prototype = prototype;
+        RefundAction = refundAction;
     }
 
-    public override DoAfterEvent Clone() => new AIBuildDoAfterEvent(Location, Prototype);
+    public override DoAfterEvent Clone() => new AIBuildDoAfterEvent(Location, Prototype, RefundAction);
 }


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## Sobre a PR
<!-- O que ela muda? -->
Agora a habilidade de override e overload da malf AI também funciona em computadores e máquinas de venda, além disso, quando a malf AI cancela a ação de colocar a fábrica de ciborgues, a carga da fábrica de ciborfues é restituída, bem legal.

## Por quê? / Balanceamento
<!-- Discuta do por que da existencia da PR. (opcional | recomendado) -->
Sobre a parte das skills de override e overload a Malf IA tinha que ficar literalmente selecionando o que explodia ou não, spammando a skill em várias coisas para testar se realmente explodia/virava mob agressivo. Ela tinha que hackear 10 APCs no caso para explodir e 15 APCs para fazer a máquina virar agressiva e mesmo assim a habilidade era quase inútil por só funcionar em entidades com o componente machine (que são entidades bem específicas). 
Sobre a parte do bug fix, antigamente se a IA cancelasse a ação de colocar a fábrica de ciborgues, ela perdia permanentemente a habilidade. Como a fábrica de ciborgues é essencial, perder permanente não é nada legal, frustra bastante o jogador.


## Detalhes Tecnicos
<!-- Mudanças do codigo para uma review mais facil (opcional). -->
Bom, a parte da habilidade de override e overload é bem simples, eu só coloquei para ao invés de checar apenas o componente machine, checar também o componente computer e o componente VendingMachine.
A parte da fábrica de ciborgues foi bem shitcode mesmo, eu criei uma função que vai verificando todas as ações da IA, quando ela encontra a ação da fábricas de robôs, é adiciona uma carga a essa ação e o loop para. Essa função é puxada quando a IA cancela o DoAfter de colocar a fábrica de ciborgues.

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione uma entrada para changelog do servidor, bote o emoji :cl: e siga com as mudanças assim como o exemplo.
:cl: em branco fara com que seu nome na changelog apareça como do github, adicione um nome depois do emoji para mudar seu nome na changelog. -->

:cl:
- tweak: Agora a habilidade de explodir máquinas e também a habilidade de fazer elas viraram mobs agressivos funciona em computadores e máquinas de venda.
- fix: Agora a IA Malfuncional não perde a habildade da fábrica de robôs quando ela cancela a ação de colocar.

