### PR TITLE
[Tweak] Acesso Alarmes de Ar

### DIFF
--- a/Resources/Locale/pt-BR/atmos/air-alarm-ui.ftl
+++ b/Resources/Locale/pt-BR/atmos/air-alarm-ui.ftl
@@ -23,14 +23,14 @@ air-alarm-ui-window-alarm-state = {$state}
 air-alarm-ui-window-alarm-state-indicator = Status: [color={$color}]{$state}[/color]
 
 air-alarm-ui-window-tab-vents = Ventilações
-air-alarm-ui-window-tab-scrubbers = Depuradores
+air-alarm-ui-window-tab-scrubbers = Filtradores
 air-alarm-ui-window-tab-sensors = Sensores
 
 air-alarm-ui-gases = {$gas}: {$amount} mol ({$percentage}%)
 air-alarm-ui-gases-indicator = {$gas}: [color={$color}]{$amount} mol ({$percentage}%)[/color]
 
 air-alarm-ui-mode-filtering = Filtragem
-air-alarm-ui-mode-wide-filtering = Filtragem (wide)
+air-alarm-ui-mode-wide-filtering = Filtragem (largo)
 air-alarm-ui-mode-fill = Encher
 air-alarm-ui-mode-panic = Pânico
 air-alarm-ui-mode-none = Nenhum
@@ -62,9 +62,9 @@ air-alarm-ui-scrubber-wide-net-label = Rede Local
 
 air-alarm-ui-sensor-gases = Gases
 air-alarm-ui-sensor-thresholds = Limites
-air-alarm-ui-thresholds-pressure-title = Thresholds (kPa)
-air-alarm-ui-thresholds-temperature-title = Thresholds (K)
-air-alarm-ui-thresholds-gas-title = Thresholds (%)
+air-alarm-ui-thresholds-pressure-title = Limites (kPa)
+air-alarm-ui-thresholds-temperature-title = Limites (K)
+air-alarm-ui-thresholds-gas-title = Limites (%)
 air-alarm-ui-thresholds-upper-bound = Perigo acima
 air-alarm-ui-thresholds-lower-bound = Perigo abaixo
 air-alarm-ui-thresholds-upper-warning-bound = Aviso acima

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/air_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/air_alarm.yml
@@ -97,7 +97,7 @@
     boardName: wires-board-name-airalarm
     layoutId: AirAlarm
   - type: AccessReader
-    access: [["Engineering"]] #Goob change from atmos to engi
+    access: [["Atmospherics"]] # Dumont edit - Reverted Goob change
   - type: ContainerFill
     containers:
       board: [ AirAlarmElectronics ]

--- a/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/Atmospherics/hfr.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/Atmospherics/hfr.yml
@@ -44,6 +44,8 @@
     node: hfrConsole
   - type: HFRSidePart
   - type: HFRConsole
+  - type: AccessReader
+    access: [["Atmospherics"]] # Dumont edit
 
 - type: entity
   parent: BaseStructure


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
<!-- O que ela muda? -->
Muda novamente alarmes de ar para requisitarem acesso atmosférico. Também adiciona requisito de acesso ao console do Torus.

## Por quê? / Balanceamento
<!-- Discuta do por que da existência da PR. (opcional | recomendado) -->
Atmos é área de alta segurança não é atoa. Alguém má intencionado pode prejudicar a estação como um todo e até acabar com um round mechendo nos alarme de distribuição. Isso também impede engenheiros que não entendem a interface de fazerem acidentes.

## Detalhes Técnicos
<!-- Mudanças do codigo para uma review mais facil (opcional). -->
3 linhas, uma mudando acesso e outras  duas adicionando.

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl:
- add: Adicionado requisito de acesso atmosférico para o console do Reator Hiper Torus.
- tweak: Alarmes de ar novamente requerem acesso de atmosfera.
