### PR TITLE
Remove alguns huds dos fantasmas

### DIFF
--- a/Content.Server/_Orion/ToggleableHUD/ToggleableHUDSystem.cs
+++ b/Content.Server/_Orion/ToggleableHUD/ToggleableHUDSystem.cs
@@ -30,82 +30,80 @@ public sealed class ToggleableHudSystem : EntitySystem
         SubscribeLocalEvent<ToggleableHUDComponent, ToggleActionEvent>(OnToggle);
     }
 
-    private void OnMapInit(EntityUid uid, ToggleableHUDComponent component, MapInitEvent args)
+    private void OnMapInit(Entity<ToggleableHUDComponent> ent, ref MapInitEvent args)
     {
-        _actions.AddAction(uid, ref component.ActionEntity, component.Action, uid);
+        var (uid, comp) = ent;
+        _actions.AddAction(uid, ref comp.ActionEntity, comp.Action, uid);
     }
 
-    private void OnShutdown(EntityUid uid, ToggleableHUDComponent component, ComponentShutdown args)
+    private void OnShutdown(Entity<ToggleableHUDComponent> ent, ref ComponentShutdown args)
     {
-        _actions.RemoveAction(uid, component.ActionEntity);
+        _actions.RemoveAction(ent.Owner, ent.Comp.ActionEntity);
     }
 
-    private void OnToggle(EntityUid uid, ToggleableHUDComponent component, ref ToggleActionEvent args)
+    private void OnToggle(Entity<ToggleableHUDComponent> ent, ref ToggleActionEvent args)
     {
         if (args.Handled)
             return;
 
-        args.Handled = TryToggle(uid, component);
+        args.Handled = TryToggle(ent);
     }
 
-    public bool TryToggle(EntityUid uid, ToggleableHUDComponent? component = null)
+    public bool TryToggle(Entity<ToggleableHUDComponent> ent)
     {
-        if (!Resolve(uid, ref component))
-            return false;
+        var actionToggle = !ent.Comp.IsToggled;
 
-        var actionToggle = !component.IsToggled;
-
-        var popupKey = actionToggle ? component.PopupToggleOn : component.PopupToggleOff;
+        var popupKey = actionToggle ? ent.Comp.PopupToggleOn : ent.Comp.PopupToggleOff;
         var popupMessage = Loc.GetString(popupKey);
 
         // 这是个好办法，我发誓 😱
         if (actionToggle)
         {
-            EnsureComp<ShowJobIconsComponent>(uid);
+            EnsureComp<ShowJobIconsComponent>(ent);
 
             // HealthBars should have a list of damage containers
-            var healthBars = EnsureComp<ShowHealthBarsComponent>(uid);
-            healthBars.DamageContainers = new List<ProtoId<DamageContainerPrototype>>(component.DamageContainers);
-            Dirty(uid, healthBars);
-            EnsureComp<ShowHealthIconsComponent>(uid);
+            var healthBars = EnsureComp<ShowHealthBarsComponent>(ent);
+            healthBars.DamageContainers = new List<ProtoId<DamageContainerPrototype>>(ent.Comp.DamageContainers);
+            Dirty(ent, healthBars);
+            EnsureComp<ShowHealthIconsComponent>(ent);
 
-            if (component.IsAdmin)
+            if (ent.Comp.IsAdmin)
             {
-                EnsureComp<ShowMindShieldIconsComponent>(uid);
-                EnsureComp<ShowCriminalRecordIconsComponent>(uid);
+                EnsureComp<ShowMindShieldIconsComponent>(ent);
+                EnsureComp<ShowCriminalRecordIconsComponent>(ent);
 
-                EnsureComp<ShowDiseaseIconsComponent>(uid);
+                EnsureComp<ShowDiseaseIconsComponent>(ent);
 
-                EnsureComp<ShowSyndicateIconsComponent>(uid);
+                EnsureComp<ShowSyndicateIconsComponent>(ent);
 
-                EnsureComp<ShowHungerIconsComponent>(uid);
-                EnsureComp<ShowThirstIconsComponent>(uid);
+                EnsureComp<ShowHungerIconsComponent>(ent);
+                EnsureComp<ShowThirstIconsComponent>(ent);
             }
         }
         else
         {
-            RemComp<ShowJobIconsComponent>(uid);
-            RemComp<ShowHealthBarsComponent>(uid);
-            RemComp<ShowHealthIconsComponent>(uid);
+            RemComp<ShowJobIconsComponent>(ent);
+            RemComp<ShowHealthBarsComponent>(ent);
+            RemComp<ShowHealthIconsComponent>(ent);
 
-            if (component.IsAdmin)
+            if (ent.Comp.IsAdmin)
             {
-                RemComp<ShowMindShieldIconsComponent>(uid);
-                RemComp<ShowCriminalRecordIconsComponent>(uid);
+                RemComp<ShowMindShieldIconsComponent>(ent);
+                RemComp<ShowCriminalRecordIconsComponent>(ent);
 
-                RemComp<ShowDiseaseIconsComponent>(uid);
+                RemComp<ShowDiseaseIconsComponent>(ent);
 
-                RemComp<ShowSyndicateIconsComponent>(uid);
+                RemComp<ShowSyndicateIconsComponent>(ent);
 
-                RemComp<ShowHungerIconsComponent>(uid);
-                RemComp<ShowThirstIconsComponent>(uid);
+                RemComp<ShowHungerIconsComponent>(ent);
+                RemComp<ShowThirstIconsComponent>(ent);
             }
         }
 
-        _popup.PopupEntity(popupMessage, uid, uid);
+        _popup.PopupEntity(popupMessage, ent, ent);
 
-        component.IsToggled = actionToggle;
-        Dirty(uid, component);
+        ent.Comp.IsToggled = actionToggle;
+        Dirty(ent);
 
         return true;
     }

--- a/Content.Server/_Orion/ToggleableHUD/ToggleableHUDSystem.cs
+++ b/Content.Server/_Orion/ToggleableHUD/ToggleableHUDSystem.cs
@@ -62,35 +62,44 @@ public sealed class ToggleableHudSystem : EntitySystem
         if (actionToggle)
         {
             EnsureComp<ShowJobIconsComponent>(uid);
-            EnsureComp<ShowMindShieldIconsComponent>(uid);
-            EnsureComp<ShowCriminalRecordIconsComponent>(uid);
 
             // HealthBars should have a list of damage containers
             var healthBars = EnsureComp<ShowHealthBarsComponent>(uid);
             healthBars.DamageContainers = new List<ProtoId<DamageContainerPrototype>>(component.DamageContainers);
             Dirty(uid, healthBars);
             EnsureComp<ShowHealthIconsComponent>(uid);
-            EnsureComp<ShowDiseaseIconsComponent>(uid);
 
-            EnsureComp<ShowSyndicateIconsComponent>(uid);
+            if (component.IsAdmin)
+            {
+                EnsureComp<ShowMindShieldIconsComponent>(uid);
+                EnsureComp<ShowCriminalRecordIconsComponent>(uid);
 
-            EnsureComp<ShowHungerIconsComponent>(uid);
-            EnsureComp<ShowThirstIconsComponent>(uid);
+                EnsureComp<ShowDiseaseIconsComponent>(uid);
+
+                EnsureComp<ShowSyndicateIconsComponent>(uid);
+
+                EnsureComp<ShowHungerIconsComponent>(uid);
+                EnsureComp<ShowThirstIconsComponent>(uid);
+            }
         }
         else
         {
             RemComp<ShowJobIconsComponent>(uid);
-            RemComp<ShowMindShieldIconsComponent>(uid);
-            RemComp<ShowCriminalRecordIconsComponent>(uid);
-
             RemComp<ShowHealthBarsComponent>(uid);
             RemComp<ShowHealthIconsComponent>(uid);
-            RemComp<ShowDiseaseIconsComponent>(uid);
 
-            RemComp<ShowSyndicateIconsComponent>(uid);
+            if (component.IsAdmin)
+            {
+                RemComp<ShowMindShieldIconsComponent>(uid);
+                RemComp<ShowCriminalRecordIconsComponent>(uid);
 
-            RemComp<ShowHungerIconsComponent>(uid);
-            RemComp<ShowThirstIconsComponent>(uid);
+                RemComp<ShowDiseaseIconsComponent>(uid);
+
+                RemComp<ShowSyndicateIconsComponent>(uid);
+
+                RemComp<ShowHungerIconsComponent>(uid);
+                RemComp<ShowThirstIconsComponent>(uid);
+            }
         }
 
         _popup.PopupEntity(popupMessage, uid, uid);

--- a/Content.Shared/_Orion/ToggleableHUD/ToggleableHUDComponent.cs
+++ b/Content.Shared/_Orion/ToggleableHUD/ToggleableHUDComponent.cs
@@ -37,4 +37,7 @@ public sealed partial class ToggleableHUDComponent : Component
 
     [DataField]
     public string PopupToggleOff = "ghost-gui-toggle-hud-popup-off";
+
+    [DataField]
+    public bool IsAdmin;
 }

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -286,6 +286,8 @@
     allowedVerbs: []
   - type: ExplosionResistance
     damageCoefficient: 0
+  - type: ToggleableHUD # Orion
+    isAdmin: true
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR
Altera para que o botão de toggle hud dos fantasma apenas mostre vida e trabalho.

## Por quê? / Balanceamento
A pedido da administração.

## Detalhes Técnicos
criei um campo `IsAdmin` em `ToggleableHUDComponent` e adiciono/removo os huds dependendo do conteúdo. para aghost esse campo é verdadeiro.

**Changelog**
:cl:
- remove: Removidos alguns huds dos fantasmas.
