### PR TITLE
usa Id do trabalho na LocId dos highlights

### DIFF
--- a/Content.Client/CharacterInfo/CharacterInfoSystem.cs
+++ b/Content.Client/CharacterInfo/CharacterInfoSystem.cs
@@ -55,7 +55,7 @@ public sealed class CharacterInfoSystem : EntitySystem
     private void OnCharacterInfoEvent(CharacterInfoEvent msg, EntitySessionEventArgs args)
     {
         var entity = GetEntity(msg.NetEntity);
-        var data = new CharacterData(entity, msg.JobTitle, msg.Objectives, msg.Briefing, Name(entity), msg.NanoBankBriefing, msg.Job);
+        var data = new CharacterData(entity, msg.JobTitle, msg.Objectives, msg.Briefing, Name(entity), msg.NanoBankBriefing, msg.Job); // Dumont Station - passa o id do job
 
         OnCharacterUpdate?.Invoke(data);
     }
@@ -74,7 +74,7 @@ public sealed class CharacterInfoSystem : EntitySystem
         string? Briefing,
         string EntityName,
         string? NanoBankBriefing, // Gabystation change - Bank
-        ProtoId<JobPrototype>? JobId
+        ProtoId<JobPrototype>? JobId // Dumont Station - passa o id do job
     );
 
     /// <summary>

--- a/Content.Client/CharacterInfo/CharacterInfoSystem.cs
+++ b/Content.Client/CharacterInfo/CharacterInfoSystem.cs
@@ -21,8 +21,10 @@
 
 using Content.Shared.CharacterInfo;
 using Content.Shared.Objectives;
+using Content.Shared.Roles;
 using Robust.Client.Player;
 using Robust.Client.UserInterface;
+using Robust.Shared.Prototypes;
 
 namespace Content.Client.CharacterInfo;
 
@@ -53,7 +55,7 @@ public sealed class CharacterInfoSystem : EntitySystem
     private void OnCharacterInfoEvent(CharacterInfoEvent msg, EntitySessionEventArgs args)
     {
         var entity = GetEntity(msg.NetEntity);
-        var data = new CharacterData(entity, msg.JobTitle, msg.Objectives, msg.Briefing, Name(entity), msg.NanoBankBriefing);
+        var data = new CharacterData(entity, msg.JobTitle, msg.Objectives, msg.Briefing, Name(entity), msg.NanoBankBriefing, msg.Job);
 
         OnCharacterUpdate?.Invoke(data);
     }
@@ -71,7 +73,8 @@ public sealed class CharacterInfoSystem : EntitySystem
         Dictionary<string, List<ObjectiveInfo>> Objectives,
         string? Briefing,
         string EntityName,
-        string? NanoBankBriefing // Gabystation change - Bank
+        string? NanoBankBriefing, // Gabystation change - Bank
+        ProtoId<JobPrototype>? JobId
     );
 
     /// <summary>

--- a/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
+++ b/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
@@ -161,7 +161,7 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
             return;
         }
 
-        var (entity, job, objectives, briefing, entityName, nanoBank) = data;
+        var (entity, job, objectives, briefing, entityName, nanoBank, _) = data;
 
         _window.SpriteView.SetEntity(entity);
 

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -191,6 +191,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         if (newHighlights.Count(c => c == '-') > 1)
             newHighlights = newHighlights.Split('-')[0] + "\n@" + newHighlights.Split('-')[^1];
 
+        // Dumont Station - usa o id do job para loc
         if (!string.IsNullOrWhiteSpace(jobId)
             && _loc.TryGetString($"highlights-{jobId}", out var jobMatches))
             newHighlights += '\n' + jobMatches.Replace(", ", "\n");

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -191,7 +191,8 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         if (newHighlights.Count(c => c == '-') > 1)
             newHighlights = newHighlights.Split('-')[0] + "\n@" + newHighlights.Split('-')[^1];
 
-        if (_loc.TryGetString($"highlights-{jobId}", out var jobMatches))
+        if (!string.IsNullOrWhiteSpace(jobId)
+            && _loc.TryGetString($"highlights-{jobId}", out var jobMatches))
             newHighlights += '\n' + jobMatches.Replace(", ", "\n");
 
         UpdateHighlights(newHighlights);

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -177,7 +177,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         if (!_charInfoIsAttach)
             return;
 
-        var (_, job, _, _, entityName, _) = data; // Gabystation change - bank
+        var (_, job, _, _, entityName, _, jobId) = data; // Gabystation change - bank
 
         // Mark this entity's name as our character name for the "UpdateHighlights" function.
         var newHighlights = "@" + entityName;
@@ -191,10 +191,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         if (newHighlights.Count(c => c == '-') > 1)
             newHighlights = newHighlights.Split('-')[0] + "\n@" + newHighlights.Split('-')[^1];
 
-        // Convert the job title to kebab-case and use it as a key for the loc file.
-        var jobKey = job.Replace(' ', '-').ToLower();
-
-        if (_loc.TryGetString($"highlights-{jobKey}", out var jobMatches))
+        if (_loc.TryGetString($"highlights-{jobId}", out var jobMatches))
             newHighlights += '\n' + jobMatches.Replace(", ", "\n");
 
         UpdateHighlights(newHighlights);

--- a/Content.Server/CharacterInfo/CharacterInfoSystem.cs
+++ b/Content.Server/CharacterInfo/CharacterInfoSystem.cs
@@ -29,6 +29,8 @@ using Content.Shared.CharacterInfo;
 using Content.Shared.Objectives;
 using Content.Shared.Objectives.Components;
 using Content.Shared.Objectives.Systems;
+using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.CharacterInfo;
 
@@ -40,6 +42,7 @@ public sealed class CharacterInfoSystem : EntitySystem
     [Dependency] private readonly SharedObjectivesSystem _objectives = default!;
     [Dependency] private readonly EconomyManagerSystem _bank = default!;
     [Dependency] private readonly StationSystem _station = default!; // Gaby change
+    [Dependency] private readonly PrototypeManager _proto = default!;
 
     public override void Initialize()
     {
@@ -58,6 +61,7 @@ public sealed class CharacterInfoSystem : EntitySystem
 
         var objectives = new Dictionary<string, List<ObjectiveInfo>>();
         var jobTitle = Loc.GetString("character-info-no-profession");
+        ProtoId<JobPrototype>? job = null;
         string? briefing = null;
         string? nanoBankBriefing = null; // Gabystation change - bank
         if (_minds.TryGetMind(entity, out var mindId, out var mind))
@@ -76,8 +80,9 @@ public sealed class CharacterInfoSystem : EntitySystem
                 objectives[issuer].Add(info.Value);
             }
 
-            if (_jobs.MindTryGetJobName(mindId, out var jobName))
-                jobTitle = jobName;
+            if (_jobs.MindTryGetJobId(mindId, out job)
+                && _proto.TryIndex(job, out var jobProto))
+                jobTitle = jobProto.LocalizedName;
 
             // Get briefing
             briefing = _roles.MindGetBriefing(mindId);
@@ -94,6 +99,6 @@ public sealed class CharacterInfoSystem : EntitySystem
                 nanoBankBriefing = Loc.GetString("economy-character-info-unknown");
         }
 
-        RaiseNetworkEvent(new CharacterInfoEvent(GetNetEntity(entity), jobTitle, objectives, briefing, nanoBankBriefing), args.SenderSession);
+        RaiseNetworkEvent(new CharacterInfoEvent(GetNetEntity(entity), jobTitle, objectives, briefing, nanoBankBriefing, job), args.SenderSession);
     }
 }

--- a/Content.Server/CharacterInfo/CharacterInfoSystem.cs
+++ b/Content.Server/CharacterInfo/CharacterInfoSystem.cs
@@ -42,7 +42,7 @@ public sealed class CharacterInfoSystem : EntitySystem
     [Dependency] private readonly SharedObjectivesSystem _objectives = default!;
     [Dependency] private readonly EconomyManagerSystem _bank = default!;
     [Dependency] private readonly StationSystem _station = default!; // Gaby change
-    [Dependency] private readonly PrototypeManager _proto = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
 
     public override void Initialize()
     {

--- a/Content.Server/CharacterInfo/CharacterInfoSystem.cs
+++ b/Content.Server/CharacterInfo/CharacterInfoSystem.cs
@@ -61,7 +61,7 @@ public sealed class CharacterInfoSystem : EntitySystem
 
         var objectives = new Dictionary<string, List<ObjectiveInfo>>();
         var jobTitle = Loc.GetString("character-info-no-profession");
-        ProtoId<JobPrototype>? job = null;
+        ProtoId<JobPrototype>? job = null; // Dumont Station - passa o id do job
         string? briefing = null;
         string? nanoBankBriefing = null; // Gabystation change - bank
         if (_minds.TryGetMind(entity, out var mindId, out var mind))
@@ -80,6 +80,7 @@ public sealed class CharacterInfoSystem : EntitySystem
                 objectives[issuer].Add(info.Value);
             }
 
+            // Dumont Station - passa o id do job
             if (_jobs.MindTryGetJobId(mindId, out job)
                 && _proto.TryIndex(job, out var jobProto))
                 jobTitle = jobProto.LocalizedName;
@@ -99,6 +100,6 @@ public sealed class CharacterInfoSystem : EntitySystem
                 nanoBankBriefing = Loc.GetString("economy-character-info-unknown");
         }
 
-        RaiseNetworkEvent(new CharacterInfoEvent(GetNetEntity(entity), jobTitle, objectives, briefing, nanoBankBriefing, job), args.SenderSession);
+        RaiseNetworkEvent(new CharacterInfoEvent(GetNetEntity(entity), jobTitle, objectives, briefing, nanoBankBriefing, job), args.SenderSession); // Dumont Station - passa o id do job
     }
 }

--- a/Content.Shared/CharacterInfo/SharedCharacterInfoSystem.cs
+++ b/Content.Shared/CharacterInfo/SharedCharacterInfoSystem.cs
@@ -13,6 +13,8 @@
 // SPDX-License-Identifier: MIT
 
 using Content.Shared.Objectives;
+using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.CharacterInfo;
@@ -36,13 +38,15 @@ public sealed class CharacterInfoEvent : EntityEventArgs
     public readonly Dictionary<string, List<ObjectiveInfo>> Objectives;
     public readonly string? Briefing;
     public readonly string? NanoBankBriefing;
+    public readonly ProtoId<JobPrototype>? Job;
 
-    public CharacterInfoEvent(NetEntity netEntity, string jobTitle, Dictionary<string, List<ObjectiveInfo>> objectives, string? briefing, string? nanoBankBriefing)
+    public CharacterInfoEvent(NetEntity netEntity, string jobTitle, Dictionary<string, List<ObjectiveInfo>> objectives, string? briefing, string? nanoBankBriefing, ProtoId<JobPrototype>? job)
     {
         NetEntity = netEntity;
         JobTitle = jobTitle;
         Objectives = objectives;
         Briefing = briefing;
         NanoBankBriefing = nanoBankBriefing; // Gabystation change - bank
+        Job = job; // Dumont station - passa o id do job
     }
 }

--- a/Content.Shared/CharacterInfo/SharedCharacterInfoSystem.cs
+++ b/Content.Shared/CharacterInfo/SharedCharacterInfoSystem.cs
@@ -38,7 +38,7 @@ public sealed class CharacterInfoEvent : EntityEventArgs
     public readonly Dictionary<string, List<ObjectiveInfo>> Objectives;
     public readonly string? Briefing;
     public readonly string? NanoBankBriefing;
-    public readonly ProtoId<JobPrototype>? Job;
+    public readonly ProtoId<JobPrototype>? Job; // Dumont Station - passa o id do job
 
     public CharacterInfoEvent(NetEntity netEntity, string jobTitle, Dictionary<string, List<ObjectiveInfo>> objectives, string? briefing, string? nanoBankBriefing, ProtoId<JobPrototype>? job)
     {

--- a/Resources/Locale/en-US/chat/highlights.ftl
+++ b/Resources/Locale/en-US/chat/highlights.ftl
@@ -1,64 +1,62 @@
 #Goob start
 #Central Command
-highlights-nanotrasen-representative = Nanotrasen Representative, "Central Command", "NTR", "NT", "CC", Bridge, "Command"
-highlights-blueshield-officer = Blueshield Officer, "Central Command", "BSO", "CC", Bridge, "Command"
-
+highlights-NanotrasenRepresentative = Nanotrasen Representative, "Central Command", "NTR", "NT", "CC", Bridge, "Command"
+highlights-BlueshieldOfficer = Blueshield Officer, "Central Command", "BSO", "CC", Bridge, "Command"
 
 # Command
-highlights-captain = Captain, "Cap", Bridge, "Command"
-highlights-head-of-personnel = Head Of Personnel, "HoP", Service, Bridge, "Command"
-highlights-chief-engineer = Chief Engineer, "CE", Engineering, Engineer, "Engi", Bridge, "Command"
-highlights-chief-medical-officer = Chief Medical Officer, "CMO", MedBay, "Med", Bridge, "Command"
-highlights-head-of-security = Head of Security, "HoS", Security, "Sec", Bridge, "Command"
-highlights-quartermaster = Quartermaster, "QM", Cargo, Bridge, "Command"
-highlights-research-director = Research Director, "RD", Science, "Sci", Bridge, "Command"
+highlights-Captain = Captain, "Cap", Bridge, "Command"
+highlights-HeadOfPersonnel = Head Of Personnel, "HoP", Service, Bridge, "Command"
+highlights-ChiefEngineer = Chief Engineer, "CE", Engineering, Engineer, "Engi", Bridge, "Command"
+highlights-ChiefMedicalOfficer = Chief Medical Officer, "CMO", MedBay, "Med", Bridge, "Command"
+highlights-HeadOfSecurity = Head of Security, "HoS", Security, "Sec", Bridge, "Command"
+highlights-Quartermaster = Quartermaster, "QM", Cargo, Bridge, "Command"
+highlights-ResearchDirector = Research Director, "RD", Science, "Sci", Bridge, "Command"
 #Goob end
 
 # Security
-highlights-detective = Detective, "Det", Security, "Sec"
-highlights-security-cadet = Security Cadet, Secoff, Cadet, Security, "Sec"
-highlights-security-officer = Security Officer, Secoff, Officer, Security, "Sec"
-highlights-warden = Warden, "Ward", Security, "Sec"
+highlights-Detective = Detective, "Det", Security, "Sec"
+highlights-SecurityCadet = Security Cadet, Secoff, Cadet, Security, "Sec"
+highlights-SecurityOfficer = Security Officer, Secoff, Officer, Security, "Sec"
+highlights-Warden = Warden, "Ward", Security, "Sec"
 
 # Cargo
-highlights-cargo-technician = Cargo Technician, Cargo Tech, "Cargo"
-highlights-salvage-specialist = Salvage Specialist, Salvager, Salvage, "Salv", "Cargo", Miner
+highlights-CargoTechnician = Cargo Technician, Cargo Tech, "Cargo"
+highlights-SalvageSpecialist = Salvage Specialist, Salvager, Salvage, "Salv", "Cargo", Miner
 
 # Engineering
-highlights-atmospheric-technician = Atmospheric Technician, Atmos tech, Atmospheric, Engineering, "Atmos", "Engi"
-highlights-station-engineer = Station Engineer, Engineering, Engineer, "Engi"
-highlights-technical-assistant = Technical Assistant, Tech Assistant, Engineering, Engineer, "Engi"
+highlights-AtmosphericTechnician = Atmospheric Technician, Atmos tech, Atmospheric, Engineering, "Atmos", "Engi"
+highlights-StationEngineer = Station Engineer, Engineering, Engineer, "Engi"
+highlights-TechnicalAssistant = Technical Assistant, Tech Assistant, Engineering, Engineer, "Engi"
 
 # Medical
-highlights-chemist = Chemist, Chemistry, "Chem", MedBay, "Med"
-highlights-medical-doctor = Medical Doctor, Doctor, "Doc", MedBay, "Med"
-highlights-medical-intern = Medical Intern, "Doc", Intern, MedBay, "Med"
-highlights-paramedic = Paramedic, "Para", MedBay, "Med"
+highlights-Chemist = Chemist, Chemistry, "Chem", MedBay, "Med"
+highlights-MedicalDoctor = Medical Doctor, Doctor, "Doc", MedBay, "Med"
+highlights-MedicalIntern = Medical Intern, "Doc", Intern, MedBay, "Med"
+highlights-Paramedic = Paramedic, "Para", MedBay, "Med"
 
 # Science
-highlights-scientist = Scientist, Science, "Sci"
-highlights-research-assistant = Research Assistant, Science, "Sci"
+highlights-Scientist = Scientist, Science, "Sci"
+highlights-ResearchAssistant = Research Assistant, Science, "Sci"
 
 # Civilian
-highlights-bartender = Bartender, Barkeeper, Barkeep, "Bar"
-highlights-botanist = Botanist, Botany, Hydroponics
-highlights-chaplain = Chaplain, "Chap", Chapel
-highlights-chef = Chef, "Cook", Kitchen
-highlights-clown = Clown, Jester
-highlights-janitor = Janitor, "Jani"
-highlights-lawyer = Lawyer, Attorney
-highlights-librarian = Librarian, Library
-highlights-mime = Mime
-highlights-passenger = Passenger, Greytider, "Tider"
-highlights-service-worker = Service Worker
+highlights-Bartender = Bartender, Barkeeper, Barkeep, "Bar"
+highlights-Botanist = Botanist, Botany, Hydroponics
+highlights-Chaplain = Chaplain, "Chap", Chapel
+highlights-Chef = Chef, "Cook", Kitchen
+highlights-Clown = Clown, Jester
+highlights-Janitor = Janitor, "Jani"
+highlights-Lawyer = Lawyer, Attorney
+highlights-Librarian = Librarian, Library
+highlights-Mime = Mime
+highlights-Passenger = Passenger, Greytider, "Tider"
+highlights-ServiceWorker = Service Worker
 
 # Station-specific
-highlights-boxer = Boxer
-highlights-reporter = Reporter, Journalist
-highlights-zookeeper = Zookeeper
-highlights-psychologist = Psychologist, Psychology
+highlights-Boxer = Boxer
+highlights-Reporter = Reporter, Journalist
+highlights-Zookeeper = Zookeeper
+highlights-Psychologist = Psychologist, Psychology
 
 # Silicon
-highlights-personal-ai = Personal AI, "pAI"
-highlights-cyborg = Cyborg, Silicon, Borg
-highlights-station-ai = Station AI, Silicon, "AI", "sAI"
+highlights-Borg = Cyborg, Silicon, Borg
+highlights-StationAi = Station AI, Silicon, "AI", "sAI"

--- a/Resources/Locale/pt-BR/chat/highlights.ftl
+++ b/Resources/Locale/pt-BR/chat/highlights.ftl
@@ -1,0 +1,62 @@
+#Goob start
+#Central Command
+highlights-NanotrasenRepresentative = Representante, Central de Comando, "NTR", "NT", "CC", Bridge, Ponte, Comando
+highlights-BlueshieldOfficer = Oficial Blueshield, Central de Comando, "BSO", "CC", Bridge, Ponte, Comando
+
+# Command
+highlights-Captain = Capitão, "Cap", Bridge, Ponte, Comando
+highlights-HeadOfPersonnel = Chefe dos Funcionários, "HoP", Serviço, Bridge, Ponte, Comando
+highlights-ChiefEngineer = Engenheiro Chefe, "CE", Engenharia, Engenheiro, "Eng", Bridge, Ponte, Comando
+highlights-ChiefMedicalOfficer = Médico Chefe, "CMO", MedBay, "Med", Bridge, Ponte, Comando
+highlights-HeadOfSecurity = Chefe da Segurança, "HoS", Security, Segurança, "Sec", Bridge, Ponte, Comando
+highlights-Quartermaster = Intendente, "QM", Cargo, Logística, Bridge, Ponte, Comando
+highlights-ResearchDirector = Diretor de Pesquisa, "RD", Ciência, "Sci", Bridge, Ponte, Comando
+#Goob end
+
+# Security
+highlights-Detective = Detetive, "Det", Segurança, "Sec"
+highlights-SecurityCadet = Cadete da Segurança, Cadete, Segurança, "Sec"
+highlights-SecurityOfficer = Oficial de Segurança, Oficial, Segurança, "Sec"
+highlights-Warden = Warden, Carcereiro, Segurança, "Sec"
+
+# Cargo
+highlights-CargoTechnician = Técnico de Carga, Cargo
+highlights-SalvageSpecialist = Especialista de Exploração, Salvata, Salvage, "Salv", Cargo, Logística, Minerador
+
+# Engineering
+highlights-AtmosphericTechnician = Técnico Atmosférico, Atmosfera, Engenharia, Atmos, "Engi"
+highlights-StationEngineer = Engenheiro da Estação, Engenharia, Engenheiro, "Engi"
+highlights-TechnicalAssistant = Assistente Técnico, Engenharia, Engenheiro, "Engi"
+
+# Medical
+highlights-Chemist = Química, "Chem", MedBay, "Med"
+highlights-MedicalDoctor = Médico, "Doc", MedBay, "Med"
+highlights-MedicalIntern = Médico em Treinamento, Assistente Médico, "Doc", MedBay, "Med"
+highlights-Paramedic = Paramédico, MedBay, "Med"
+
+# Science
+highlights-Scientist = Cientista, Ciência, "Sci"
+highlights-ResearchAssistant = Pesquisador Assistente, Ciência, "Sci"
+
+# Civilian
+highlights-Bartender = Bartender, "Bar"
+highlights-Botanist = Botânico, Botânica, Hidropônica
+highlights-Chaplain = Capelão, "Chap", Capela, Padre
+highlights-Chef = Chefe, Cozinha
+highlights-Clown = Palhaço, Clown, Comédia
+highlights-Janitor = Zelador, Janitor, Jani
+highlights-Lawyer = Advogado
+highlights-Librarian = Bibliotecário, Biblioteca
+highlights-Mime = "Mime", Mímico
+highlights-Passenger = Passageiro, Greytider, Tider
+highlights-ServiceWorker = Faz-Tudo, Serviço, Diarista
+
+# Station-specific
+highlights-Boxer = Boxeador, Boxer
+highlights-Reporter = Reporter, Jornalista
+highlights-Zookeeper = Zoologísta, Zoológico
+highlights-Psychologist = Psicológo, Psicologia, DOIDO VARRIDO
+
+# Silicon
+highlights-Borg = Ciborgue, Silício, Borg
+highlights-StationAi = Station AI, IA da Estação, Silício, "AI", "IA", satélite


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## sobre a PR
o sistema de highlight do chat usa o nome traduzido do trabalho como chave das loc's. então, os nomes com acentos ou sinal gráfico (por exemplo, capitão) não são compatíveis com esse formato, visto que acentos não são permitidos como chave.

essa PR repassa o id do trabalho até o sistema de highlight que usa ele pra criar a chave de loc.

essa mudança vai quebrar todos os highlights que vão precisar ter seu id atualizado.

- [x] rever todos os LocIds e alterar para esse novo formato;
- [x] marcar as mudanças com `# dumont station`.