### PR TITLE
[Add] Geradores de gravidade produzem radiação

### DIFF
--- a/Content.Server/Gravity/GravityGeneratorComponent.cs
+++ b/Content.Server/Gravity/GravityGeneratorComponent.cs
@@ -43,6 +43,9 @@ namespace Content.Server.Gravity
         [DataField("lightRadiusMin")] public float LightRadiusMin { get; set; }
         [DataField("lightRadiusMax")] public float LightRadiusMax { get; set; }
 
+        [DataField("activeRadiation")]
+        public float ActiveRadiation { get; set; } = 0f;
+
         /// <summary>
         /// Is the gravity generator currently "producing" gravity?
         /// </summary>

--- a/Content.Server/Gravity/GravityGeneratorComponent.cs
+++ b/Content.Server/Gravity/GravityGeneratorComponent.cs
@@ -43,6 +43,10 @@ namespace Content.Server.Gravity
         [DataField("lightRadiusMin")] public float LightRadiusMin { get; set; }
         [DataField("lightRadiusMax")] public float LightRadiusMax { get; set; }
 
+        /// <summary>
+        /// Dumont
+        /// How much radiation whill it generate when active?
+        /// </summary>
         [DataField("activeRadiation")]
         public float ActiveRadiation { get; set; } = 0f;
 

--- a/Content.Server/Gravity/GravityGeneratorSystem.cs
+++ b/Content.Server/Gravity/GravityGeneratorSystem.cs
@@ -21,7 +21,7 @@
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Shared.Gravity;
-using Content.Shared.Radiation.Components;
+using Content.Shared.Radiation.Components; // Dumont
 
 namespace Content.Server.Gravity;
 
@@ -65,6 +65,7 @@ public sealed class GravityGeneratorSystem : EntitySystem
             _gravitySystem.EnableGravity(xform.ParentUid, gravity);
         }
 
+        // Dumont - Radiation generated when active
         var comp = EnsureComp<RadiationSourceComponent>(ent.Owner);
 
         comp.Intensity = ent.Comp.ActiveRadiation;
@@ -81,6 +82,7 @@ public sealed class GravityGeneratorSystem : EntitySystem
             _gravitySystem.RefreshGravity(xform.ParentUid, gravity);
         }
 
+        // Dumont - No radiation when off
         var comp = EnsureComp<RadiationSourceComponent>(ent.Owner);
 
         comp.Intensity = 0;

--- a/Content.Server/Gravity/GravityGeneratorSystem.cs
+++ b/Content.Server/Gravity/GravityGeneratorSystem.cs
@@ -21,6 +21,7 @@
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Shared.Gravity;
+using Content.Shared.Radiation.Components;
 
 namespace Content.Server.Gravity;
 
@@ -63,6 +64,10 @@ public sealed class GravityGeneratorSystem : EntitySystem
         {
             _gravitySystem.EnableGravity(xform.ParentUid, gravity);
         }
+
+        var comp = EnsureComp<RadiationSourceComponent>(ent.Owner);
+
+        comp.Intensity = ent.Comp.ActiveRadiation;
     }
 
     private void OnDeactivated(Entity<GravityGeneratorComponent> ent, ref ChargedMachineDeactivatedEvent args)
@@ -75,6 +80,10 @@ public sealed class GravityGeneratorSystem : EntitySystem
         {
             _gravitySystem.RefreshGravity(xform.ParentUid, gravity);
         }
+
+        var comp = EnsureComp<RadiationSourceComponent>(ent.Owner);
+
+        comp.Intensity = 0;
     }
 
     private void OnParentChanged(EntityUid uid, GravityGeneratorComponent component, ref EntParentChangedMessage args)

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -100,6 +100,7 @@
   - type: GravityGenerator
     lightRadiusMin: 0.75
     lightRadiusMax: 2.5
+    activeRadiation: 1 # Dumont
     spriteMap:
       broken: "broken"
       unpowered: "off"
@@ -125,6 +126,8 @@
     tags:
     - Structure
     - IgnoreImmovableRod
+  - type: RadiationSource # Dumont
+    intensity: 0
 
 - type: entity
   id: GravityGeneratorMini
@@ -183,8 +186,11 @@
   - type: GravityGenerator
     lightRadiusMin: 0.75
     lightRadiusMax: 2.5
+    activeRadiation: 0.2 # Dumont
   - type: StaticPrice
     price: 2000
   - type: Tag # Goobstation
     tags:
     - Structure
+  - type: RadiationSource # Dumont
+    intensity: 0


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
<!-- O que ela muda? -->
Geradores de gravidade agora produzem radiação enquanto ativos e funcionando.

## Por quê? / Balanceamento
<!-- Discuta do por que da existencia da PR. (opcional | recomendado) -->
Compatibilidade com SS13, faz as diversas referências a radiação em alguns mapas reais e torna o gerador levemente mais interessante.


A radiação é pequena, testes indicam que leva cerca de 4min de exposição em contato direto com o gerador e sem nenhuma proteção para entrar em critico. Um espaço de distancia junto de uma janela de plasma são suficientes para parar a radiação quase que por completo. Uma única parede reforçada completamente anula a radiação.
<img width="779" height="597" alt="Screenshot_4" src="https://github.com/user-attachments/assets/07867f98-938c-4580-998a-b5afbf2b4a06" />




Traje antiradiação completamente anula o efeito mesmo em contato direto.
<img width="579" height="279" alt="Screenshot_5" src="https://github.com/user-attachments/assets/b5844890-dfd7-4ef4-861e-30831a1de32d" />




O mini gerador é significativamente mais fraco e gerando 5x menos radiação.
<img width="406" height="153" alt="Screenshot_6" src="https://github.com/user-attachments/assets/d835519b-49f9-414d-a7bc-fc84f3a097b3" />




Nenhuma radiação é gerada com o gerador desligado.
<img width="329" height="229" alt="image" src="https://github.com/user-attachments/assets/508d8044-839f-46f0-9649-b6a102b5dd04" />

## Detalhes Técnicos
<!-- Mudanças do codigo para uma review mais facil (opcional). -->
Novo campo `ActiveRadiation` no `GravityGeneratorComponent.cs` que define a quantidade de radiação a ser produzida pelo gerador enquanto ativo.

`GravityGeneratorSystem` agora seta a radiação para valor definido em `ActiveRadiation` quando a gravidade está ativa e para 0 quando a mesma desliga.

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->
<img width="256" height="256" alt="57c37a52c069b273a21b63" src="https://github.com/user-attachments/assets/67448550-84dc-4d56-bd30-d1fa2ec9a768" />
gay


## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl:
- add: Geradores de gravidade produzem radiação enquanto ativos.
