### PR TITLE
faz cartridges usarem projeteis 

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/antimateriel.yml
@@ -34,8 +34,8 @@
     tags:
     - Cartridge
     - CartridgeAntiMateriel
-  - type: CartridgeAmmo
-    proto: AntiMaterielBullet
+  - type: HitScanCartridgeAmmo
+    hitscan: AntiMaterielBulletTrace
   - type: Sprite
     sprite: Objects/Weapons/Guns/Ammunition/Casings/large_casing.rsi
     layers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/antimateriel.yml
@@ -34,8 +34,8 @@
     tags:
     - Cartridge
     - CartridgeAntiMateriel
-  - type: HitScanCartridgeAmmo
-    hitscan: AntiMaterielBulletTrace
+  - type: CartridgeAmmo
+    proto: AntiMaterielBullet
   - type: Sprite
     sprite: Objects/Weapons/Guns/Ammunition/Casings/large_casing.rsi
     layers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/caseless_rifle.yml
@@ -29,9 +29,9 @@
     tags:
       - Cartridge
       - CartridgeCaselessRifle
-  - type: HitScanCartridgeAmmo
+  - type: CartridgeAmmo
     deleteOnSpawn: true
-    hitscan: BulletCaselessRifleTrace
+    proto: BulletCaselessRifle
   - type: Sprite
     noRot: false
     sprite: Objects/Weapons/Guns/Ammunition/Casings/ammo_casing.rsi
@@ -49,8 +49,8 @@
   parent: BaseCartridgeCaselessRifle
   description: A small caliber utilizing caseless technology, omitting conventional brass casing in favor of hardened propellant. Standard kinetic ammunition is common and useful in most situations.
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletCaselessRifleTrace
+  - type: CartridgeAmmo
+    proto: BulletCaselessRifle
 
 - type: entity
   id: CartridgeCaselessRiflePractice
@@ -58,8 +58,8 @@
   parent: BaseCartridgeCaselessRifle
   description: A small caliber utilizing caseless technology, omitting conventional brass casing in favor of hardened propellant. Chalk ammunition is generally non-harmful, used for practice.
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletCaselessRiflePracticeTrace
+  - type: CartridgeAmmo
+    proto: BulletCaselessRiflePractice
   - type: Sprite
     layers:
       - state: base

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/heavy_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/heavy_rifle.yml
@@ -36,8 +36,8 @@
     tags:
       - Cartridge
       - CartridgeHeavyRifle
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletHeavyRifleTrace
+  - type: CartridgeAmmo
+    proto: BulletHeavyRifle
   - type: Sprite
     sprite: Objects/Weapons/Guns/Ammunition/Casings/ammo_casing.rsi
     layers:
@@ -53,6 +53,6 @@
   name: cartridge (.10 rifle)
   parent: BaseCartridgeHeavyRifle
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletMinigunTrace
+  - type: CartridgeAmmo
+    proto: BulletMinigun
     deleteOnSpawn: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
@@ -29,8 +29,8 @@
     tags:
     - Cartridge
     - CartridgeLightRifle
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletLightRifleTrace
+  - type: CartridgeAmmo
+    proto: BulletLightRifle
   - type: Sprite
     sprite: Objects/Weapons/Guns/Ammunition/Casings/ammo_casing.rsi
     layers:
@@ -45,8 +45,8 @@
   parent: BaseCartridgeLightRifle
   description: A classic intermediate cartridge used by many combat rifles and LMGs. Standard kinetic ammunition is common and useful in most situations.
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletLightRifleTrace
+  - type: CartridgeAmmo
+    proto: BulletLightRifle
 
 - type: entity
   id: CartridgeLightRiflePractice
@@ -54,8 +54,8 @@
   parent: BaseCartridgeLightRifle
   description: A classic intermediate cartridge used by many combat rifles and LMGs. Chalk ammunition is generally non-harmful, used for practice.
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletLightRiflePracticeTrace
+  - type: CartridgeAmmo
+    proto: BulletLightRiflePractice
   - type: Sprite
     layers:
       - state: base
@@ -70,8 +70,8 @@
   parent: BaseCartridgeLightRifle
   description: A classic intermediate cartridge used by many combat rifles and LMGs. Incendiary ammunition contains a self-igniting compound that sets the target ablaze.
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletLightRifleIncendiaryTrace
+  - type: CartridgeAmmo
+    proto: BulletLightRifleIncendiary
   - type: Sprite
     layers:
       - state: base
@@ -86,8 +86,8 @@
   parent: BaseCartridgeLightRifle
   description: A classic intermediate cartridge used by many combat rifles and LMGs. Uranium ammunition replaces the lead core of the bullet with fissile material, irradiating the target from the inside.
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletLightRifleUraniumTrace
+  - type: CartridgeAmmo
+    proto: BulletLightRifleUranium
   - type: Sprite
     layers:
       - state: base

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
@@ -42,8 +42,8 @@
     tags:
       - Cartridge
       - CartridgeMagnum
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletMagnumTrace
+  - type: CartridgeAmmo
+    proto: BulletMagnum
   - type: Sprite
     sprite: Objects/Weapons/Guns/Ammunition/Casings/ammo_casing.rsi
     layers:
@@ -58,8 +58,8 @@
   parent: BaseCartridgeMagnum
   description: Heavy magnum cartridge mostly used by revolvers. Standard kinetic ammunition is common and useful in most situations.
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletMagnumTrace
+  - type: CartridgeAmmo
+    proto: BulletMagnum
 
 - type: entity
   id: CartridgeMagnumPractice
@@ -67,8 +67,8 @@
   parent: BaseCartridgeMagnum
   description: Heavy magnum cartridge mostly used by revolvers. Chalk ammunition is generally non-harmful, used for practice.
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletMagnumPracticeTrace
+  - type: CartridgeAmmo
+    proto: BulletMagnumPractice
   - type: Sprite
     layers:
       - state: base
@@ -83,8 +83,8 @@
   parent: BaseCartridgeMagnum
   description: Heavy magnum cartridge mostly used by revolvers. Incendiary ammunition contains a self-igniting compound that sets the target ablaze.
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletMagnumIncendiaryTrace
+  - type: CartridgeAmmo
+    proto: BulletMagnumIncendiary
   - type: Sprite
     layers:
       - state: base
@@ -99,8 +99,8 @@
   parent: BaseCartridgeMagnum
   description: Heavy magnum cartridge mostly used by revolvers. Armor piercing ammunition is renowned for its ability to cut straight through body armor.
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletMagnumAPTrace
+  - type: CartridgeAmmo
+    proto: BulletMagnumAP
   - type: Sprite
     layers:
       - state: base
@@ -115,8 +115,8 @@
   parent: BaseCartridgeMagnum
   description: Heavy magnum cartridge mostly used by revolvers. Uranium ammunition replaces the lead core of the bullet with fissile material, irradiating the target from the inside.
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletMagnumUraniumTrace
+  - type: CartridgeAmmo
+    proto: BulletMagnumUranium
   - type: Sprite
     layers:
       - state: base

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
@@ -43,8 +43,8 @@
     tags:
       - Cartridge
       - CartridgePistol
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletPistolTrace
+  - type: CartridgeAmmo
+    proto: BulletPistol
   - type: Sprite
     sprite: Objects/Weapons/Guns/Ammunition/Casings/ammo_casing.rsi
     layers:
@@ -59,8 +59,8 @@
   description: Arguably the most popular caliber on the market, used by all manner of pistols and submachine guns. Standard kinetic ammunition is common and useful in most situations.
   parent: BaseCartridgePistol
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletPistolTrace
+  - type: CartridgeAmmo
+    proto: BulletPistol
 
 - type: entity
   id: CartridgePistolPractice
@@ -68,8 +68,8 @@
   description: Arguably the most popular caliber on the market, used by all manner of pistols and submachine guns. Chalk ammunition is generally non-harmful, used for practice.
   parent: BaseCartridgePistol
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletPistolPracticeTrace
+  - type: CartridgeAmmo
+    proto: BulletPistolPractice
   -  type: Sprite
      layers:
        - state: base
@@ -84,8 +84,8 @@
   description: Arguably the most popular caliber on the market, used by all manner of pistols and submachine guns. Incendiary ammunition contains a self-igniting compound that sets the target ablaze.
   parent: BaseCartridgePistol
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletPistolIncendiaryTrace
+  - type: CartridgeAmmo
+    proto: BulletPistolIncendiary
   - type: Sprite
     layers:
       - state: base
@@ -100,8 +100,8 @@
   description: Arguably the most popular caliber on the market, used by all manner of pistols and submachine guns. Uranium core ammunition features a load of fissile material, irradiating the target from the inside.
   parent: BaseCartridgePistol
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletPistolUraniumTrace
+  - type: CartridgeAmmo
+    proto: BulletPistolUranium
   - type: Sprite
     layers:
       - state: base

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/rifle.yml
@@ -29,8 +29,8 @@
     tags:
       - Cartridge
       - CartridgeRifle
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletRifleTrace
+  - type: CartridgeAmmo
+    proto: BulletRifle
   - type: Sprite
     sprite: Objects/Weapons/Guns/Ammunition/Casings/ammo_casing.rsi
     layers:
@@ -44,16 +44,16 @@
   name: cartridge (.20 rifle)
   parent: BaseCartridgeRifle
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletRifleTrace
+  - type: CartridgeAmmo
+    proto: BulletRifle
 
 - type: entity
   id: CartridgeRiflePractice
   name: cartridge (.20 rifle practice)
   parent: BaseCartridgeRifle
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletRiflePracticeTrace
+  - type: CartridgeAmmo
+    proto: BulletRiflePractice
   - type: Sprite
     layers:
       - state: base
@@ -67,8 +67,8 @@
   name: cartridge (.20 rifle incendiary)
   parent: BaseCartridgeRifle
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletRifleIncendiaryTrace
+  - type: CartridgeAmmo
+    proto: BulletRifleIncendiary
   - type: Sprite
     layers:
       - state: base
@@ -82,8 +82,8 @@
   name: cartridge (.20 rifle uranium)
   parent: BaseCartridgeRifle
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletRifleUraniumTrace
+  - type: CartridgeAmmo
+    proto: BulletRifleUranium
   - type: Sprite
     layers:
       - state: base

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -190,8 +190,6 @@
       - state: base
         map: [ "enum.AmmoVisualLayers.Base" ]
   - type: CartridgeAmmo
-    soundEject:
-      collection: ShellEject
     proto: PelletShotgunSpread
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -136,10 +136,10 @@
     layers:
       - state: beanbag
         map: [ "enum.AmmoVisualLayers.Base" ]
-  - type: HitScanCartridgeAmmo
+  - type: CartridgeAmmo
     soundEject:
       collection: ShellEject
-    hitscan: PelletShotgunBeanbagTrace
+    proto: PelletShotgunBeanbag
   - type: SpentAmmoVisuals
     state: "beanbag"
 
@@ -152,10 +152,10 @@
     layers:
       - state: slug
         map: [ "enum.AmmoVisualLayers.Base" ]
-  - type: HitScanCartridgeAmmo
+  - type: CartridgeAmmo
     soundEject:
       collection: ShellEject
-    hitscan: PelletShotgunSlugTrace
+    proto: PelletShotgunSlug
   - type: SpentAmmoVisuals
     state: "slug"
 
@@ -189,10 +189,10 @@
     layers:
       - state: base
         map: [ "enum.AmmoVisualLayers.Base" ]
-  - type: HitScanCartridgeAmmo
+  - type: CartridgeAmmo
     soundEject:
       collection: ShellEject
-    hitscan: PelletShotgunSpreadTrace
+    proto: PelletShotgunSpread
 
 - type: entity
   id: ShellShotgunIncendiary
@@ -203,10 +203,10 @@
     layers:
       - state: incendiary
         map: [ "enum.AmmoVisualLayers.Base" ]
-  - type: HitScanCartridgeAmmo
+  - type: CartridgeAmmo
     soundEject:
       collection: ShellEject
-    hitscan: ShellShotgunIncendiaryTrace
+    proto: PelletShotgunIncendiary
   - type: SpentAmmoVisuals
     state: "incendiary"
 
@@ -219,10 +219,10 @@
     layers:
       - state: practice
         map: [ "enum.AmmoVisualLayers.Base" ]
-  - type: HitScanCartridgeAmmo
+  - type: CartridgeAmmo
     soundEject:
       collection: ShellEject
-    hitscan: PelletShotgunPracticeSpreadTrace
+    proto: PelletShotgunPractice
   - type: SpentAmmoVisuals
     state: "practice"
 
@@ -274,10 +274,10 @@
   - type: Construction
     graph: ImprovisedShotgunShellGraph
     node: shell
-  - type: HitScanCartridgeAmmo
+  - type: CartridgeAmmo
     soundEject:
       collection: ShellEject
-    hitscan: PelletShotgunImprovisedSpreadTrace
+    proto: PelletShotgunImprovised
   - type: SpentAmmoVisuals
     state: "improvised"
 
@@ -290,9 +290,9 @@
     layers:
       - state: depleted-uranium
         map: [ "enum.AmmoVisualLayers.Base" ]
-  - type: HitScanCartridgeAmmo
+  - type: CartridgeAmmo
     soundEject:
       collection: ShellEject
-    hitscan: PelletShotgunUraniumSpreadTrace
+    proto: PelletShotgunUranium
   - type: SpentAmmoVisuals
     state: "depleted-uranium"

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
@@ -47,7 +47,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 35
+        Piercing: 35 # Heartbeat i had nerfed this before but i think i overdid it, it's fine
 
 - type: entity
   id: BulletMagnumPractice


### PR DESCRIPTION
## Sobre a PR
Faz cartuchos usarem projeteis.

## Por quê? / Balanceamento
Mudamos pra ser hitscan por causa do servidor ruim, não temos mais esse problema.

## Detalhes Técnicos
YML.
Eu deixei o dano da magnum e o hitscan do sniper .60.

## Anexos

https://github.com/user-attachments/assets/67c6a8b1-480f-4b5c-b239-69e51b50265c


ignora o final é erro do goob


## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl: Heartbeat
- tweak: Armas usam projeteis denovo.
