### PR TITLE
conserta as receitas de granadas da sec

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -791,12 +791,12 @@
     - SecurityBoardsStaticGoob
     - SecurityBoardsStaticGoob
     - PowerCellsStatic
-    - ScienceExplosives
     - GrenadeTriggersStatic
     - SecurityWeaponsStaticGoob
     - CablesStatic #Dumont
     - ERTAmmoStaticGoob #Dumont, so that sec can print .30 for some new guns
     dynamicPacks:
+    - ScienceExplosives
     - SalvageSecurityBoards
     - SalvageSecurityWeapons
     - SecurityEquipment

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -470,7 +470,6 @@
     - SecurityWeaponsStaticGoob
     - SecurityAmmoStaticGoob
     - SyndicateAmmoLightStatic
-    - ScienceExplosives
   - type: BlueprintReceiver
     whitelist:
       tags:
@@ -566,6 +565,7 @@
     - SecurityWeaponsGoob
     - RestraintTechnology
     - MiningWeapons
+    - ScienceExplosives
 
 - type: entity
   id: ProtolatheHyperConvection

--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -39,7 +39,6 @@
   - Dropper #Goobstation
   - PillCanister
   - HandLabeler
-  - ChemicalPayload
   - BaseChemistryEmptyVial
 
 - type: latheRecipePack
@@ -124,6 +123,7 @@
   - SyringeBluespace
   - MedkitCombat #goob - Move combat kit to research
   - VialBluespace # goob edit - bluespace vials
+  - ChemicalPayload
 
 - type: latheRecipePack
   id: MedicalBoards

--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -67,8 +67,6 @@
   - MagazineShotgunSlug
   - SpeedLoaderMagnum
   - SpeedLoaderMagnumEmpty
-  - ShrapnelPayload
-  - GrenadeStinger #Dumont
 
 - type: latheRecipePack
   id: SecurityWeaponsStatic
@@ -111,6 +109,8 @@
   - GrenadeEMP
   - GrenadeFlash
   - MagazineGrenadeEmpty
+  - ShrapnelPayload
+  - GrenadeStinger #Dumont
 
 # Shared between secfab and emagged protolathe
 - type: latheRecipePack

--- a/Resources/Prototypes/_Gabystation/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Clothing/Shoes/boots.yml
@@ -83,9 +83,9 @@
           - Knife
           - Sidearm
   - type: ClothingSlowOnDamageModifier
-    modifier: 0.5
+    modifier: 0.75
   - type: ModifyStandingUpTime
-    multiplier: 0.5
+    multiplier: 0.75
   - type: Armor
     traumaDeductions:
       Dismemberment: 0.1
@@ -108,3 +108,6 @@
   - type: FootstepModifier # GabyStation
     footstepSoundCollection:
       collection: BootStomp
+  - type: ClothingSpeedModifier
+    walkModifier: 0.85
+    sprintModifier: 0.85

--- a/Resources/Prototypes/_Gabystation/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Clothing/Shoes/boots.yml
@@ -108,6 +108,3 @@
   - type: FootstepModifier # GabyStation
     footstepSoundCollection:
       collection: BootStomp
-  - type: ClothingSpeedModifier
-    walkModifier: 0.85
-    sprintModifier: 0.85

--- a/Resources/Prototypes/_Gabystation/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Clothing/Shoes/boots.yml
@@ -83,9 +83,9 @@
           - Knife
           - Sidearm
   - type: ClothingSlowOnDamageModifier
-    modifier: 0.75
+    modifier: 0.5
   - type: ModifyStandingUpTime
-    multiplier: 0.75
+    multiplier: 0.5
   - type: Armor
     traumaDeductions:
       Dismemberment: 0.1

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/lathe.yml
@@ -207,10 +207,10 @@
     - ElectronicsStatic
     - SurgeryStatic
     - ScienceBoardsStatic
-    - ScienceExplosives # Goobstation - Roundstart Grenade Tech
     - GrenadeTriggersStatic # Goobstation - Roundstart Grenade Tech
     - MiscSignallersStatic
     dynamicPacks:
+    - ScienceExplosives
     - AdvancedTools
     - ScienceEquipment
     - ScienceClothing


### PR DESCRIPTION
## Sobre a PR
Conserta as pesquisas de granadas ainda sendo roundstart

## Por quê? / Balanceamento
<img width="264" height="191" alt="image" src="https://github.com/user-attachments/assets/90d55608-b0ac-4e98-a521-da48f620b249" />

## Detalhes Tecnicos
movi os science explosives e security explosives pra o dynamic pack5%

## Anexos
<img width="356" height="124" alt="image" src="https://github.com/user-attachments/assets/1a67f94a-b292-42cf-8c85-a6f517bb17cd" />

<img width="391" height="177" alt="image" src="https://github.com/user-attachments/assets/5227ea6a-fb8d-4dda-b9f9-a7eed4463244" />


pós pesquisa:

<img width="385" height="143" alt="image" src="https://github.com/user-attachments/assets/2ea09baf-8074-4ae5-865c-7ec8e66083bf" />


<img width="406" height="191" alt="image" src="https://github.com/user-attachments/assets/a8d788e0-c469-46a8-b9d8-e7242a1d00c7" />


## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl: Heartbeat
- fix: Agora granadas de borracha e payloads REALMENTE precisam ser pesquisadas.
