### PR TITLE
Desativar Waddlers

### DIFF
--- a/Resources/Prototypes/_Gabystation/Species/waddler.yml
+++ b/Resources/Prototypes/_Gabystation/Species/waddler.yml
@@ -6,7 +6,7 @@
 - type: species
   id: Waddler
   name: species-name-waddler
-  roundStart: true
+  roundStart: false
   prototype: MobWaddler
   sprites: MobWaddlerSprites
   defaultSkinTone: "#0c0b52"


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: MIT -->

## Sobre a PR
<!-- O que ela muda? -->
Desativa Waddlers

## Por quê? / Balanceamento
<!-- Discuta do por que da existencia da PR. (opcional | recomendado) -->
Como criadora da espécie, eu estou recebendo notícias sobre como estão absolutamente deturpando ela.
Ver: #430 #444 e #445

Waddlers, do verbo "waddle", são uma referência direta aos pinguins do jogo online finado Club Penguin, de autoria da Disney.
**TODOS** os elementos dessa espécie servem como referência direta ao jogo e como uma piada. A espécie também nasceu como uma crítica as atitudes dos jogadores em quererem CONSTANTEMENTE modificar as espécies por não gostarem de algum fator delas, como visto no PR #430 na frase "Ela foi criada tanto como uma piada quanto como um protesto aos jogadores que cobram dos contribuidores que suas espécies sejam mais fortes.".

Ando recebendo notícias de que a comunidade vem constantemente modificando a espécie para colocar uma lore TOTALMENTE SEM NEXO E EXTREMAMENTE ENVIESADA/POLITIZADA num personagem de jogo infantil, além de modificarem os sprites da espécie para um que, POR MAIS QUE SEJAM DE QUALIDADE, não condizem de forma alguma com o intuito original da espécie. Não vou entrar muito no assunto aqui, mas seria o equivalente a você colocar uma ideologia pessoal sua nos Teletubbies para tornar o conteúdo mais dark, quando não há necessidade alguma disso.

Dito isso, toda essa movimentação feita pela comunidade é uma agressão DIRETA ao meu trabalho, um tapa na cara daqueles que AINDA jogam dessa espécie (QUE NÃO CONCORDARAM COM AS MUDANÇAS DE LORE E SPRITE), e um cuspe na testa daqueles que tiveram infância e receberam dose de nostalgia ao jogar com essa espécie.

Eu peço humildemente que esse PR seja aceito, como medida de **prevenção** de danos a essa obra.

## Detalhes Tecnicos
<!-- Mudanças do codigo para uma review mais facil (opcional). -->

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione uma entrada para changelog do servidor, bote o emoji :cl: e siga com as mudanças assim como o exemplo.
:cl: em branco fara com que seu nome na changelog apareça como do github, adicione um nome depois do emoji para mudar seu nome na changelog. -->
:cl:
- remove: Waddlers removidos da rotação.
