### PR TITLE
cria comando para exportar sprites

### DIFF
--- a/Content.Client/_Dumont/Commands/ExportSpriteCommand.cs
+++ b/Content.Client/_Dumont/Commands/ExportSpriteCommand.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Client.Sprite;
 using JetBrains.Annotations;
 using Robust.Shared.Console;

--- a/Content.Client/_Dumont/Commands/ExportSpriteCommand.cs
+++ b/Content.Client/_Dumont/Commands/ExportSpriteCommand.cs
@@ -1,0 +1,32 @@
+using Content.Client.Sprite;
+using JetBrains.Annotations;
+using Robust.Shared.Console;
+
+namespace Content.Client._Dumont.Commands;
+
+[UsedImplicitly]
+public sealed class ExportSpriteCommand : LocalizedCommands
+{
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+
+    public override string Command => "exportsprite";
+
+    public override async void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length is not 1)
+        {
+            shell.WriteLine(Help);
+            return;
+        }
+
+        if (!NetEntity.TryParse(args[0], out var targetUidNet)
+            || !_entityManager.TryGetEntity(targetUidNet, out var targetUid))
+        {
+            shell.WriteLine("Entidade não encontrada");
+            return;
+        }
+
+        var contentSprite = _entityManager.System<ContentSpriteSystem>();
+        await contentSprite.Export(targetUid.Value);
+    }
+}

--- a/Resources/clientCommandPerms.yml
+++ b/Resources/clientCommandPerms.yml
@@ -89,6 +89,7 @@
     - dumpentities
     - showaccessreaders
     - showaudiomuffle # Trauma
+    - exportsprite # Dumont
 
 - Flags: MAPPING
   Commands:


### PR DESCRIPTION
## Sobre a PR
Adiciona um comando de debug client-side que exporta o sprite de uma entidade a partir do uid do server dela.

Esse é um começo... O que eu queria fazer é poder usar esse comando com o toolshed mas o toolshed roda completamente no servidor e isso precisa necessariamente rodar no cliente. Mas não sei como fazer isso :skull:.
