### PR TITLE
Muda valores de muitas coisas midround

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -164,7 +164,7 @@
     - id: JobDistributionError
     - id: KudzuGrowth
     - id: MassHallucinations
-    - id: MimicVendorRule
+#    - id: MimicVendorRule dumont edit doesn't do shit, useless event
     - id: MouseMigration
     - id: PowerGridCheck
     - id: RandomSentience
@@ -641,7 +641,7 @@
     eventType: Maintenance # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 80
+    chaosScore: 100 #dumont edit
   - type: KudzuGrowthRule
 
 - type: entity
@@ -649,7 +649,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
-    weight: 5
+    weight: 3
     startAnnouncement: station-event-power-grid-check-start-announcement
     startAudio:
       path: /Audio/_Gabystation/Announcements/power_off_saae.ogg
@@ -659,7 +659,7 @@
     eventType: Interference # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 80
+    chaosScore: 120 #Dumont edit annoying
   - type: PowerGridCheckRule
 
 - type: entity
@@ -667,7 +667,7 @@
   id: SolarFlare
   components:
   - type: StationEvent
-    weight: 8
+    weight: 6
     startAnnouncement: station-event-solar-flare-start-announcement
     startAudio:
       path: /Audio/_Gabystation/Announcements/solarflare_on_saae.ogg
@@ -681,7 +681,7 @@
     eventType: Interference # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 60
+    chaosScore: 100 #Dumont edit annoying
   - type: SolarFlareRule
     onlyJamHeadsets: true
     affectedChannels:
@@ -715,7 +715,7 @@
     eventType: Interference # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 70
+    chaosScore: 240 #Dumont edit distracting and fucks up combat
   - type: VentClogRule
 
 - type: entity
@@ -736,7 +736,7 @@
     eventType: HostilesSpawn # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 200
+    chaosScore: 120 # dumont edit doesn't do shit
   - type: VentCrittersRule
     table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
       children:
@@ -760,7 +760,7 @@
     eventType: HostilesSpawn # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 240
+    chaosScore: 180 #dumont edit sometimes kills people
   - type: VentCrittersRule
     table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
       children:
@@ -786,7 +786,7 @@
     eventType: HostilesSpawn # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 240
+    chaosScore: 120 # dumont edit weak
   - type: VentCrittersRule
     table: # DeltaV: EntityTable instead of spawn entries
       id: MobGiantSpiderAngry
@@ -809,7 +809,7 @@
     eventType: HostilesSpawn # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 240
+    chaosScore: 150 # Dumont edit they're weak as hell
   - type: VentCrittersRule
     playerRatio: 20 # DeltaV: Clown spiders are very robust
     table: # DeltaV: EntityTable instead of spawn entries
@@ -866,18 +866,19 @@
   components:
   - type: StationEvent
     earliestStart: 35
-    weight: 6.0 # Goobstation - was 5.5
-    minimumPlayers: 20 # Dumontstation was 50 # Goobstation - was 20
+    weight: 1 # Dumontstation - was 6.0 because of *us* and we never noticed it and we always complained about it.
+    minimumPlayers: 30 # Dumontstation was 20
     duration: null
     maxOccurrences: 1 # Gabystation - loneops apenas uma vez por round
     chaos: # Goobstation
-      Hostile: 200
-      Medical: 200
-      Death: 200
+      Hostile: 250
+      Medical: 250
+      Death: 250
+      Combat: 400
     eventType: HostilesSpawn # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 700
+    chaosScore: 800 # Dumont edit they end the round when they show up and can declare war
   - type: RuleGrids
   - type: LoadMapRule
     gridPath: /Maps/Shuttles/ShuttleEvent/striker_loneops.yml # GabyStation

--- a/Resources/Prototypes/_Gabystation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Gabystation/GameRules/midround.yml
@@ -63,7 +63,7 @@
       Death: 200
     eventType: HostilesSpawn
   - type: GameRule
-    chaosScore: 500
+    chaosScore: 800
   - type: AlertLevelInterceptionRule
   - type: AntagSelection
     selectionTime: PostPlayerSpawn
@@ -112,7 +112,7 @@
   - type: AlertLevelInterceptionRule
   - type: AntagSelection
     selectionTime: PostPlayerSpawn
-    agentName: cosmic-cult-roundend-name 
+    agentName: cosmic-cult-roundend-name
     definitions:
     - prefRoles: [ CosmicAntagCultist ]
       max: 4
@@ -152,7 +152,7 @@
       Death: 400
     eventType: HostilesSpawn
   - type: GameRule
-    chaosScore: 1000
+    chaosScore: 1100
   - type: AlertLevelInterceptionRule
   - type: AntagSelection
     selectionTime: PostPlayerSpawn
@@ -190,7 +190,7 @@
   - type: StationEvent
     earliestStart: 20
     weight: 3
-    minimumPlayers: 30
+    minimumPlayers: 20
     duration: null
     occursDuringRoundEnd: false
   - type: MorphRule
@@ -210,6 +210,8 @@
         sound: /Audio/_Gabystation/Misc/Morph/mutate.ogg
       mindRoles:
       - MindRoleMorph
+  - type: GameRule
+    chaosScore: 200 # dumont edit maybe it'll actually be spawned now
 
 # Midround Revs
 - type: entity

--- a/Resources/Prototypes/_Goobstation/GameRules/bingleEvent.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/bingleEvent.yml
@@ -17,7 +17,7 @@
   components:
   - type: StationEvent
     earliestStart: 30 # Gaby change
-    weight: 8
+    weight: 6 # Dumont edit
     duration: 50
     minimumPlayers: 25 # Gaby change
     maxOccurrences: 1 # Gaby change

--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -347,7 +347,7 @@
       Death: 60
     eventType: HostilesSpawn
   - type: GameRule
-    chaosScore: 350
+    chaosScore: 200 # he barely does anything
   - type: AntagSpawner
     prototype: MobHumanDarkPriest
   - type: AntagSelection

--- a/Resources/Prototypes/_Goobstation/_Pirates/game_ticking.yml
+++ b/Resources/Prototypes/_Goobstation/_Pirates/game_ticking.yml
@@ -27,7 +27,7 @@
       Death: 25
     eventType: HostilesSpawn
   - type: GameRule
-    chaosScore: 150 # dumont edit make the chaos score apply to the pirate being spawned not cargo losing 5 spesos
+    chaosScore: 300 # dumont edit make the chaos score apply to the pirate being spawned not cargo losing 5 spesos
   - type: PendingPirateRule
     ransomPrototype: BikeHornRansom
   - type: Tag

--- a/Resources/Prototypes/_Goobstation/_Pirates/game_ticking.yml
+++ b/Resources/Prototypes/_Goobstation/_Pirates/game_ticking.yml
@@ -27,7 +27,7 @@
       Death: 25
     eventType: HostilesSpawn
   - type: GameRule
-    chaosScore: 650
+    chaosScore: 150 # dumont edit make the chaos score apply to the pirate being spawned not cargo losing 5 spesos
   - type: PendingPirateRule
     ransomPrototype: BikeHornRansom
   - type: Tag
@@ -61,6 +61,8 @@
   - type: Tag
     tags:
     - MidroundAntag
+  - type: GameRule
+    chaosScore: 500 # dumont edit make the chaos score apply to the pirate being spawned not cargo losing 5 spesos
 
 - type: entity
   parent: BikeHorn

--- a/Resources/Prototypes/_Shitmed/GameRules/events.yml
+++ b/Resources/Prototypes/_Shitmed/GameRules/events.yml
@@ -28,10 +28,10 @@
   - type: StationEvent
     earliestStart: 45
     reoccurrenceDelay: 45
-    weight: 3 # Goobstation - 7.5 -> 3
+    weight: 2 # dumont edit too many abductors (was 3)
     minimumPlayers: 18 # menos abductor por favor
     duration: null # Goobstation - chud
-    maxOccurrences: 2 # Gabystation - menos abductors
+    maxOccurrences: 1 # Dumont edit why do we need more than 1 abductor, plus abductor duo?
     chaos:
       Hostile: 150 # menos abductor por favor
       Medical: 75
@@ -129,7 +129,7 @@
   - type: StationEvent # Gabystation - Less abductors
     earliestStart: 60
     reoccurrenceDelay: 45
-    weight: 3 # Goobstation - 7.5 -> 3
+    weight: 1 # Dumont edit too many abductors (was 3)
     minimumPlayers: 25
     duration: null # Goobstation - chud
     maxOccurrences: 1

--- a/Resources/Prototypes/_White/GameRules/events.yml
+++ b/Resources/Prototypes/_White/GameRules/events.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   parent: BaseGameRule
   id: XenomorphsInfestation

--- a/Resources/Prototypes/_White/GameRules/events.yml
+++ b/Resources/Prototypes/_White/GameRules/events.yml
@@ -3,9 +3,9 @@
   id: XenomorphsInfestation
   components:
   - type: StationEvent
-    weight: 1.5 # Goobstation - was 7.5
+    weight: 3 #Dumont edit was 1.5
     duration: null
-    minimumPlayers: 50 # Goobstation - was 20
+    minimumPlayers: 30 # Dumont edit was 50
     earliestStart: 30 # Goobstation
     #reoccurrenceDelay: 50 # Goobstation - no longer needed
     maxOccurrences: 1 # Goobstation
@@ -15,7 +15,7 @@
       Death: 400
     eventType: HostilesSpawn
   - type: GameRule
-    chaosScore: 400
+    chaosScore: 600
   - type: VentSpawnRule
   - type: AntagSpawner
     prototype: MobXenomorphLarva


### PR DESCRIPTION
## Sobre a PR
Muda valores de peso e chaosscore para vários midrounds.

## Por quê? / Balanceamento
Tava tendo uma inflação de o que tinha que ser raro e uma falta do que precisava ter mais.
Eu alterei em base do que pessoas reclamaram e minhas experiências pessoais com o jogo.

<img width="498" height="459" alt="secretomedio" src="https://github.com/user-attachments/assets/27044908-f3aa-437c-90b2-d383bf5ba980" />



## Detalhes Tecnicos
Yml.
Você sabia que lone ops era 3 vezes mais comum que dragão e spawnava com so 20 players? 
Sintam livre pra comentar qualquer coisa ai que eu deveria alterar.

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione uma entrada para changelog do servidor, bote o emoji :cl: e siga com as mudanças assim como o exemplo.
:cl: em branco fara com que seu nome na changelog apareça como do github, adicione um nome depois do emoji para mudar seu nome na changelog. -->
:cl: Heartbeat
- tweak: Mudança para spawns de vários midrounds. Lone ops não vai mais spawnar *todo* round.
