### PR TITLE
Jetpacks no slot de hardsuit

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -79,6 +79,10 @@
     quickEquip: false
     slots:
     - Back
+    - outerClothing # Gaby change
+    clothingVisuals:
+      outerClothing:
+      - state: equipped-BACKPACK
   - type: GasTank
     outputPressure: 21.3
     air:
@@ -126,6 +130,7 @@
     sprite: Objects/Tanks/Jetpacks/blue.rsi
     slots:
       - Back
+      - outerClothing # Gaby change
 
 # Filled blue
 - type: entity
@@ -159,6 +164,7 @@
     sprite: Objects/Tanks/Jetpacks/black.rsi
     slots:
       - Back
+      - outerClothing # Gaby change
   - type: StaticPrice
     price: 1000
 
@@ -192,6 +198,7 @@
     sprite: Objects/Tanks/Jetpacks/captain.rsi
     slots:
       - Back
+      - outerClothing # Gaby change
       - SuitStorage
   - type: Item
     sprite: Objects/Tanks/Jetpacks/captain.rsi
@@ -277,6 +284,7 @@
     sprite: _Gabystation/Objects/Tanks/Jetpacks/security.rsi # Gaby
     slots:
       - Back
+      - outerClothing # Gaby change
 
 #Filled security
 - type: entity
@@ -310,6 +318,7 @@
     sprite: Objects/Tanks/Jetpacks/void.rsi
     slots:
       - Back
+      - outerClothing # Gaby change
       - suitStorage
       - Belt
 


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
Adiciona a possibilidade de tambem vestir jetpacks no slot de outerclotching, pedido feito pelo gnomio

## Por quê? / Balanceamento
Pedido do usuario, por mas que eu achei legal tambem

## Detalhes Técnicos
A animação dos jetpacks (a de ligado / desligado) não funciona pois seria necessario adicionar um state pra outerclotching em cada meta.json de cada jetpack

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl: AgentePanela
- tweak: Jetpacks agora podem ser vestidos no slot de outerclotching.

