### PR TITLE
[CARGA] adiciona uma notificação no radio quando pulando uma bounty

### DIFF
--- a/Content.Server/Cargo/Systems/CargoSystem.Bounty.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Bounty.cs
@@ -94,12 +94,16 @@ using Content.Shared.NameIdentifier;
 using Content.Shared.Paper;
 using Content.Shared.Stacks;
 using Content.Shared.Whitelist;
+using Content.Shared.Radio;
 using JetBrains.Annotations;
 using Robust.Server.Containers;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
+using Robust.Shared.Prototypes;
+using Content.Shared.IdentityManagement;
+using System.Reflection.Metadata.Ecma335;
 
 namespace Content.Server.Cargo.Systems;
 
@@ -110,6 +114,7 @@ public sealed partial class CargoSystem
     [Dependency] private readonly EntityWhitelistSystem _whitelistSys = default!;
 
     private static readonly ProtoId<NameIdentifierGroupPrototype> BountyNameIdentifierGroup = "Bounty";
+    private static readonly ProtoId<RadioChannelPrototype> CargoRadioChannel = "Supply";
 
     private EntityQuery<StackComponent> _stackQuery;
     private EntityQuery<ContainerManagerComponent> _containerQuery;
@@ -183,6 +188,17 @@ public sealed partial class CargoSystem
 
         if (!TryRemoveBounty(station, bounty.Value, true, args.Actor))
             return;
+
+        CargoBountyData bountyData = bounty.Value;
+
+        var ev = new TryGetIdentityShortInfoEvent(null, args.Actor);
+        RaiseLocalEvent(ev);
+        
+        _radio.SendRadioMessage(
+            uid, 
+            Loc.GetString("bounty-skip-message", 
+            ("bounty", "#" + bountyData.Id), ("user", ev.Title ?? Loc.GetString("bounty-skip-unknown") )), CargoRadioChannel, 
+            uid);
 
         FillBountyDatabase(station);
         db.NextSkipTime = Timing.CurTime + db.SkipDelay;

--- a/Content.Server/Cargo/Systems/CargoSystem.Bounty.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Bounty.cs
@@ -193,12 +193,12 @@ public sealed partial class CargoSystem
 
         var ev = new TryGetIdentityShortInfoEvent(null, args.Actor);
         RaiseLocalEvent(ev);
+
+        var message = Loc.GetString("bounty-skip-message", 
+            ("bounty", "ID#" + bountyData.Id), 
+            ("user", ev.Title ?? Loc.GetString("bounty-skip-unknown")));
         
-        _radio.SendRadioMessage(
-            uid, 
-            Loc.GetString("bounty-skip-message", 
-            ("bounty", "#" + bountyData.Id), ("user", ev.Title ?? Loc.GetString("bounty-skip-unknown") )), CargoRadioChannel, 
-            uid);
+        _radio.SendRadioMessage(uid, message, CargoRadioChannel, uid, escapeMarkup: false);
 
         FillBountyDatabase(station);
         db.NextSkipTime = Timing.CurTime + db.SkipDelay;

--- a/Resources/Locale/en-US/cargo/bounties.ftl
+++ b/Resources/Locale/en-US/cargo/bounties.ftl
@@ -163,5 +163,5 @@ bounty-description-microwave-machine-board = Mr. Giggles thought it'd be funny t
 bounty-description-flashes = GREETINGS \[Station] WE REQUIRE 6 FLASHES DUE TO A NORMAL \[TrainingExercise] WITH SECURITY. EVERYTHING IS \[Normal].
 bounty-description-ring = On this EXTRAORDINARY day there will be a wedding between the Gelts, but Mr. Gelt has lost the rings, send a pair of rings.
 
-bounty-skip-message = Bounty {$bounty} was skipped by {$user}.
+bounty-skip-message = Bounty [bold]{$bounty}[/bold] was skipped by [bold]{$user}[/bold].
 bounty-skip-unknown = unknown

--- a/Resources/Locale/en-US/cargo/bounties.ftl
+++ b/Resources/Locale/en-US/cargo/bounties.ftl
@@ -162,3 +162,6 @@ bounty-description-cotton-boll = A massive swarm of mothroaches ate all the pape
 bounty-description-microwave-machine-board = Mr. Giggles thought it'd be funny to stick forks in all the kitchen microwaves. Help us replace them before the chefs start making clown burgers.
 bounty-description-flashes = GREETINGS \[Station] WE REQUIRE 6 FLASHES DUE TO A NORMAL \[TrainingExercise] WITH SECURITY. EVERYTHING IS \[Normal].
 bounty-description-ring = On this EXTRAORDINARY day there will be a wedding between the Gelts, but Mr. Gelt has lost the rings, send a pair of rings.
+
+bounty-skip-message = Bounty {$bounty} was skipped by {$user}.
+bounty-skip-unknown = unknown

--- a/Resources/Locale/pt-BR/cargo/bounties.ftl
+++ b/Resources/Locale/pt-BR/cargo/bounties.ftl
@@ -139,5 +139,5 @@ bounty-description-flashes = SAUDAÇÕES \[Estação] EXIGIMOS 6 FLASHES DEVIDO 
 bounty-description-tooth-space-carp = Alguns rapazes da "unda down" precisam de alguns dentes para fazer suas roupas tradicionais. Envie-lhes alguns de alguma carpa espacial.
 bounty-description-tooth-sharkminnow = O chef afirma que os dentes dos sharminnows é um material de faca de alta qualidade. Não sei o que eles estão falando, mas eles querem um set. Envie para eles.
 
-bounty-skip-message = Recompensa {$bounty} foi pulada por {$user}.
+bounty-skip-message = Recompensa [bold]{$bounty}[/bold] foi pulada por [bold]{$user}[/bold].
 bounty-skip-unknown = desconhecido

--- a/Resources/Locale/pt-BR/cargo/bounties.ftl
+++ b/Resources/Locale/pt-BR/cargo/bounties.ftl
@@ -138,3 +138,6 @@ bounty-description-microwave-machine-board = O Sr. Giggles achou que seria engra
 bounty-description-flashes = SAUDAÇÕES \[Estação] EXIGIMOS 6 FLASHES DEVIDO A UM \[Exercício de Treinamento] NORMAL COM SEGURANÇA. TUDO ESTÁ \[Normal].
 bounty-description-tooth-space-carp = Alguns rapazes da "unda down" precisam de alguns dentes para fazer suas roupas tradicionais. Envie-lhes alguns de alguma carpa espacial.
 bounty-description-tooth-sharkminnow = O chef afirma que os dentes dos sharminnows é um material de faca de alta qualidade. Não sei o que eles estão falando, mas eles querem um set. Envie para eles.
+
+bounty-skip-message = Recompensa {$bounty} foi pulada por {$user}.
+bounty-skip-unknown = desconhecido


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## Sobre a PR
Pular uma bounty na cargo agora manda uma mensagem no rádio. Closes Issue #687 

## Por quê? / Balanceamento
É bom avisar os jogadores quando isso acontece

## Detalhes Tecnicos
Levanta o evento local pra conseguir a identidade da pessoa fazendo, e usa radiosystem pra mandar uma mensagem no chat

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione uma entrada para changelog do servidor, bote o emoji :cl: e siga com as mudanças assim como o exemplo.
:cl: em branco fara com que seu nome na changelog apareça como do github, adicione um nome depois do emoji para mudar seu nome na changelog. -->
:cl:
- add: Radio agora avisa quando uma bounty é pulada.

espero que não haja nada de errado