### PR TITLE
rebalanceamento as secboots

### DIFF
--- a/Resources/Prototypes/_Gabystation/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Clothing/Shoes/boots.yml
@@ -83,9 +83,9 @@
           - Knife
           - Sidearm
   - type: ClothingSlowOnDamageModifier
-    modifier: 0.5
+    modifier: 0.75
   - type: ModifyStandingUpTime
-    multiplier: 0.5
+    multiplier: 0.75
   - type: Armor
     traumaDeductions:
       Dismemberment: 0.1
@@ -108,3 +108,6 @@
   - type: FootstepModifier # GabyStation
     footstepSoundCollection:
       collection: BootStomp
+  - type: ClothingSpeedModifier
+    walkModifier: 0.85
+    sprintModifier: 0.85


### PR DESCRIPTION
## Sobre a PR
faz as magboots de segurança ser coturnos piores e magboots melhores

## Por quê? / Balanceamento
Pra as magboots não ser um upgrade perfeito aos coturnos.

## Detalhes Tecnicos
50% redução de slowdown de ferimento e knockdown >25%
20% slowdown>15%

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/coebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl: Heartbeat
- tweak: Magboots de sec agora são melhores como magboots e piores como coturnos.
