### PR TITLE
Permite Oni usar revólveres

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -121,13 +121,14 @@
   - type: EmitSoundOnDrop
     sound:
       collection: RevolversDrop
-  - type: RestrictGunshotsByUserTag # Goobstation
-    doesntContain:
-    - Oni
-    messages:
-    - oni-cannot-shoot-guns-1
-    - oni-cannot-shoot-guns-2
-    - oni-cannot-shoot-guns-3
+ # Dumont | Goobcode made all revolvers unusable but all pistols are fine, let the Oni use them too at least
+ # - type: RestrictGunshotsByUserTag # Goobstation
+ #   doesntContain:
+ #   - Oni
+ #   messages:
+ #   - oni-cannot-shoot-guns-1
+ #   - oni-cannot-shoot-guns-2
+ #   - oni-cannot-shoot-guns-3
   - type: EmitSoundOnLand
     sound:
       collection: RevolversDrop


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
Permite que Onis usem a maioria dos revólveres.

## Por quê? / Balanceamento
Apesar de ser uma raça focada no corpo-a-corpo e incapaz de utilizar armas de fogo, eles podem utilizar qualquer pistola do jogo, mas nenhum revólver, portanto removi essa limitação dos revólveres, exceto o EG-1 e EG-4, que são de energia e utilizam outro parent. O motivo é simplesmente por paridade com as pistolas, coisa que o Goob provavelmente esqueceu de mudar quando readicionaram a capacidade de utilizar pistolas ao Oni.
## Detalhes Técnicos
YAML

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl: SrKolobanov
- tweak: Onis agora podem usar revólveres.

