### PR TITLE
[Tweak] Ajustes AME

### DIFF
--- a/Content.Server/Ame/AmeNodeGroup.cs
+++ b/Content.Server/Ame/AmeNodeGroup.cs
@@ -182,8 +182,9 @@ public sealed class AmeNodeGroup : BaseNodeGroup
     /// </summary>
     public float CalculatePower(int fuel, int cores)
     {
-        // Balanced around a single core AME with injection level 2 producing 120KW.
-        // Two core with four injection is 150kW. Two core with two injection is 90kW.
+        // Dumont edit - Powerful AME
+        // Balanced around a single core AME with injection level 2 producing 361,2KW.
+        // Two core with four injection is 421,4kW. Two core with two injection is 301kW.
 
         // Increasing core count creates diminishing returns, increasing injection amount increases
         // Unlike the previous solution, increasing fuel and cores always leads to an increase in power, even if by very small amounts.

--- a/Content.Server/Ame/AmeNodeGroup.cs
+++ b/Content.Server/Ame/AmeNodeGroup.cs
@@ -185,11 +185,11 @@ public sealed class AmeNodeGroup : BaseNodeGroup
         // Balanced around a single core AME with injection level 2 producing 120KW.
         // Two core with four injection is 150kW. Two core with two injection is 90kW.
 
-        // Increasing core count creates diminishing returns, increasing injection amount increases 
+        // Increasing core count creates diminishing returns, increasing injection amount increases
         // Unlike the previous solution, increasing fuel and cores always leads to an increase in power, even if by very small amounts.
         // Increasing core count without increasing fuel always leads to reduced power as well.
         // At 18+ cores and 2 inject, the power produced is less than 0, the Max ensures the AME can never produce "negative" power.
-        return MathF.Max(200000f * MathF.Log10(2 * fuel * MathF.Pow(cores, (float)-0.5)), 0);
+        return MathF.Max(400000f * MathF.Log10(4 * fuel * MathF.Pow(cores, (float)-0.5)), 0); // Dumont edit - Powerful AME
     }
 
     public int GetTotalStability()

--- a/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
@@ -35,7 +35,7 @@
     sprite: Objects/Power/AME/ame_jar.rsi
     state: jar
   product: CrateEngineeringAMEJar
-  cost: 25000
+  cost: 25000 # Dumont edit - Powerful AME
   category: cargoproduct-category-name-engineering
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
@@ -35,7 +35,7 @@
     sprite: Objects/Power/AME/ame_jar.rsi
     state: jar
   product: CrateEngineeringAMEJar
-  cost: 20000
+  cost: 25000
   category: cargoproduct-category-name-engineering
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
@@ -35,7 +35,7 @@
     sprite: Objects/Power/AME/ame_jar.rsi
     state: jar
   product: CrateEngineeringAMEJar
-  cost: 2000
+  cost: 20000
   category: cargoproduct-category-name-engineering
   group: market
 

--- a/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
@@ -50,7 +50,7 @@
   - type: StorageFill
     contents:
       - id: AmeJar
-        amount: 2
+        amount: 2 # Dumont edit - Powerful AME
 
 - type: entity
   id: CrateEngineeringAMEControl

--- a/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
@@ -50,7 +50,7 @@
   - type: StorageFill
     contents:
       - id: AmeJar
-        amount: 3
+        amount: 2
 
 - type: entity
   id: CrateEngineeringAMEControl


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## Sobre a PR
<!-- O que ela muda? -->
Aumenta significativamente a produção de energia da AME para combater a falta de energia da estação que ocorre em diversos rounds. Uma AME de um núcleo é capaz de sustentar estações pequenas e maioria das médias enquanto a AME de dois núcleos será capaz de sustentar uma maior. Para compensar, diminui a quantidade de combustível por caixa roundstart e compra para 2 (antes 3) e aumenta o preço de compra de anti materia para 25k.

## Por quê? / Balanceamento
<!-- Discuta do por que da existencia da PR. (opcional | recomendado) -->
Muitos rounds sofrem com engenheiros ou técnicos atmosféricos lentos na geração ou ainda aprendendo a fazer as coisas, com a AME da estação sendo insuficiente para sustenta-la. Resultando rounds onde a estação fica +30min sem energia e/ou Evac precisa ser chamada.

Ao mesmo tempo combate estações pequenas onde a Eng pode ignorar o trabalho por conta da AME conseguir sustentar sozinha pelo combustível extra ser barato.

Em geral, torna a AME um reator poderoso, mas emergencial, sendo caro para ser mantido como principal. Dando ao menos 30min para que a Eng consiga uma forma sustentável de geração de energia, ainda sendo uma opção, embora cara, que a estação consegue manter para eventuais emergências.

Essa PR

## Detalhes Técnicos
<!-- Mudanças do codigo para uma review mais facil (opcional). -->
Maioria yml, leves mudanças no funcionamento do AmeNodeGroup.cs
## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->
<img width="810" height="584" alt="Screenshot_1" src="https://github.com/user-attachments/assets/f27ca7c3-79da-43cc-9c40-5f298ce438a3" />

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione uma entrada para changelog do servidor, bote o emoji :cl: e siga com as mudanças assim como o exemplo.
:cl: em branco fara com que seu nome na changelog apareça como do github, adicione um nome depois do emoji para mudar seu nome na changelog. -->

:cl: PiiCat
- tweak: AMEs agora produzem o dobro de energia base.
- tweak: Injeções da AME são mais poderosas.
- tweak: Caixa de combustível da AME agora vem com 2 jarros ao invés de 3.
- tweak: O preço de compra do combustivel pela Logi aumentou para 25k e vem com 1 jarro a menos.

