### PR TITLE
Adiciona megafone e tablet pro hos remove tablet do cap

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -222,7 +222,7 @@
       conditions:
       - !type:PlayerCountCondition
         max: 15
-    - id: SecApartmentTablet # Corvax-SecApartment
+#    - id: SecApartmentTablet # Dumont edit not the captain's job.
 
 # No laser table + Laser table
 - type: entityTable
@@ -562,6 +562,8 @@
     - id: HeadOfSecurityWeaponUndetermined # Gabystation - readiciona kit de arma pro hos
     - id: BoxTapeRecorder # Gabystation
       prob: 0.5
+    - id: SecApartmentTablet # Dumont edit it's the hos's job
+    - id: SecurityMegaphone
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable


### PR DESCRIPTION
## Sobre a PR
Remove o tablet segurapartamento do armário do capitão.
Adiciona o megafone de segurança e tablet segurapartamento pro hos.

## Por quê? / Balanceamento
Não é o trabalho do cap organizar a sec, isso é coisa do hos.
Eu não sei porque o hos não recebeu um megafone quando o warden recebeu.
É irritante ser hos e ver o capitão tentando alterar as equipes do SEU departamento.

## Detalhes Tecnicos
yml my beloved

## Anexos

https://github.com/user-attachments/assets/ecea19d4-859c-4a07-a1ea-b4ec2d32d96b




## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl: Heartbeat
- add: Tablet de equipes de segurança pro armário do chefe de segurança.
- add: Megafone de segurança pro armário do chefe de segurança.
- remove: Tablet de equipes de segurança do armário do capitão.
