### PR TITLE
Rank dos mais ricos da rodada

### DIFF
--- a/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
+++ b/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
@@ -90,6 +90,7 @@ namespace Content.Client.RoundEnd
             RoundId = roundId;
             var roundEndTabs = new TabContainer();
             roundEndTabs.AddChild(MakeRoundEndSummaryTab(gm, roundEnd, roundTimeSpan, roundId));
+            roundEndTabs.AddChild(MakeEconomyRankTab(info)); // gaby
             roundEndTabs.AddChild(MakePlayerManifestTab(info));
             roundEndTabs.AddChild(MakeStationReportTab()); //goob
 
@@ -412,6 +413,55 @@ namespace Content.Client.RoundEnd
             StationReportContainerScrollbox.AddChild(StationReportContainer);
             stationReportTab.AddChild(StationReportContainerScrollbox);
             return stationReportTab;
+        }
+        #endregion
+
+        #region GabyStation/Dumont
+        private BoxContainer MakeEconomyRankTab(RoundEndMessageEvent.RoundEndPlayerInfo[] playersInfo)
+        {
+            var tab = new BoxContainer
+            {
+                Orientation = LayoutOrientation.Vertical,
+                Name = Loc.GetString("round-end-summary-window-economy-rank-tab-title")
+            };
+
+            var title = new RichTextLabel();
+            title.SetMarkup("[head=3]Ranking dos mais ricos da rodada.[/head]");
+
+            var scrollBox = new ScrollContainer
+            {
+                VerticalExpand = true,
+                Margin = new Thickness(10),
+                HScrollEnabled = false,
+            };
+
+            var container = new BoxContainer { Orientation = LayoutOrientation.Vertical };
+
+            var rankedPlayers = playersInfo
+                .OrderByDescending(x => x.ICCurrency)
+                .ToArray();
+
+            int rank = 1;
+
+            foreach (var info in rankedPlayers)
+            {
+                var label = new RichTextLabel();
+
+                label.SetMarkup(
+                    $"[color=cyan]#{rank}[/color] " +
+                    $"[color=white]{info.PlayerICName}[/color] - " +
+                    $"[color=yellow]{info.ICCurrency} créditos[/color]"
+                );
+
+                container.AddChild(label);
+                rank++;
+            }
+
+            scrollBox.AddChild(container);
+            tab.AddChild(new Label() { Text = "" });
+            tab.AddChild(title);
+            tab.AddChild(scrollBox);
+            return tab;
         }
         #endregion
     }

--- a/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
+++ b/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
@@ -425,9 +425,6 @@ namespace Content.Client.RoundEnd
                 Name = Loc.GetString("round-end-summary-window-economy-rank-tab-title")
             };
 
-            var title = new RichTextLabel();
-            title.SetMarkup("[head=3]Ranking dos mais ricos da rodada.[/head]");
-
             var scrollBox = new ScrollContainer
             {
                 VerticalExpand = true,
@@ -438,28 +435,96 @@ namespace Content.Client.RoundEnd
             var container = new BoxContainer { Orientation = LayoutOrientation.Vertical };
 
             var rankedPlayers = playersInfo
-                .OrderByDescending(x => x.ICCurrency)
+                .Where(p => !p.Observer)
+                .OrderByDescending(x => x.PlayerICCurrency)
                 .ToArray();
+
+            var headerLabel = new Label()
+            {
+                Text = Loc.GetString("round-end-summary-window-economy-rank-tab-title"),
+                StyleClasses = { StyleNano.StyleClassLabelHeading },
+            };
+            container.AddChild(headerLabel);
 
             int rank = 1;
 
             foreach (var info in rankedPlayers)
             {
-                var label = new RichTextLabel();
+                var panel = new PanelContainer
+                {
+                    StyleClasses = { StyleNano.StyleClassBackgroundBaseDark },
+                    Margin = new Thickness(0, 0, 0, 6)
+                };
 
-                label.SetMarkup(
-                    $"[color=cyan]#{rank}[/color] " +
-                    $"[color=white]{info.PlayerICName}[/color] - " +
-                    $"[color=yellow]{info.ICCurrency} créditos[/color]"
-                );
+                var hBox = new BoxContainer
+                {
+                    Orientation = LayoutOrientation.Horizontal,
+                    VerticalExpand = true
+                };
 
-                container.AddChild(label);
+                // Rank badge
+                var rankLabel = new Label
+                {
+                    Text = $"#{rank}",
+                    StyleClasses = { StyleNano.StyleClassLabelHeading },
+                    VerticalAlignment = VAlignment.Center,
+                    Margin = new Thickness(8, 0, 4, 0),
+                    FontColorOverride = rank == 1 ? Color.Gold : rank == 2 ? Color.Silver : rank == 3 ? Color.FromHex("#cd7f32") : Color.Gray,
+                };
+                hBox.AddChild(rankLabel);
+
+                // Player sprite
+                if (info.PlayerNetEntity != null)
+                {
+                    hBox.AddChild(new SpriteView(info.PlayerNetEntity.Value, _entityManager)
+                    {
+                        OverrideDirection = Direction.South,
+                        VerticalAlignment = VAlignment.Center,
+                        SetSize = new Vector2(64, 64),
+                        VerticalExpand = true,
+                        Stretch = SpriteView.StretchMode.Fill,
+                        Margin = new Thickness(3, 0, 3, 0)
+                    });
+                }
+
+                var textVBox = new BoxContainer
+                {
+                    Orientation = LayoutOrientation.Vertical,
+                    VerticalExpand = true,
+                    SeparationOverride = 2,
+                };
+
+                if (info.PlayerICName != null)
+                {
+                    var nameLabel = new Label
+                    {
+                        Text = info.PlayerICName,
+                        StyleClasses = { StyleNano.StyleClassLabelHeading },
+                        VerticalAlignment = VAlignment.Bottom,
+                        Margin = new Thickness(0, 0, 6, 0),
+                    };
+                    textVBox.AddChild(nameLabel);
+
+                    var oocLabel = new Label
+                    {
+                        Text = Loc.GetString("round-end-summary-window-player-name", ("player", info.PlayerOOCName)),
+                        StyleClasses = { StyleNano.StyleClassLabelSubText },
+                        VerticalAlignment = VAlignment.Top,
+                    };
+                    textVBox.AddChild(oocLabel);
+                }
+
+                var currencyLabel = new RichTextLabel { VerticalAlignment = VAlignment.Center };
+                currencyLabel.SetMarkup(Loc.GetString("round-end-summary-window-ic-balance", ("balance", info.PlayerICCurrency ?? 0)));
+                textVBox.AddChild(currencyLabel);
+
+                hBox.AddChild(textVBox);
+                panel.AddChild(hBox);
+                container.AddChild(panel);
                 rank++;
             }
 
             scrollBox.AddChild(container);
-            tab.AddChild(new Label() { Text = "" });
-            tab.AddChild(title);
             tab.AddChild(scrollBox);
             return tab;
         }

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -119,6 +119,7 @@ using Content.Goobstation.Maths.FixedPoint;
 using Content.Goobstation.Shared.Mind.Components;
 
 using Content.Server._CD.Traits;
+using Content.Server._Gabystation.Economy;
 
 namespace Content.Server.GameTicking
 {
@@ -127,6 +128,7 @@ namespace Content.Server.GameTicking
         [Dependency] private readonly DiscordWebhook _discord = default!;
         [Dependency] private readonly RoleSystem _role = default!;
         [Dependency] private readonly ITaskManager _taskManager = default!;
+        [Dependency] private readonly EconomyManagerSystem _econSys = default!;
 
         private static readonly Counter RoundNumberMetric = Metrics.CreateCounter(
             "ss14_round_number",
@@ -686,6 +688,11 @@ namespace Content.Server.GameTicking
                 }
 
                 #endregion
+                #region GabyStation
+                var icCurrency = 0;
+                if (mind.NanoBankAccount is not null)
+                    icCurrency = _econSys.GetFirstBalance(mind.NanoBankAccount.Value);
+                #endregion
                 // END
 
                 var playerEndRoundInfo = new RoundEndMessageEvent.RoundEndPlayerInfo()
@@ -708,7 +715,8 @@ namespace Content.Server.GameTicking
                     // Goob Station - End of Round Screen
                     LastWords = lastWords,
                     EntMobState = mobState,
-                    DamagePerGroup = damagePerGroup
+                    DamagePerGroup = damagePerGroup,
+                    ICCurrency = icCurrency,
                 };
                 listOfPlayerInfo.Add(playerEndRoundInfo);
             }

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -716,7 +716,7 @@ namespace Content.Server.GameTicking
                     LastWords = lastWords,
                     EntMobState = mobState,
                     DamagePerGroup = damagePerGroup,
-                    ICCurrency = icCurrency,
+                    PlayerICCurrency = icCurrency,
                 };
                 listOfPlayerInfo.Add(playerEndRoundInfo);
             }

--- a/Content.Server/_Gabystation/Economy/EconomyManagerSystem.cs
+++ b/Content.Server/_Gabystation/Economy/EconomyManagerSystem.cs
@@ -18,6 +18,7 @@ using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
 using Content.Shared.NameIdentifier;
 using Content.Shared.Roles;
+using NetCord;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
@@ -351,6 +352,23 @@ namespace Content.Server._Gabystation.Economy
 
             return result;
 
+        }
+
+        /// <summary>
+        /// Get the first balance the system find in any available component.
+        /// </summary>
+        /// <returns>0 if theres no account registred</returns>
+        public int GetFirstBalance(int accountId)
+        {
+            var balance = 0;
+            var query = AllEntityQuery<EconomyManagerComponent>();
+            while (query.MoveNext(out var comp))
+            {
+                if (TryGetBalance(comp, accountId, out balance))
+                    return balance;
+            }
+
+            return 0;
         }
     }
 }

--- a/Content.Shared/GameTicking/SharedGameTicker.cs
+++ b/Content.Shared/GameTicking/SharedGameTicker.cs
@@ -261,7 +261,7 @@ namespace Content.Shared.GameTicking
             #endregion
 
             #region GabyStation
-            public int? ICCurrency;
+            public int? PlayerICCurrency;
             #endregion
         }
 

--- a/Content.Shared/GameTicking/SharedGameTicker.cs
+++ b/Content.Shared/GameTicking/SharedGameTicker.cs
@@ -259,6 +259,10 @@ namespace Content.Shared.GameTicking
 
             public Dictionary<string, FixedPoint2> DamagePerGroup;
             #endregion
+
+            #region GabyStation
+            public int? ICCurrency;
+            #endregion
         }
 
         public string GamemodeTitle { get; }

--- a/Resources/Locale/pt-BR/_Gabystation/round-end/round-end-summary.ftl
+++ b/Resources/Locale/pt-BR/_Gabystation/round-end/round-end-summary.ftl
@@ -1,0 +1,2 @@
+round-end-summary-window-ic-balance = [color=yellow]{$balance}[/color] spesos
+round-end-summary-window-economy-rank-tab-title = Rank de Spesos

--- a/Resources/Locale/pt-BR/_Goobstation/round-end/round-end-summary-window.ftl
+++ b/Resources/Locale/pt-BR/_Goobstation/round-end/round-end-summary-window.ftl
@@ -1,0 +1,7 @@
+round-end-summary-window-station-report-tab-title = Relatório da Estação
+no-station-report-summited = Nenhum relatório da estação foi enviado, o NTR designado à sua estação recebeu uma multa de 2000 pesos.
+round-end-summary-window-player-name-role = como {$role}, interpretado por {$player}.
+round-end-summary-window-player-name = interpretado por {$player}.
+round-end-summary-window-last-words = [italic][color=gray]"{$lastWords}"[/color][/italic]
+round-end-summary-window-death = Teve uma morte {$severity} por {$type}.
+round-end-summary-window-death-unknown = Seu corpo não pôde ser encontrado.


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
Adiciona uma aba no manifesto de fim de turno contendo o ranking dos mais ricos da rodada

## Por quê? / Balanceamento
Pq eu sempre quis 💥 

## Detalhes Técnicos
Apenas adiciona um novo campo a mensagem de informação de player de fim de turno, simples

## Anexos
<img width="646" height="563" alt="image" src="https://github.com/user-attachments/assets/9bb21d9f-8e3e-47c5-bdaa-a217555f4165" />

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl: AgentePanela
- add: Aba no manifesto de fim de turno com o ranking de jogadores mais ricos.

beijo a todos
