### PR TITLE
Dá o fim para os larp de atmo

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/teg.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/teg.yml
@@ -81,7 +81,7 @@
     # It fires processing on behalf of its connected circulators.
     - type: AtmosDevice
     - type: TegGenerator
-
+      thermalEfficiency: 0.1 #Sem mais waste.
     - type: DeviceNetwork
       deviceNetId: AtmosDevices
       receiveFrequencyId: AtmosMonitor


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
Essa PR tem como objetivo alterar o funcionamento do TEG, fazendo com que os jogadores de técnico de atmosfera criem um TEG funcional, em vez de apenas montar um modelo com alto desperdício.

## Por quê? / Balanceamento

[Essa PR descreve todo o motivo.](https://github.com/funky-station/funky-station/pull/2956)
Esse problema também ocorria aqui da mesma forma. Muitos técnicos de atmosfera não interagiam com todo o sistema que o departamento tem a oferecer, focando sempre em setups que não seguem um modelo realmente sustentável. Com isso, a gameplay acabava se resumindo a TEG waste e só. Com essa mudança, os técnicos de atmosfera vão precisar montar um circuito de canos mais elaborado e bem pensado.


## Detalhes Técnicos
Acrescenta apenas uma linha.

## Anexos

<img width="531" height="347" alt="saboooteg" src="https://github.com/user-attachments/assets/c1591ecd-8bb4-4182-851b-80ba7cc6793f" />

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl:

- remove: Larp de atmo.
- tweak: Ajusta o TEG para reduzir desperdício e incentivar configurações mais eficientes.

