### PR TITLE
Hristov volta a utilizar projéteis

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/antimateriel.yml
@@ -34,8 +34,8 @@
     tags:
     - Cartridge
     - CartridgeAntiMateriel
-  - type: HitScanCartridgeAmmo
-    hitscan: AntiMaterielBulletTrace
+  - type: CartridgeAmmo # Dumont
+    proto: BulletAntiMateriel # Dumont
   - type: Sprite
     sprite: Objects/Weapons/Guns/Ammunition/Casings/large_casing.rsi
     layers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -261,6 +261,7 @@
   - type: Gun
     # fireRate: 0.4 # Goobstation
     selectedMode: SemiAuto
+    projectileSpeed: 55 # Dumont
     availableModes:
     - SemiAuto
     soundGunshot:


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
Alterado o cartucho .60 anti-material da Hristov para utilizar projéteis ao invés de hitscan.
Os projéteis voltaram a ser bem letais e podem atravessar paredes novamente.

## Por quê? / Balanceamento
Mudamos as munições para usar projéteis ao invés de hitscan, mas a .60 anti-material ainda usava hitscan.
Essa mudança também visa tornar a Hristov uma arma mais competitiva no uplink, e mais assustadora de se enfrentar.
## Detalhes Técnicos
YAML

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl: SrKolobanov
- tweak: Os cartuchos .60 anti-material da Hristov voltam a ser projéteis com alto dano e atravessam paredes.
