### PR TITLE
Sem mais chems meta

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -96,6 +96,9 @@
     grid:
     - 0,0,6,3
     maxItemSize: Huge
+    blacklist: # gaby change
+      tags:
+      - Jug
   - type: ContainerContainer
     containers:
       storagebase: !type:Container

--- a/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chem_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chem_bag.yml
@@ -48,6 +48,9 @@
         - MedicalPatch
         - CigPack
         - Cigarette
+        - Jug # gaby change
   - type: Dumpable
   - type: ExplosionResistance # Goob - end
     damageCoefficient: 0.25
+  - type: StaticPrice
+    price: 500 # gaby change

--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -185,6 +185,7 @@
     - type: Tag
       tags:
       - ChemDispensable
+      - Jug # Dumont
     - type: DnaSubstanceTrace
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -103,6 +103,9 @@
   id: Jug
   description: Used to contain a very large amount of chemicals or solutions. Chugging is extremely ill-advised.
   components:
+    - type: Tag # gaby change
+      tags:
+      - Jug
     - type: SolutionContainerManager
       solutions:
         beaker:
@@ -183,7 +186,7 @@
       tags:
       - ChemDispensable
     - type: DnaSubstanceTrace
-    
+
 - type: entity
   name: tanque de reagente
   parent: BaseItem
@@ -230,7 +233,7 @@
   - type: MultiHandedItem
   - type: StaticPrice
     price: 400
-    
+
     #feito por skysnowflok/supernova com ajuda do Bruno e sprite por skysnowflok/supernova
     #Gabystation
 

--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -103,9 +103,6 @@
   id: Jug
   description: Used to contain a very large amount of chemicals or solutions. Chugging is extremely ill-advised.
   components:
-    - type: Tag # gaby change
-      tags:
-      - Jug
     - type: SolutionContainerManager
       solutions:
         beaker:

--- a/Resources/Prototypes/_Gabystation/tags.yml
+++ b/Resources/Prototypes/_Gabystation/tags.yml
@@ -61,3 +61,6 @@
 
 - type: Tag
   id: MagazineChesterLeverRifle
+
+- type: Tag
+  id: Jug


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
Não será mais possivel botar jugs em mochilas, apenas na chem bag forçando os jogadores a realmente usarem o smart fridge pra sua função real

## Por quê? / Balanceamento
Pedido do nate e realmente reforça uma mecanica
"Não conseguir por jugs dentro de mochilas, só na bolsinha da chem(pra finalmente usarem a geladeira inteligente) e aumentar o preço da bolsa de chem absurdamente pra evitar usarem ela pra isso também. Só o departamento médico consegue acessar a geladeira inteligente da medbay." (pedido dele)

## Detalhes Técnicos
Adiciona uma tag nova aos chems, teoricamente é pra funcionar direito com tudo

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl: AgentePanela
- tweak: Não é mais possivel botar jugs em mochilas. Use o smart fridge!
