### PR TITLE
[HotFix] Acesso temporário para exploradores

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -1898,7 +1898,7 @@
   - type: Wires # DeltaV: Use shop vendor wires layout
     layoutId: ShopVendor
   - type: AccessReader
-    access: [["Mining"]] # Dumont edit
+    access: [["Salvage"], ["Mining"]] # Dumont edit
   - type: GuideHelp
     guides:
     - Salvage

--- a/Resources/Prototypes/_Lavaland/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Structures/Machines/vending_machines.yml
@@ -50,7 +50,7 @@
     energy: 1.6
     color: "#b89e2a"
   - type: AccessReader
-    access: [["Mining"]] # Dumont edit
+    access: [["Salvage"], ["Mining"]] # Dumont edit
 
 - type: localizedDataset
   id: MiningDrobeAds


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
<!-- O que ela muda? -->
Restaura acesso para MiningDrobe e Vending de Tickets dos mineradores para os exploradores até que o merge do rework esteja completo.

Reverter após rework da Exploração. 

## Por quê? / Balanceamento
<!-- Discuta do por que da existencia da PR. (opcional | recomendado) -->
Fix temporário.

## Detalhes Técnicos
<!-- Mudanças do codigo para uma review mais facil (opcional). -->
Acesso de exploração adicionado a vend de tickets e roupa da mineração.

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl:
- fix: Acesso a vend de tickets e roupas da mineração temporariamente restaurado aos exploradores até o merge do rework.
