### PR TITLE
[Fix] Airlocks de correio não aparecendo em mapload.

### DIFF
--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -157,8 +157,8 @@ AirlockClownGlassLocked: AirlockServiceGlassLocked
 AirlockClownLocked: AirlockServiceGlassLocked
 AirlockCorpsmanGlassLocked: AirlockServiceGlassLocked
 AirlockExternalGlassShuttleShipyard: AirlockExternalGlassLocked
-AirlockMailGlassLocked: AirlockCargoGlassLocked
-AirlockMaintMailLocked: AirlockMaintCargoLocked
+# AirlockMailGlassLocked: AirlockCargoGlassLocked # Dumont edit
+# AirlockMaintMailLocked: AirlockMaintCargoLocked # Dumont edit
 AirlockMaintMimeLocked: AirlockMaintTheatreLocked
 AirlockMaintPsychologistLocked: AirlockMaintMedLocked
 AirlockMaintReporterLocked: AirlockServiceLocked
@@ -220,7 +220,7 @@ DefaultStationBeaconMantis: null
 DefaultStationBeaconMetempsychosis: null
 DefaultStationBeaconPark: null
 DefaultStationBeaconPsychologist: null
-DefaultStationBeaconVirology: null
+# DefaultStationBeaconVirology: null # Dumont edit
 DrinkBubbleTeaGlass: null
 FishLabeler: null
 FoodLollipop: null
@@ -333,7 +333,7 @@ WarpPointSingulo: null
 WashingMachineBroken: null
 WashingMachineFilledClothes: null
 WeaponShotgunKammererNonLethal: null
-WindoorSecureMailLocked: null
+# WindoorSecureMailLocked: null # Dumont edit
 WindoorSecureParamedicLocked: null
 SpawnPointMailCarrier: null
 HoloprojectorEngineering: null


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
<!-- O que ela muda? -->
Atualiza `migration.yml` para possibilitar o carregamento de alguns dos novo prototypes da PR #775 durante mapload. Obrigado @Will-Oliver-Br por me informar sobre esse arquivo!

Fixes #793 
## Por quê? / Balanceamento
<!-- Discuta do por que da existencia da PR. (opcional | recomendado) -->
Fix.

## Detalhes Técnicos
<!-- Mudanças do codigo para uma review mais facil (opcional). -->
Remove novos IDs utilizados pela #775 presentes em `migration.yml`.

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl:
- fix: Airlocks do correio agora devem spawnar corretamente durante carregamento do mapa.
