### PR TITLE
[FIX] Suspicious Spesos Stack

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/space_cash.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/space_cash.yml
@@ -10,6 +10,9 @@
   id: SpaceCashCounterfeit
   name: suspicious spesos
   description: This looks like painted-on paper.
+  components:
+  - type: Stack
+    stackType: SuspiciousCredit
 
 - type: entity
   parent: SpaceCashCounterfeit
@@ -35,3 +38,8 @@
   - type: Construction
     graph: SpesosCounterfeit
     node: spesos
+
+- type: stack
+  parent: Credits
+  id: SuspiciousCredit
+  spawn: SpaceCashCounterfeit


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
<!-- O que ela muda? -->
Arruma o bug de suspicius spesos se divindo em spesos normais.

## Por quê? / Balanceamento
<!-- Discuta do por que da existencia da PR. (opcional | recomendado) -->
Fix

## Detalhes Técnicos
<!-- Mudanças do codigo para uma review mais facil (opcional). -->
O problema era que como os suspicious spesos é derivado dos spesos normais, ele também estava usando o stack de spesos normais, que gera os próprios spesos. A PR cria um novo tipo de stack.

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl:
- fix: Agora ao dividir spesos suspeitos, você terá spesos suspeitos!
