### PR TITLE
Nuclear Fix

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
@@ -116,3 +116,4 @@
   - BluespaceGasVendorMachineCircuitBoard # Gabystation
   - NuclearFabricatorMachineCircuitboard
   - NuclearCentrifugeMachineCircuitboard
+  - NuclearReactorMonitorComputerCircuitboard

--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Machines/nuclear_fabricator.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Machines/nuclear_fabricator.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: NuclearFabricator
-  parent: BaseLatheLube
+  parent: [BaseLatheLube, BaseSiloUtilizer]
   name: nuclear fabricator
   description: It makes nuclear reactor parts.
   components:


### PR DESCRIPTION
## Sobre a PR
Correção de pequenos bugs no yml, onde o fabricador nuclear não podia ser linkado no silo e o computador de controle do reator não podia ser fabricado.

## Por quê? / Balanceamento
Bug fix 

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl:
- fix: Corrigido bug do fabricador nuclear não podendo ser linkado no silo.
- fix: Agora a placa do computador de monitoramento do reator nuclear pode ser fabricada.