### PR TITLE
Remove contractor baton do uplink normal (mald)

### DIFF
--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -334,10 +334,9 @@
   - UplinkWeaponry
   conditions:
   - !type:StoreWhitelistCondition
-    blacklist:
+    whitelist:
       tags:
-      - ContractorUplink #cheaper for contractors
-    #  - NukeOpsUplink why wouldn't nukies be allowed to get this for hostage ops?
+      - NukeOpsUplink #Dumont edit only for nukies
   - !type:ListingLimitedStockCondition
     stock: 1
 

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -337,7 +337,7 @@
     blacklist:
       tags:
       - ContractorUplink #cheaper for contractors
-      - NukeOpsUplink
+    #  - NukeOpsUplink why wouldn't nukies be allowed to get this for hostage ops?
   - !type:ListingLimitedStockCondition
     stock: 1
 

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/contractor_baton.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/contractor_baton.yml
@@ -24,13 +24,13 @@
   - type: Clothing
     sprite: _Goobstation/Objects/Weapons/Melee/contractor_baton.rsi
   - type: TelescopicBaton
-    alwaysDropItems: true
+    alwaysDropItems: false
   - type: UseDelay
     delays:
       default:
         length: 1
       telebaton:
-        length: 1
+        length: 3 #Dumont edit man, goob really went "my relatively cheap uplink item that costs around as much as a hypopen will insta knockdown, insta desarm, 2 hit stun, have practically no cooldown and be infinite" and NOONE argued against it, apparently. Well i do. Fuck you.
   - type: ItemToggle
     soundActivate:
       path: /Audio/_Goobstation/Weapons/Baton/contractorbatonextend.ogg
@@ -48,6 +48,6 @@
   - type: MeleeWeapon
     bluntStaminaDamageFactor: 0
   - type: StaminaDamageOnHit
-    damage: 85
+    damage: 70
   - type: StunBorgsOnHit
   - type: TogglePreventStaminaDamage

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/contractor_baton.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/contractor_baton.yml
@@ -30,7 +30,7 @@
       default:
         length: 1
       telebaton:
-        length: 2 #Dumont edit man, goob really went "my relatively cheap uplink item that costs around as much as a hypopen will insta knockdown, insta desarm, 2 hit stun, have practically no cooldown and be infinite" and NOONE argued against it, apparently. Well i do. Fuck you.
+        length: 2 
   - type: ItemToggle
     soundActivate:
       path: /Audio/_Goobstation/Weapons/Baton/contractorbatonextend.ogg

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/contractor_baton.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/contractor_baton.yml
@@ -24,13 +24,13 @@
   - type: Clothing
     sprite: _Goobstation/Objects/Weapons/Melee/contractor_baton.rsi
   - type: TelescopicBaton
-    alwaysDropItems: false
+    alwaysDropItems: true
   - type: UseDelay
     delays:
       default:
         length: 1
       telebaton:
-        length: 2 #Dumont edit man, goob really went "my relatively cheap uplink item that costs around as much as a hypopen will insta knockdown, insta desarm, 2 hit stun, have practically no cooldown and be infinite" and NOONE argued against it, apparently. Well i do. Fuck you.
+        length: 1
   - type: ItemToggle
     soundActivate:
       path: /Audio/_Goobstation/Weapons/Baton/contractorbatonextend.ogg
@@ -48,6 +48,6 @@
   - type: MeleeWeapon
     bluntStaminaDamageFactor: 0
   - type: StaminaDamageOnHit
-    damage: 70
+    damage: 85
   - type: StunBorgsOnHit
   - type: TogglePreventStaminaDamage

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/contractor_baton.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/contractor_baton.yml
@@ -30,7 +30,7 @@
       default:
         length: 1
       telebaton:
-        length: 3 #Dumont edit man, goob really went "my relatively cheap uplink item that costs around as much as a hypopen will insta knockdown, insta desarm, 2 hit stun, have practically no cooldown and be infinite" and NOONE argued against it, apparently. Well i do. Fuck you.
+        length: 2 #Dumont edit man, goob really went "my relatively cheap uplink item that costs around as much as a hypopen will insta knockdown, insta desarm, 2 hit stun, have practically no cooldown and be infinite" and NOONE argued against it, apparently. Well i do. Fuck you.
   - type: ItemToggle
     soundActivate:
       path: /Audio/_Goobstation/Weapons/Baton/contractorbatonextend.ogg


### PR DESCRIPTION
## Sobre a PR
Remove contractor baton do uplink normal, apenas pra nukies e contractor agora.

## Por quê? / Balanceamento
Sim, isso é uma mald PR.
Não, eu não me importo.
No momento, o bastão de contrator:
- Desarma
- Causa knockdown instantaneo
- Stuna qualquer um com qualquer armadura em 2 hits
- Ataca 1 vez por segundo
- Poderia stunar 2-3 pessoas ao mesmo tempo com completa facilidade
Tudo isso custando so 5 mais telecristais que a hypopen SEM a nocturina. É excessivo, e arruina a parte do balanceamento de custo do uplink relacionado a formas de stunar alguém.
Também, ele so... Ta sendo usado demais. Uma vez vendo alguém usando ele com a betrayal knife é engraçado e penso "Okay, bom saber" mas agora eu vi/ouvi 5 pessoas fazendo isso até agora, fiz isso eu mesmo, morri sabendo que é uma coisa... agora so ta ficando chato.

## Detalhes Tecnicos
Transformei blacklist em whitelist e inclui nukeops uplink apenas.

## Anexos

O baton não estando em um uplink normal.

<img width="853" height="499" alt="image" src="https://github.com/user-attachments/assets/fa8dee19-d58d-4397-b6e8-8612a7e3fbdf" />

O baton estando em um uplink de nukie. 

<img width="675" height="497" alt="image" src="https://github.com/user-attachments/assets/4e46dec9-a32f-458c-a72b-867f8ab8020e" />



## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl: Heartbeat
- tweak: Bastão de contrator apenas é comprável por nukies, contratores e por meio de bundles indeterminados agora.
