### PR TITLE
Altera munições da Chester Mk. II pra projéteis + ajustes

### DIFF
--- a/Resources/Prototypes/_Gabystation/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/heavy_rifle.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/heavy_rifle.yml
@@ -13,8 +13,8 @@
       - Cartridge
       - CartridgeRifle
       - CartridgeChesterRifle 
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletChesterRifleTrace
+  - type: CartridgeAmmo
+    proto: BulletChesterRifle
   - type: Sprite
     sprite: Objects/Weapons/Guns/Ammunition/Casings/ammo_casing.rsi
     layers:
@@ -51,8 +51,8 @@
   parent: BaseCartridgeChesterRifle
   description: A powerful cartridge used by the Chester lever rifle. The .315 Jumbo is said to be able to pierce clean through space rhinos' thick hide and Syndicate agents.
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletChesterRifleTrace
+  - type: CartridgeAmmo
+    proto: BulletChesterRifle
 
 - type: entity
   id: CartridgeChesterRifleIncendiary
@@ -60,8 +60,8 @@
   parent: BaseCartridgeChesterRifle
   description: A powerful cartridge used by the Chester lever rifle. The .315 incendiary ammunition contains a self-igniting compound that sets the target ablaze.
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletChesterRifleIncendiaryTrace
+  - type: CartridgeAmmo
+    proto: BulletChesterRifleIncendiary
   - type: Sprite
     layers:
       - state: base
@@ -76,8 +76,8 @@
   parent: BaseCartridgeChesterRifle
   description: A powerful cartridge used by the Chester lever rifle. The .315 uranium ammunition replaces the lead core of the bullet with fissile material, irradiating the target from the inside.
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletChesterRifleUraniumTrace
+  - type: CartridgeAmmo
+    proto: BulletChesterRifleUranium
   - type: Sprite
     layers:
       - state: base
@@ -92,8 +92,8 @@
   parent: BaseCartridgeChesterRifle
   description: A powerful cartridge used by the Chester lever rifle. This one is meant for training purposes only.
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletChesterRiflePracticeTrace
+  - type: CartridgeAmmo
+    proto: BulletChesterRiflePractice
   - type: Sprite
     layers:
       - state: base
@@ -108,8 +108,8 @@
   parent: BaseCartridgeChesterRifle
   description: A powerful cartridge used by the Chester lever rifle. The .315 disabler ammunition features a special composite core designed for immobilizing targets.
   components:
-  - type: HitScanCartridgeAmmo
-    hitscan: BulletChesterRifleDisablerTrace
+  - type: CartridgeAmmo
+    proto: BulletChesterRifleDisabler
   - type: Sprite
     layers:
       - state: base

--- a/Resources/Prototypes/_Gabystation/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -92,7 +92,7 @@
   parent: BulletTrace
   damage:
     types:
-      Piercing: 35
+      Piercing: 40 
     armorPenetration: 0.15 
 
 - type: hitscan
@@ -117,12 +117,12 @@
   damage:
     types:
       Radiation: 15
-      Piercing: 15
+      Piercing: 20
 
 - type: hitscan
   id: BulletChesterRifleDisablerTrace
   parent: BulletTrace
   damage:
     types:
-      Blunt: 5
-  staminaDamage: 35 # Balancear aqui
+      Blunt: 3
+  staminaDamage: 45 # 3 hits pra stun sem armadura

--- a/Resources/Prototypes/_Gabystation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Gabystation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -113,7 +113,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 35
+        Piercing: 40
       armorPenetration: 0.15
 
 - type: entity
@@ -138,10 +138,10 @@
     damage:
       types:
         Radiation: 15
-        Piercing: 15
+        Piercing: 20
 
 - type: entity
-  id: BulletChesterRIflePractice
+  id: BulletChesterRiflePractice
   name: bullet (0.315 rifle practice)
   parent: BaseBulletPractice
   categories: [ HideSpawnMenu ]
@@ -160,9 +160,9 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 5
+        Blunt: 3
   - type: StaminaDamageOnCollide
-    damage: 35
+    damage: 45 # 3 hits pra stun sem armadura
 
 - type: entity
   id: BulletChesterRifleEMP

--- a/Resources/Prototypes/_Gabystation/NTR/Catalog/ntr_catalog.yml
+++ b/Resources/Prototypes/_Gabystation/NTR/Catalog/ntr_catalog.yml
@@ -11,7 +11,7 @@
     sprite: Objects/Weapons/Guns/Ammunition/Boxes/rifle.rsi
     state: full-base
   cost:
-    NTLoyaltyPoint: 50
+    NTLoyaltyPoint: 35
   categories:
   - NTRBSO
   restockTime: 1800 # Se isso precisar ser comprado em menos de meia-hora, talvez o BSO precise ser demitido.
@@ -30,7 +30,7 @@
     sprite: Objects/Weapons/Guns/Ammunition/Boxes/rifle.rsi
     state: full-uranium
   cost:
-    NTLoyaltyPoint: 45
+    NTLoyaltyPoint: 30
   categories:
   - NTRBSO
   restockTime: 1800 
@@ -49,7 +49,7 @@
     sprite: Objects/Weapons/Guns/Ammunition/Boxes/rifle.rsi
     state: full-incendiary
   cost:
-    NTLoyaltyPoint: 35
+    NTLoyaltyPoint: 25
   categories:
   - NTRBSO
   restockTime: 1800 
@@ -68,7 +68,7 @@
     sprite: Objects/Weapons/Guns/Ammunition/Boxes/rifle.rsi
     state: full-rubber
   cost:
-    NTLoyaltyPoint: 20
+    NTLoyaltyPoint: 15
   categories:
   - NTRBSO
   restockTime: 1200 


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
Com a mudança das munições hitscan passando a ser projéteis, os cartuchos .315 da Chester Mk. II ficaram de fora, então eu mudei elas para ficarem no padrão.
Alguns valores de dano e custo de munições foram alterados. 

## Por quê? / Balanceamento
Hitscan is no more.

## Detalhes Técnicos
YAML

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl: SrKolobanov
- tweak: As munições da Chester Mk. II agora usam projéteis ao invés de hitscan.
- tweak: Alterados alguns valores de dano, munição atordoadora ficou mais eficaz.
- tweak: O custo geral das munições na loja de pontos do NTR foi reduzido.
