### PR TITLE
Renomear estação no console de Comns + Mudanças na UI

### DIFF
--- a/Content.Client/Communications/UI/CommunicationsConsoleBoundUserInterface.cs
+++ b/Content.Client/Communications/UI/CommunicationsConsoleBoundUserInterface.cs
@@ -27,9 +27,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using System.ComponentModel;
+using Content.Shared.Access.Systems;
 using Content.Shared.CCVar;
 using Content.Shared.Chat;
 using Content.Shared.Communications;
+using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Shared.Configuration;
 using Content.Client.UserInterface.Controls;
@@ -40,12 +42,16 @@ namespace Content.Client.Communications.UI
     public sealed class CommunicationsConsoleBoundUserInterface : BoundUserInterface
     {
         [Dependency] private readonly IConfigurationManager _cfg = default!;
+        [Dependency] private readonly IPlayerManager _playerManager = default!;
+
+        private AccessReaderSystem _accessReader = default!;
 
         [ViewVariables]
         private CommunicationsConsoleMenu? _menu;
 
         public CommunicationsConsoleBoundUserInterface(EntityUid owner, Enum uiKey) : base(owner, uiKey)
         {
+            _accessReader = EntMan.System<AccessReaderSystem>();
         }
 
         protected override void Open()
@@ -61,6 +67,7 @@ namespace Content.Client.Communications.UI
             _menu.OnMaint += MaintEmergencyButtonPressed;
             _menu.OnCentcomm += CentCommButtonPressed;
             _menu.OnMartial += MartialButtonPressed;
+            _menu.OnRenameStation += RenameStationPressed;
         }
 
         public void AlertLevelSelected(string level)
@@ -106,6 +113,20 @@ namespace Content.Client.Communications.UI
             SendMessage(new CommunicationsConsoleMartialButtonMessage());
         }
 
+        public void RenameStationPressed(string newName)
+        {
+            SendMessage(new CommunicationsConsoleStationRenameMessage(newName));
+        }
+
+        private bool LocalPlayerCanRename()
+        {
+            var localEntity = _playerManager.LocalSession?.AttachedEntity;
+            if (localEntity == null)
+                return false;
+            var tags = _accessReader.FindAccessTags(localEntity.Value);
+            return tags.Contains("Captain") || tags.Contains("CentralCommand");
+        }
+
         public void CallShuttle()
         {
             SendMessage(new CommunicationsConsoleCallEmergencyShuttleMessage());
@@ -136,13 +157,29 @@ namespace Content.Client.Communications.UI
                 if (commsState.AlertLevels is not null && !_menu.LoadedButtons) _menu.AddAlertButtons(commsState.AlertLevels);
 
                 // shit code, mas fds
-                if (commsState.IsSyndie) {
+                if (commsState.IsSyndie)
+                {
                     _menu.BroadcastButton.Visible = false;
                     _menu.CentCommButton.Visible = false;
 
                     _menu.EmergencyArea.Visible = false;
                     _menu.AlertLevelArea.Visible = false;
+                    _menu.RenameArea.Visible = false;
                 }
+
+                if (!string.IsNullOrEmpty(commsState.StationName))
+                {
+                    _menu.StationNameLabel.Text = Loc.GetString("comms-console-menu-header") + " " + commsState.StationName;
+                    if (!_menu.StationNameLoaded)
+                    {
+                        _menu.RenameInput.Text = commsState.StationName;
+                        _menu.StationNameLoaded = true;
+                    }
+                }
+
+                var canRename = LocalPlayerCanRename();
+                _menu.RenameButton.Visible = canRename;
+                _menu.RenameInput.Visible = canRename;
 
                 _menu.UpdateButtons();
                 _menu.UpdateRemainingTime();

--- a/Content.Client/Communications/UI/CommunicationsConsoleBoundUserInterface.cs
+++ b/Content.Client/Communications/UI/CommunicationsConsoleBoundUserInterface.cs
@@ -169,7 +169,7 @@ namespace Content.Client.Communications.UI
 
                 if (!string.IsNullOrEmpty(commsState.StationName))
                 {
-                    _menu.StationNameLabel.Text = Loc.GetString("comms-console-menu-header") + " " + commsState.StationName;
+                    _menu.StationNameLabel.Text = Loc.GetString("comms-console-menu-header", ("stationName", commsState.StationName));
                     if (!_menu.StationNameLoaded)
                     {
                         _menu.RenameInput.Text = commsState.StationName;

--- a/Content.Client/Communications/UI/CommunicationsConsoleBoundUserInterface.cs
+++ b/Content.Client/Communications/UI/CommunicationsConsoleBoundUserInterface.cs
@@ -180,6 +180,9 @@ namespace Content.Client.Communications.UI
                 var canRename = LocalPlayerCanRename();
                 _menu.RenameButton.Visible = canRename;
                 _menu.RenameInput.Visible = canRename;
+                _menu.RenameButton.Disabled = commsState.RenameOnCooldown;
+                _menu.RenameButton.ToolTip = commsState.RenameOnCooldown
+                    ? Loc.GetString("comms-console-rename-cooldown") : null;
 
                 _menu.UpdateButtons();
                 _menu.UpdateRemainingTime();

--- a/Content.Client/Communications/UI/CommunicationsConsoleMenu.xaml
+++ b/Content.Client/Communications/UI/CommunicationsConsoleMenu.xaml
@@ -11,10 +11,33 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 <controls:FancyWindow xmlns="https://spacestation14.io"
     xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+    xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
     Title="{Loc 'comms-console-menu-title'}"
-    SetSize="870 300">
+    SetSize="870 375">
 
-    <BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True">
+    <BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True" Margin="10">
+        <PanelContainer HorizontalExpand="True">
+            <PanelContainer.PanelOverride>
+                <gfx:StyleBoxFlat BackgroundColor="#1b1b1e" />
+            </PanelContainer.PanelOverride>
+            <BoxContainer Name="RenameArea" Orientation="Vertical" Margin="15 5 15 5" HorizontalExpand="True" Access="Public">
+                <Label Name="StationNameLabel"
+                    Access="Public"
+                    Text="{Loc 'comms-console-menu-header'}"
+                    HorizontalAlignment="Left"
+                    StyleClasses="LabelHeading"/>
+                <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
+                    <LineEdit Name="RenameInput"
+                            Access="Public"
+                            PlaceHolder="{Loc 'comms-console-menu-rename-placeholder'}"
+                            HorizontalExpand="True"
+                            Margin="0 0 4 0"/>
+                    <Button Name="RenameButton"
+                            Access="Public"
+                            Text="{Loc 'comms-console-menu-rename-button'}"/>
+                </BoxContainer>
+            </BoxContainer>
+        </PanelContainer>
         <BoxContainer Name="StationActions" Orientation="Horizontal" MinHeight="190" VerticalExpand="True" HorizontalExpand="True">
             <BoxContainer Name="AnnouncementArea" Orientation="Vertical" Margin="15" VerticalExpand="True" HorizontalExpand="True">
                 <TextEdit Name="MessageInput" VerticalExpand="True" HorizontalExpand="True"/>
@@ -65,7 +88,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             </BoxContainer>
 
         </BoxContainer>
-        <BoxContainer Name="AlertLevelArea" Orientation="Horizontal" Margin="20" MinHeight="70" HorizontalAlignment="Center" HorizontalExpand="True" Access="Public">
-        </BoxContainer>
+        <PanelContainer HorizontalExpand="True">
+            <PanelContainer.PanelOverride>
+                <gfx:StyleBoxFlat BackgroundColor="#1b1b1e" />
+            </PanelContainer.PanelOverride>
+            <BoxContainer Name="AlertLevelArea" Orientation="Horizontal" Margin="20" MinHeight="70" HorizontalAlignment="Center" HorizontalExpand="True" Access="Public">
+            </BoxContainer>
+        </PanelContainer>
     </BoxContainer>
 </controls:FancyWindow>

--- a/Content.Client/Communications/UI/CommunicationsConsoleMenu.xaml
+++ b/Content.Client/Communications/UI/CommunicationsConsoleMenu.xaml
@@ -13,7 +13,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
     Title="{Loc 'comms-console-menu-title'}"
-    SetSize="870 375">
+    SetSize="870 410">
 
     <BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True" Margin="10">
         <PanelContainer HorizontalExpand="True">
@@ -92,7 +92,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             <PanelContainer.PanelOverride>
                 <gfx:StyleBoxFlat BackgroundColor="#1b1b1e" />
             </PanelContainer.PanelOverride>
-            <BoxContainer Name="AlertLevelArea" Orientation="Horizontal" Margin="20" MinHeight="70" HorizontalAlignment="Center" HorizontalExpand="True" Access="Public">
+            <BoxContainer Orientation="Vertical" Margin="10">
+                <Label Text="{Loc 'comms-console-menu-alert-header'}" HorizontalAlignment="Left" StyleClasses="LabelHeading"/>
+                <BoxContainer Name="AlertLevelArea" Orientation="Horizontal" Margin="10" MinHeight="70" HorizontalAlignment="Center" HorizontalExpand="True" Access="Public"/>
             </BoxContainer>
         </PanelContainer>
     </BoxContainer>

--- a/Content.Client/Communications/UI/CommunicationsConsoleMenu.xaml.cs
+++ b/Content.Client/Communications/UI/CommunicationsConsoleMenu.xaml.cs
@@ -131,6 +131,7 @@ namespace Content.Client.Communications.UI
         public bool CountdownStarted;
         public bool Blinking = false;
         public bool LoadedButtons = false;
+        public bool StationNameLoaded = false;
 
         public string CurrentStationAlertLevel = string.Empty;
         public TimeSpan? CountdownEnd;
@@ -146,6 +147,7 @@ namespace Content.Client.Communications.UI
         public event Action? OnCentcomm; // Gabystation
         public event Action? OnMaint; // Gabystation
         public event Action? OnMartial; // Gabystation
+        public event Action<string>? OnRenameStation; // Gabystation
 
         public AlertLevelButton? CurrentAlertButton;
 
@@ -198,15 +200,13 @@ namespace Content.Client.Communications.UI
             MaintEmergencyButton.OnPressed += _ => OnMaint?.Invoke(); // Gabystation
             CentCommButton.OnPressed += _ => OnCentcomm?.Invoke(); // Gabystation
             MartialButton.OnPressed += _ => OnMartial?.Invoke(); // Gabystation
+            RenameButton.OnPressed += _ => OnRenameStation?.Invoke(RenameInput.Text); // Gabystation
 
             // we use real time here because CurTime gets it from the server at a delay
             nextBlink = _timing.RealTime.TotalSeconds + buttonBlinkDelay;
             Blinking = false;
 
             _sawMill = _logMan.GetSawmill("ui");
-
-
-
         }
 
         public void AddAlertButtons(List<(string id, Color color)> alertLevels) {

--- a/Content.Server/Communications/CommunicationsConsoleComponent.cs
+++ b/Content.Server/Communications/CommunicationsConsoleComponent.cs
@@ -88,6 +88,12 @@ namespace Content.Server.Communications
         [DataField]
         public double ToggleAcessDelay = 5;
 
+        [DataField]
+        public double RenameTimer = 0;
+
+        [DataField]
+        public double RenameDelay = 300;
+
         /// <summary>
         /// Can call or recall the shuttle
         /// </summary>

--- a/Content.Server/Communications/CommunicationsConsoleComponent.cs
+++ b/Content.Server/Communications/CommunicationsConsoleComponent.cs
@@ -89,7 +89,7 @@ namespace Content.Server.Communications
         public double ToggleAcessDelay = 5;
 
         [DataField]
-        public double RenameTimer = 0;
+        public double RenameTimer = -300;
 
         [DataField]
         public double RenameDelay = 300;

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -252,6 +252,7 @@ namespace Content.Server.Communications
 
 
             var stationName = stationUid != null ? MetaData(stationUid.Value).EntityName : string.Empty;
+            var renameOnCooldown = (_timing.CurTime.TotalSeconds - comp.RenameTimer) < comp.RenameDelay;
 
             _uiSystem.SetUiState(uid, CommunicationsConsoleUiKey.Key, new CommunicationsConsoleInterfaceState(
                 isSyndie,
@@ -261,7 +262,8 @@ namespace Content.Server.Communications
                 currentLevel,
                 currentDelay,
                 _roundEndSystem.ExpectedCountdownEnd,
-                stationName
+                stationName,
+                renameOnCooldown
             ));
         }
 

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -133,6 +133,7 @@ namespace Content.Server.Communications
             SubscribeLocalEvent<CommunicationsConsoleComponent, CommunicationsConsoleToggleEmergencyMaintMessage>(OnToggleEmergencyMaintMessage);
             SubscribeLocalEvent<CommunicationsConsoleComponent, CommunicationsConsoleCentCommButtonMessage>(OnCentCommMessage);
             SubscribeLocalEvent<CommunicationsConsoleComponent, CommunicationsConsoleMartialButtonMessage>(OnMartialMessage);
+            SubscribeLocalEvent<CommunicationsConsoleComponent, CommunicationsConsoleStationRenameMessage>(OnRenameMessage);
 
             // On console init, set cooldown
             SubscribeLocalEvent<CommunicationsConsoleComponent, MapInitEvent>(OnCommunicationsConsoleMapInit);
@@ -143,7 +144,6 @@ namespace Content.Server.Communications
             _maintDoorPrototypeList.Add("AirlockMaintLocked");
             _maintDoorPrototypeList.Add("AirlockMaintCommonLocked");
         }
-
         public override void Update(float frameTime)
         {
             var query = EntityQueryEnumerator<CommunicationsConsoleComponent>();
@@ -251,6 +251,8 @@ namespace Content.Server.Communications
             var isSyndie = protoId == "SyndicateComputerComms";
 
 
+            var stationName = stationUid != null ? MetaData(stationUid.Value).EntityName : string.Empty;
+
             _uiSystem.SetUiState(uid, CommunicationsConsoleUiKey.Key, new CommunicationsConsoleInterfaceState(
                 isSyndie,
                 CanAnnounce(comp),
@@ -258,7 +260,8 @@ namespace Content.Server.Communications
                 levels,
                 currentLevel,
                 currentDelay,
-                _roundEndSystem.ExpectedCountdownEnd
+                _roundEndSystem.ExpectedCountdownEnd,
+                stationName
             ));
         }
 
@@ -412,6 +415,54 @@ namespace Content.Server.Communications
                 } //pop up avisando q ta vazio
                 _popupSystem.PopupEntity(Loc.GetString("comms-console-empty-input"), uid, message.Actor);
             });
+        }
+
+        private void OnRenameMessage(Entity<CommunicationsConsoleComponent> ent, ref CommunicationsConsoleStationRenameMessage message)
+        {
+            if (!EntityManager.TryGetComponent(message.Actor, out ActorComponent? actor))
+                return;
+
+            var mob = message.Actor;
+            if (!CanUse(mob, ent.Owner))
+            {
+                _popupSystem.PopupEntity(Loc.GetString("comms-console-permission-denied"), ent.Owner, message.Actor);
+                return;
+            }
+
+            var accessTags = _accessReaderSystem.FindAccessTags(mob);
+            if (!accessTags.Contains("Captain") && !accessTags.Contains("CentralCommand"))
+            {
+                _popupSystem.PopupEntity(Loc.GetString("comms-console-permission-denied"), ent.Owner, message.Actor);
+                return;
+            }
+
+            if ((_timing.CurTime.TotalSeconds - ent.Comp.RenameTimer) < ent.Comp.RenameDelay)
+            {
+                _popupSystem.PopupEntity(Loc.GetString("comms-console-rename-cooldown"), ent.Owner, message.Actor);
+                return;
+            }
+
+            var newName = message.NewName.Trim();
+            if (string.IsNullOrWhiteSpace(newName))
+            {
+                _popupSystem.PopupEntity(Loc.GetString("comms-console-empty-input"), ent.Owner, message.Actor);
+                return;
+            }
+
+            var stationUid = _stationSystem.GetOwningStation(ent.Owner);
+            if (stationUid == null)
+                return;
+
+            var currentName = MetaData(stationUid.Value).EntityName;
+            if (newName == currentName)
+            {
+                _popupSystem.PopupEntity(Loc.GetString("comms-console-rename-same-name"), ent.Owner, message.Actor);
+                return;
+            }
+
+            _stationSystem.RenameStation(stationUid.Value, newName, loud: true);
+            _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(mob):player} renamed the station to '{newName}'.");
+            ent.Comp.RenameTimer = _timing.CurTime.TotalSeconds;
         }
 
         private void OnMartialMessage(EntityUid uid, CommunicationsConsoleComponent comp, CommunicationsConsoleMartialButtonMessage message)

--- a/Content.Shared/Communications/SharedCommunicationsConsoleComponent.cs
+++ b/Content.Shared/Communications/SharedCommunicationsConsoleComponent.cs
@@ -39,8 +39,9 @@ namespace Content.Shared.Communications
         public List<(string id, Color color)>? AlertLevels;
         public string CurrentAlert;
         public float CurrentAlertDelay;
+        public string StationName;
 
-        public CommunicationsConsoleInterfaceState(bool isSyndie, bool canAnnounce, bool canCall, List<(string, Color)>? alertLevels, string currentAlert, float currentAlertDelay, TimeSpan? expectedCountdownEnd = null)
+        public CommunicationsConsoleInterfaceState(bool isSyndie, bool canAnnounce, bool canCall, List<(string, Color)>? alertLevels, string currentAlert, float currentAlertDelay, TimeSpan? expectedCountdownEnd = null, string stationName = "")
         {
             IsSyndie = isSyndie;
             CanAnnounce = canAnnounce;
@@ -50,6 +51,7 @@ namespace Content.Shared.Communications
             AlertLevels = alertLevels;
             CurrentAlert = currentAlert;
             CurrentAlertDelay = currentAlertDelay;
+            StationName = stationName;
         }
     }
 
@@ -86,6 +88,7 @@ namespace Content.Shared.Communications
     }
 
 
+    #region GabyStation
     [Serializable, NetSerializable]
     public sealed class CommunicationsConsoleToggleEmergencyMaintMessage : BoundUserInterfaceMessage { }
 
@@ -94,6 +97,18 @@ namespace Content.Shared.Communications
 
     [Serializable, NetSerializable]
     public sealed class CommunicationsConsoleMartialButtonMessage : BoundUserInterfaceMessage { }
+
+    [Serializable, NetSerializable]
+    public sealed class CommunicationsConsoleStationRenameMessage : BoundUserInterfaceMessage
+    {
+        public readonly string NewName;
+        public CommunicationsConsoleStationRenameMessage(string newName)
+        {
+            NewName = newName;
+        }
+    }
+
+    #endregion
 
     [Serializable, NetSerializable]
     public sealed class CommunicationsConsoleCallEmergencyShuttleMessage : BoundUserInterfaceMessage

--- a/Content.Shared/Communications/SharedCommunicationsConsoleComponent.cs
+++ b/Content.Shared/Communications/SharedCommunicationsConsoleComponent.cs
@@ -40,8 +40,9 @@ namespace Content.Shared.Communications
         public string CurrentAlert;
         public float CurrentAlertDelay;
         public string StationName;
+        public readonly bool RenameOnCooldown;
 
-        public CommunicationsConsoleInterfaceState(bool isSyndie, bool canAnnounce, bool canCall, List<(string, Color)>? alertLevels, string currentAlert, float currentAlertDelay, TimeSpan? expectedCountdownEnd = null, string stationName = "")
+        public CommunicationsConsoleInterfaceState(bool isSyndie, bool canAnnounce, bool canCall, List<(string, Color)>? alertLevels, string currentAlert, float currentAlertDelay, TimeSpan? expectedCountdownEnd = null, string stationName = "", bool renameOnCooldown = false)
         {
             IsSyndie = isSyndie;
             CanAnnounce = canAnnounce;
@@ -52,6 +53,7 @@ namespace Content.Shared.Communications
             CurrentAlert = currentAlert;
             CurrentAlertDelay = currentAlertDelay;
             StationName = stationName;
+            RenameOnCooldown = renameOnCooldown;
         }
     }
 

--- a/Resources/Locale/pt-BR/communications/communications-console-component.ftl
+++ b/Resources/Locale/pt-BR/communications/communications-console-component.ftl
@@ -55,6 +55,7 @@ comms-console-rename-cooldown = Aguarde antes de renomear a estação novamente.
 comms-console-rename-same-name = A estação já possui esse nome.
 
 # alerts
+comms-console-menu-alert-header = Nivel de alerta da estação:
 comms-console-menu-disabled-alert = Impossivel mudar o alerta agora
 comms-console-menu-declare-alert = Declarar Alerta {$alertLevel}
 comms-green-alert = Verde

--- a/Resources/Locale/pt-BR/communications/communications-console-component.ftl
+++ b/Resources/Locale/pt-BR/communications/communications-console-component.ftl
@@ -47,6 +47,13 @@ comms-console-announcement-title-nukie = Agente Nuclear do Sindicato
 comms-console-menu-footer-left = root@nanoOs
 comms-console-menu-footer-right = v1.5
 
+# rename
+comms-console-menu-header = Bem vindo(a) à estação
+comms-console-menu-rename-placeholder = Novo nome da estação...
+comms-console-menu-rename-button = Renomear
+comms-console-rename-cooldown = Aguarde antes de renomear a estação novamente.
+comms-console-rename-same-name = A estação já possui esse nome.
+
 # alerts
 comms-console-menu-disabled-alert = Impossivel mudar o alerta agora
 comms-console-menu-declare-alert = Declarar Alerta {$alertLevel}

--- a/Resources/Locale/pt-BR/communications/communications-console-component.ftl
+++ b/Resources/Locale/pt-BR/communications/communications-console-component.ftl
@@ -48,7 +48,7 @@ comms-console-menu-footer-left = root@nanoOs
 comms-console-menu-footer-right = v1.5
 
 # rename
-comms-console-menu-header = Bem vindo(a) à estação ${stationName}
+comms-console-menu-header = Bem vindo(a) à estação {$stationName}
 comms-console-menu-rename-placeholder = Novo nome da estação...
 comms-console-menu-rename-button = Renomear
 comms-console-rename-cooldown = Aguarde antes de renomear a estação novamente.

--- a/Resources/Locale/pt-BR/communications/communications-console-component.ftl
+++ b/Resources/Locale/pt-BR/communications/communications-console-component.ftl
@@ -48,7 +48,7 @@ comms-console-menu-footer-left = root@nanoOs
 comms-console-menu-footer-right = v1.5
 
 # rename
-comms-console-menu-header = Bem vindo(a) à estação
+comms-console-menu-header = Bem vindo(a) à estação ${stationName}
 comms-console-menu-rename-placeholder = Novo nome da estação...
 comms-console-menu-rename-button = Renomear
 comms-console-rename-cooldown = Aguarde antes de renomear a estação novamente.


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
Adiciona a possibilidade de renomear a estação pelo console de comunicação (faz o mesmo que o comando de rename station que eu usava pra brincar) essa adição foi pedida pelo Nate
Tambem modifica um pouco a interface do console de comunicações

## Por quê? / Balanceamento
Pedido do Nate, apenas pessoas com permissão de capitão e de centcomm podem mudar o nome, fazer isso manda um log de admin para os admins ficarem ciente caso alguem faça besteira.
Acho que tambem pode abrir mais portas para roleplays ja que não é mais necessario mandar fax ou ahelp pra fazer isso.
Um alerta é enviado pra estação quando a renomeação acontece (igual o comando de renomear estação)

## Detalhes Técnicos
Não vejo necessidade tendo em vista que é a mesma logica de todo o resto

## Anexos
### Sem permissão de alterar o nome:
<img width="900" height="420" alt="image" src="https://github.com/user-attachments/assets/78b44319-4526-435a-be49-b3a082356c54" />

### com permissão:
<img width="900" height="439" alt="image" src="https://github.com/user-attachments/assets/676fee6b-b818-4b02-a187-418d1e4e5d5f" />

### anuncio:
<img width="486" height="67" alt="image" src="https://github.com/user-attachments/assets/12f85a46-9cdc-45e0-a15a-f3700bd55276" />

### cooldown:
<img width="1238" height="134" alt="image" src="https://github.com/user-attachments/assets/949c34d9-7041-40be-a5af-541e5db4fc27" />

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl: AgentePanela
- add: Capitão e NTR agora podem renomear a estação pelo console de comunicação.
