### PR TITLE
[Fix] Descontrução Proto RCD

### DIFF
--- a/Content.Shared/RCD/Components/RCDComponent.cs
+++ b/Content.Shared/RCD/Components/RCDComponent.cs
@@ -91,4 +91,16 @@ public sealed partial class RCDComponent : Component
     /// </remarks>
     [ViewVariables(VVAccess.ReadOnly)]
     public Transform ConstructionTransform { get; private set; }
+
+    /// <summary>
+    /// Indicates whether this is an hybrid of an RCD and RPD - Dumont
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool IsHybrid { get; set; } = false;
+
+    /// <summary>
+    /// Indicates whether this can ignore access restrictions and bolts state when deconstructing - Dumont
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool AccessBypass { get; set; } = false;
 }

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -610,7 +610,7 @@ public sealed class RCDSystem : EntitySystem
         // Attempt to deconstruct a floor tile
         if (target == null)
         {
-            if (component.IsRpd)
+            if (component.IsRpd & component.AvailablePrototypes.Contains("DeconstructStrong") == false) // Dumontstation Edit - Really bad implementation for ProtoRCD
             {
                 if (popMsgs)
                     _popup.PopupClient(Loc.GetString("rcd-component-deconstruct-target-not-on-whitelist-message"), uid, user);
@@ -651,7 +651,7 @@ public sealed class RCDSystem : EntitySystem
         else
         {
             // The object is not in the RPD whitelist
-            if (!TryComp<RCDDeconstructableComponent>(target, out var deconstructible) || !deconstructible.RpdDeconstructable && component.IsRpd)
+            if (!TryComp<RCDDeconstructableComponent>(target, out var deconstructible) || !deconstructible.RpdDeconstructable && component.IsRpd && component.AvailablePrototypes.Contains("DeconstructStrong") == false) // Dumontstation Edit - Really bad implementation for ProtoRCD
             {
                 if (popMsgs)
                     _popup.PopupClient(Loc.GetString("rcd-component-deconstruct-target-not-on-whitelist-message"), uid, user);
@@ -669,7 +669,7 @@ public sealed class RCDSystem : EntitySystem
             }
 
             // Goobstation - RCD check access for doors
-            if (TryComp<AccessReaderComponent>(target, out var accessList) && !_accessReader.IsAllowed(user, target.Value))
+            if (TryComp<AccessReaderComponent>(target, out var accessList) && !_accessReader.IsAllowed(user, target.Value) && component.AvailablePrototypes.Contains("DeconstructStrong") == false) // Dumontstation Edit - Really bad implementation for ProtoRCD
             {
                 if (popMsgs)
                     _popup.PopupClient(Loc.GetString("rcd-component-deconstruct-target-no-access"), uid, user);
@@ -678,7 +678,7 @@ public sealed class RCDSystem : EntitySystem
             }
 
             // Goobstation - RCD check access for bolts (Yeah, this should be event based...)
-            if (TryComp<DoorBoltComponent>(target, out var doorBolt) && doorBolt.BoltsDown)
+            if (TryComp<DoorBoltComponent>(target, out var doorBolt) && doorBolt.BoltsDown && component.AvailablePrototypes.Contains("DeconstructStrong") == false) // Dumontstation Edit - Really bad implementation for ProtoRCD
             {
                 if (popMsgs)
                     _popup.PopupClient(Loc.GetString("rcd-component-deconstruct-target-is-bolted"), uid, user);

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -610,7 +610,7 @@ public sealed class RCDSystem : EntitySystem
         // Attempt to deconstruct a floor tile
         if (target == null)
         {
-            if (component.IsRpd & component.AvailablePrototypes.Contains("DeconstructStrong") == false) // Dumontstation Edit - Really bad implementation for ProtoRCD
+            if (component.IsRpd && component.AvailablePrototypes.Contains("DeconstructStrong") == false) // Dumontstation Edit - Really bad implementation for ProtoRCD
             {
                 if (popMsgs)
                     _popup.PopupClient(Loc.GetString("rcd-component-deconstruct-target-not-on-whitelist-message"), uid, user);

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -610,7 +610,7 @@ public sealed class RCDSystem : EntitySystem
         // Attempt to deconstruct a floor tile
         if (target == null)
         {
-            if (component.IsRpd && component.AvailablePrototypes.Contains("DeconstructStrong") == false) // Dumontstation Edit - Really bad implementation for ProtoRCD
+            if (component.IsRpd && component.IsHybrid == false) // Dumontstation Edit - Really bad implementation for ProtoRCD
             {
                 if (popMsgs)
                     _popup.PopupClient(Loc.GetString("rcd-component-deconstruct-target-not-on-whitelist-message"), uid, user);
@@ -651,7 +651,7 @@ public sealed class RCDSystem : EntitySystem
         else
         {
             // The object is not in the RPD whitelist
-            if (!TryComp<RCDDeconstructableComponent>(target, out var deconstructible) || !deconstructible.RpdDeconstructable && component.IsRpd && component.AvailablePrototypes.Contains("DeconstructStrong") == false) // Dumontstation Edit - Really bad implementation for ProtoRCD
+            if (!TryComp<RCDDeconstructableComponent>(target, out var deconstructible) || !deconstructible.RpdDeconstructable && component.IsRpd && component.IsHybrid == false) // Dumont Edit
             {
                 if (popMsgs)
                     _popup.PopupClient(Loc.GetString("rcd-component-deconstruct-target-not-on-whitelist-message"), uid, user);
@@ -669,7 +669,7 @@ public sealed class RCDSystem : EntitySystem
             }
 
             // Goobstation - RCD check access for doors
-            if (TryComp<AccessReaderComponent>(target, out var accessList) && !_accessReader.IsAllowed(user, target.Value) && component.AvailablePrototypes.Contains("DeconstructStrong") == false) // Dumontstation Edit - Really bad implementation for ProtoRCD
+            if (TryComp<AccessReaderComponent>(target, out var accessList) && !_accessReader.IsAllowed(user, target.Value) && component.AccessBypass == false) // Dumont Edit
             {
                 if (popMsgs)
                     _popup.PopupClient(Loc.GetString("rcd-component-deconstruct-target-no-access"), uid, user);
@@ -678,7 +678,7 @@ public sealed class RCDSystem : EntitySystem
             }
 
             // Goobstation - RCD check access for bolts (Yeah, this should be event based...)
-            if (TryComp<DoorBoltComponent>(target, out var doorBolt) && doorBolt.BoltsDown && component.AvailablePrototypes.Contains("DeconstructStrong") == false) // Dumontstation Edit - Really bad implementation for ProtoRCD
+            if (TryComp<DoorBoltComponent>(target, out var doorBolt) && doorBolt.BoltsDown && component.AccessBypass == false) // Dumont Edit
             {
                 if (popMsgs)
                     _popup.PopupClient(Loc.GetString("rcd-component-deconstruct-target-is-bolted"), uid, user);

--- a/Resources/Prototypes/_Gabystation/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Objects/Tools/tools.yml
@@ -108,4 +108,4 @@
     - DirectionalFan
     - BlastDoor
     # </GabyStation>
-    - Deconstruct
+    - DeconstructStrong

--- a/Resources/Prototypes/_Gabystation/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Objects/Tools/tools.yml
@@ -28,6 +28,8 @@
     - HighRiskItem
   - type: RCD
     isRpd: true
+    isHybrid: true
+    accessBypass: true
     availablePrototypes: #TODO Tentar fazer o Nestling funcionar
     - WallSolid
     - FloorSteel

--- a/Resources/Prototypes/_Gabystation/RCD/rcd.yml
+++ b/Resources/Prototypes/_Gabystation/RCD/rcd.yml
@@ -317,3 +317,14 @@
   rotation: Fixed
   fx: EffectRCDConstruct4
   noLayers: true
+
+# Especial
+- type: rcd
+  id: DeconstructStrong
+  name: rcd-component-deconstruct
+  category: Main
+  sprite: /Textures/Interface/Radial/RCD/deconstruct.png
+  mode: Deconstruct
+  prototype: EffectRCDDeconstructPreview
+  rotation: Camera
+  noLayers: true


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## Sobre a PR
<!-- O que ela muda? -->
Conserta o problema do Proto RCD de ser incapaz de descontruir.
## Por quê? / Balanceamento
<!-- Discuta do por que da existencia da PR. (opcional | recomendado) -->
Bom, ele devia descontuir.

Também retorna o antes acidentalmente removido beneficio do Proto RCD de ser capaz de descontruir airlocks ao qual o usuário não possui acesso, incluindo também airlocks trancados. Muito bom para invadir uma IA defeituosa ou um antag usar para seus próprios fins.

## Detalhes Tecnicos
<!-- Mudanças do codigo para uma review mais facil (opcional). -->
O sistema de RCD agora checa a ausência de dois novos datafields no yml do item antes de negar desconstrução.
``IsHybrid`` possibilitando RPDs descontruirem e ``AccessBypass`` fazendo o RCD ignorar restrições de acesso e tranca durante descontrução.

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->
<img width="241" height="234" alt="image" src="https://github.com/user-attachments/assets/db5feb74-205c-480d-b159-efd4125dff79" />

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione uma entrada para changelog do servidor, bote o emoji :cl: e siga com as mudanças assim como o exemplo.
:cl: em branco fara com que seu nome na changelog apareça como do github, adicione um nome depois do emoji para mudar seu nome na changelog. -->

:cl:
- fix: Proto RCD consegue descontruir novamente.
- add: Proto RCD pode desconstruir airlocks, independente de acesso ou tranca. 

