### PR TITLE
Indutor - Bugs e etc

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
@@ -49,6 +49,7 @@
 - type: latheRecipePack
   id: ScienceEquipment
   recipes:
+  - InducerScientific # Orion
   - AnomalyScanner
   - NodeScanner
   - AnomalyLocator

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -124,6 +124,7 @@
   recipeUnlocks:
   # Orion-Start
   - InducerScientific
+  - InducerEngineering
   - MegaCellSuper
   - MegaCellHyper
   - MegaCellHigh

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/lathe.yml
@@ -67,6 +67,7 @@
     - NFHoloflareStatic # Frontier - Holoflare
     dynamicPacks:
     - MegaCells # Orion
+    - EngineeringEquipment # Orion
     - ConstructionBagOfHolding
     - AdvancedTools
     - AtmosTools

--- a/Resources/Prototypes/_Orion/Entities/Objects/Power/megacells.yml
+++ b/Resources/Prototypes/_Orion/Entities/Objects/Power/megacells.yml
@@ -70,6 +70,14 @@
   id: MegaCellSmallPrinted
   suffix: Empty
   components:
+  - type: Sprite
+    layers:
+    - map: [ "enum.PowerCellVisualLayers.Base" ]
+      state: small
+    - map: [ "enum.PowerCellVisualLayers.Unshaded" ]
+      state: o2
+      shader: unshaded
+      visible: false
   - type: Battery
     maxCharge: 1800
     startingCharge: 0
@@ -97,6 +105,14 @@
   id: MegaCellHighPrinted
   suffix: Empty
   components:
+  - type: Sprite
+    layers:
+    - map: [ "enum.PowerCellVisualLayers.Base" ]
+      state: high
+    - map: [ "enum.PowerCellVisualLayers.Unshaded" ]
+      state: o2
+      shader: unshaded
+      visible: false
   - type: Battery
     maxCharge: 5400
     startingCharge: 0
@@ -124,6 +140,14 @@
   id: MegaCellSuperPrinted
   suffix: Empty
   components:
+  - type: Sprite
+    layers:
+    - map: [ "enum.PowerCellVisualLayers.Base" ]
+      state: super
+    - map: [ "enum.PowerCellVisualLayers.Unshaded" ]
+      state: o2
+      shader: unshaded
+      visible: false
   - type: Battery
     maxCharge: 6250
     startingCharge: 0
@@ -151,6 +175,14 @@
   id: MegaCellHyperPrinted
   suffix: Empty
   components:
+  - type: Sprite
+    layers:
+    - map: [ "enum.PowerCellVisualLayers.Base" ]
+      state: hyper
+    - map: [ "enum.PowerCellVisualLayers.Unshaded" ]
+      state: o2
+      shader: unshaded
+      visible: false
   - type: Battery
     maxCharge: 9000
     startingCharge: 0
@@ -172,12 +204,24 @@
   - type: Battery
     maxCharge: 11000
     startingCharge: 11000
+  - type: BatterySelfRecharger
+    autoRecharge: true
+    autoRechargeRate: 12
+    canEmp: true
 
 - type: entity
   parent: MegaCellBluespace
   id: MegaCellBluespacePrinted
   suffix: Empty
   components:
+  - type: Sprite
+    layers:
+    - map: [ "enum.PowerCellVisualLayers.Base" ]
+      state: bluespace
+    - map: [ "enum.PowerCellVisualLayers.Unshaded" ]
+      state: o2
+      shader: unshaded
+      visible: false
   - type: Battery
     maxCharge: 11000
     startingCharge: 0

--- a/Resources/Prototypes/_Orion/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/_Orion/Recipes/Lathes/Packs/engineering.yml
@@ -1,0 +1,4 @@
+- type: latheRecipePack
+  id: EngineeringEquipment
+  recipes:
+  - InducerEngineering

--- a/Resources/Prototypes/_Orion/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/_Orion/Recipes/Lathes/Packs/science.yml
@@ -9,4 +9,3 @@
   - MegaCellHyper
   - MegaCellSuper
   - MegaCellBluespace
-  - InducerScientific

--- a/Resources/Prototypes/_Orion/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/_Orion/Recipes/Lathes/tools.yml
@@ -9,3 +9,11 @@
   materials:
     Steel: 500
     Plastic: 100
+
+- type: latheRecipe
+  id: InducerEngineering
+  result: InducerEngineering
+  completetime: 8
+  materials:
+    Steel: 500
+    Plastic: 100


### PR DESCRIPTION
## Sobre a PR
Apenas faz com que o indutor de engenheiro seja fabricável, corrige o indutor de ciência que estava nos fabricadores errados, a luz das megacélula fabricadas que era mostrada incorretamente e a megacélula bluespace que não se recarregava.

## Por quê? / Balanceamento
Apenas qualidade de vida.

## Anexos
"-"

## Requerimentos

- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**

:cl:
- fix: Pequenas correções com os indutores.
