### PR TITLE
[Tweak] rebalanceia rendimento de minerios

### DIFF
--- a/Content.Server/_Impstation/CartridgeLoader/Cartridges/SOSCartridgeComponent.cs
+++ b/Content.Server/_Impstation/CartridgeLoader/Cartridges/SOSCartridgeComponent.cs
@@ -16,7 +16,7 @@ public sealed partial class SOSCartridgeComponent : Component
     /// <summary>
     /// Path to PDA ID
     /// </summary>
-    public const string PDAIdContainer = "PDA-id";
+    public string PDAIdContainer = "PDA-id";
 
     /// <summary>
     /// Name to use in case there is none, localized
@@ -46,7 +46,7 @@ public sealed partial class SOSCartridgeComponent : Component
     /// <summary>
     /// Timeout between calls
     /// </summary>
-    public const float TimeOut = 90;
+    public float TimeOut = 90;
 
     [DataField]
     /// <summary>

--- a/Content.Server/_Impstation/CartridgeLoader/Cartridges/SOSCartridgeSystem.cs
+++ b/Content.Server/_Impstation/CartridgeLoader/Cartridges/SOSCartridgeSystem.cs
@@ -33,7 +33,7 @@ public sealed class SOSCartridgeSystem : EntitySystem
             return;
 
         if (component.NextMinimumTime < _timing.CurTime &&
-            _container.TryGetContainer(args.Loader, SOSCartridgeComponent.PDAIdContainer, out var idContainer)) {
+            _container.TryGetContainer(args.Loader, component.PDAIdContainer, out var idContainer)) {
 
             //If theres nothing in id slot, send message anonymously
             if (idContainer.ContainedEntities.Count == 0)
@@ -51,7 +51,7 @@ public sealed class SOSCartridgeSystem : EntitySystem
             }
 
             // have to do this bullshit cuz timespan can't be constant
-            component.NextMinimumTime = TimeSpan.FromSeconds(_timing.CurTime.TotalSeconds + SOSCartridgeComponent.TimeOut);
+            component.NextMinimumTime = TimeSpan.FromSeconds(_timing.CurTime.TotalSeconds + component.TimeOut);
             // DeltaV - send feedback that you succeeded
             _popupSystem.PopupEntity(Loc.GetString("sos-message-sent-success"), uid, PopupType.Medium);
         }

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -74,7 +74,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawGold: 100 # Goobstation - was 100
+      RawGold: 100
   - type: Extractable
     grindableSolutionName: goldore
   - type: SolutionContainerManager
@@ -144,7 +144,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawIron: 80 # Goobstation - was 100
+      RawIron: 80
   - type: Extractable
     grindableSolutionName: ironore
   - type: SolutionContainerManager
@@ -177,7 +177,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawPlasma: 100 # Goobstation - was 100
+      RawPlasma: 100
   - type: PointLight
     radius: 1.2
     energy: 0.6
@@ -219,7 +219,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawSilver: 100 # Goobstation - was 100
+      RawSilver: 100
   - type: Extractable
     grindableSolutionName: silverore
   - type: SolutionContainerManager
@@ -256,7 +256,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawQuartz: 70 # Goobstation - was 100
+      RawQuartz: 70
   - type: Extractable
     grindableSolutionName: quartzore
   - type: SolutionContainerManager
@@ -289,7 +289,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawUranium: 100 # Goobstation - was 100
+      RawUranium: 100
   - type: PointLight
     radius: 1.2
     energy: 0.8
@@ -334,7 +334,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawBananium: 80 # Goobstation - was 100
+      RawBananium: 80
   - type: PointLight
     radius: 1.2
     energy: 1
@@ -396,7 +396,7 @@
           Quantity: 0.1
   - type: PhysicalComposition
     materialComposition:
-      Coal: 70 # Goobstation - was 100
+      Coal: 70
   - type: Item
     heldPrefix: coal
 
@@ -445,7 +445,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawSalt: 80 # Goobstation - was 100
+      RawSalt: 80
   - type: Extractable
     grindableSolutionName: saltore
   - type: SolutionContainerManager
@@ -458,7 +458,7 @@
           Quantity: 5
   - type: Item
     heldPrefix: salt
-  - type: StatusEffectOnCollideGhost # Goobstation
+  - type: StatusEffectOnCollideGhost
     whitelist:
       tags:
       - WeakToSalt

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -74,7 +74,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawGold: 500 # Goobstation - was 100
+      RawGold: 100 # Goobstation - was 100
   - type: Extractable
     grindableSolutionName: goldore
   - type: SolutionContainerManager
@@ -144,7 +144,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawIron: 300 # Goobstation - was 100
+      RawIron: 80 # Goobstation - was 100
   - type: Extractable
     grindableSolutionName: ironore
   - type: SolutionContainerManager
@@ -177,7 +177,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawPlasma: 500 # Goobstation - was 100
+      RawPlasma: 100 # Goobstation - was 100
   - type: PointLight
     radius: 1.2
     energy: 0.6
@@ -219,7 +219,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawSilver: 500 # Goobstation - was 100
+      RawSilver: 100 # Goobstation - was 100
   - type: Extractable
     grindableSolutionName: silverore
   - type: SolutionContainerManager
@@ -256,7 +256,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawQuartz: 300 # Goobstation - was 100
+      RawQuartz: 70 # Goobstation - was 100
   - type: Extractable
     grindableSolutionName: quartzore
   - type: SolutionContainerManager
@@ -289,7 +289,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawUranium: 500 # Goobstation - was 100
+      RawUranium: 100 # Goobstation - was 100
   - type: PointLight
     radius: 1.2
     energy: 0.8
@@ -334,7 +334,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawBananium: 300 # Goobstation - was 100
+      RawBananium: 80 # Goobstation - was 100
   - type: PointLight
     radius: 1.2
     energy: 1
@@ -396,7 +396,7 @@
           Quantity: 0.1
   - type: PhysicalComposition
     materialComposition:
-      Coal: 300 # Goobstation - was 100
+      Coal: 70 # Goobstation - was 100
   - type: Item
     heldPrefix: coal
 
@@ -445,7 +445,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawSalt: 300 # Goobstation - was 100
+      RawSalt: 80 # Goobstation - was 100
   - type: Extractable
     grindableSolutionName: saltore
   - type: SolutionContainerManager
@@ -472,4 +472,3 @@
   components:
   - type: Stack
     count: 1
-

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Materials/ore.yml
@@ -70,7 +70,7 @@
   - type: Stack
     stackType: GoldOreUnprocessed
   - type: UnclaimedOre
-    miningPoints: 12
+    miningPoints: 60
 
 - type: entity
   parent: GoldOreUnprocessed
@@ -110,7 +110,7 @@
   - type: Stack
     stackType: SteelOreUnprocessed
   - type: UnclaimedOre
-    miningPoints: 3 # very abundant, is used up more than coal (coal 0.1, iron 0.33)
+    miningPoints: 15 # very abundant, is used up more than coal (coal 0.1, iron 0.33)
 
 - type: entity
   id: SteelOre1Unprocessed
@@ -148,7 +148,7 @@
   - type: Stack
     stackType: PlasmaOreUnprocessed
   - type: UnclaimedOre
-    miningPoints: 6
+    miningPoints: 30
 
 - type: entity
   parent: PlasmaOreUnprocessed
@@ -168,7 +168,7 @@
   - type: Stack
     stackType: SilverOreUnprocessed
   - type: UnclaimedOre
-    miningPoints: 12
+    miningPoints: 60
 
 - type: entity
   parent: SilverOreUnprocessed
@@ -188,7 +188,7 @@
   - type: Stack
     stackType: SpaceQuartzUnprocessed
   - type: UnclaimedOre
-    miningPoints: 3.5 # slightly rarer than iron and coal
+    miningPoints: 18 # slightly rarer than iron and coal
 
 - type: entity
   parent: SpaceQuartzUnprocessed
@@ -226,7 +226,7 @@
   - type: Stack
     stackType: UraniumOreUnprocessed
   - type: UnclaimedOre
-    miningPoints: 24 # used for fuel, lategame schematics, artifacts ect
+    miningPoints: 120 # used for fuel, lategame schematics, artifacts ect
 
 - type: entity
   parent: UraniumOreUnprocessed
@@ -246,7 +246,7 @@
   - type: Stack
     stackType: BananiumOreUnprocessed
   - type: UnclaimedOre
-    miningPoints: 69 # nice
+    miningPoints: 345 # nice (not anymore)
 
 - type: entity
   parent: BananiumOreUnprocessed
@@ -266,7 +266,7 @@
   - type: Stack
     stackType: CoalUnprocessed
   - type: UnclaimedOre
-    miningPoints: 1 # very abundant, used up much less in steel (0.1 coal, 0.33 iron)
+    miningPoints: 5 # very abundant, used up much less in steel (0.1 coal, 0.33 iron)
 
 - type: entity
   parent: CoalUnprocessed

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Materials/ore.yml
@@ -70,7 +70,7 @@
   - type: Stack
     stackType: GoldOreUnprocessed
   - type: UnclaimedOre
-    miningPoints: 60
+    miningPoints: 12
 
 - type: entity
   parent: GoldOreUnprocessed
@@ -110,7 +110,7 @@
   - type: Stack
     stackType: SteelOreUnprocessed
   - type: UnclaimedOre
-    miningPoints: 15 # very abundant, is used up more than coal (coal 0.1, iron 0.33)
+    miningPoints: 3 # very abundant, is used up more than coal (coal 0.1, iron 0.33)
 
 - type: entity
   id: SteelOre1Unprocessed
@@ -148,7 +148,7 @@
   - type: Stack
     stackType: PlasmaOreUnprocessed
   - type: UnclaimedOre
-    miningPoints: 30
+    miningPoints: 6
 
 - type: entity
   parent: PlasmaOreUnprocessed
@@ -168,7 +168,7 @@
   - type: Stack
     stackType: SilverOreUnprocessed
   - type: UnclaimedOre
-    miningPoints: 60
+    miningPoints: 12
 
 - type: entity
   parent: SilverOreUnprocessed
@@ -188,7 +188,7 @@
   - type: Stack
     stackType: SpaceQuartzUnprocessed
   - type: UnclaimedOre
-    miningPoints: 18 # slightly rarer than iron and coal
+    miningPoints: 3.5 # slightly rarer than iron and coal
 
 - type: entity
   parent: SpaceQuartzUnprocessed
@@ -226,7 +226,7 @@
   - type: Stack
     stackType: UraniumOreUnprocessed
   - type: UnclaimedOre
-    miningPoints: 120 # used for fuel, lategame schematics, artifacts ect
+    miningPoints: 24 # used for fuel, lategame schematics, artifacts ect
 
 - type: entity
   parent: UraniumOreUnprocessed
@@ -246,7 +246,7 @@
   - type: Stack
     stackType: BananiumOreUnprocessed
   - type: UnclaimedOre
-    miningPoints: 345 # nice (not anymore)
+    miningPoints: 69 # nice
 
 - type: entity
   parent: BananiumOreUnprocessed
@@ -266,7 +266,7 @@
   - type: Stack
     stackType: CoalUnprocessed
   - type: UnclaimedOre
-    miningPoints: 5 # very abundant, used up much less in steel (0.1 coal, 0.33 iron)
+    miningPoints: 1 # very abundant, used up much less in steel (0.1 coal, 0.33 iron)
 
 - type: entity
   parent: CoalUnprocessed

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Machines/vending_machines.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   id: SLVendingMachine
   parent: BaseMachinePowered

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Machines/vending_machines.yml
@@ -115,7 +115,7 @@
   id: VendorKukriKnife
   productEntity: KukriKnife
   cost:
-    SalvageTicket: 100
+    SalvageTicket: 20
   categories:
   - SalvageWeapons
   conditions:
@@ -125,7 +125,7 @@
   id: VendorWeaponMark1Rifle
   productEntity: WeaponRifleMark1
   cost:
-    SalvageTicket: 400
+    SalvageTicket: 80
   categories:
   - SalvageWeapons
   conditions:
@@ -135,7 +135,7 @@
   id: VendorWeaponMark1SniperRifle
   productEntity: WeaponRifleMark1Sniper
   cost:
-    SalvageTicket: 600
+    SalvageTicket: 110
   categories:
   - SalvageWeapons
   conditions:
@@ -145,7 +145,7 @@
   id: VendorN14ripper
   productEntity: N14ripper
   cost:
-    SalvageTicket: 450
+    SalvageTicket: 20
   categories:
   - SalvageWeapons
   conditions:
@@ -155,7 +155,7 @@
   id: VendorWeaponMarkalibur1Rifle
   productEntity: Markalibur1SheathFilled
   cost:
-    SalvageTicket: 1000
+    SalvageTicket: 200
   categories:
   - SalvageWeapons
   conditions:
@@ -165,7 +165,7 @@
   id: VendorWeaponMakeshiftLaser
   productEntity: WeaponMakeshiftLaser
   cost:
-    SalvageTicket: 1800
+    SalvageTicket: 360
   categories:
   - SalvageWeapons
   conditions:
@@ -175,7 +175,7 @@
   id: VendorWeaponSubMachineGunForged
   productEntity: WeaponSubMachineGunForged
   cost:
-    SalvageTicket: 2400
+    SalvageTicket: 480
   categories:
   - SalvageWeapons
   conditions:
@@ -185,7 +185,7 @@
   id: VendorWeaponShotgunSalvager
   productEntity: WeaponShotgunSalvager
   cost:
-    SalvageTicket: 3000
+    SalvageTicket: 600
   categories:
   - SalvageWeapons
   conditions:
@@ -199,7 +199,7 @@
   id: VendorMiningDrill
   productEntity: MiningDrill
   cost:
-    SalvageTicket: 300
+    SalvageTicket: 60
   categories:
   - SalvageUtilities
   conditions:
@@ -209,7 +209,7 @@
   id: VendorClothingHeadHelmetSalvageMerc
   productEntity: ClothingHeadHelmetSalvageMerc
   cost:
-    SalvageTicket: 200
+    SalvageTicket: 40
   categories:
   - SalvageEquipment
   conditions:
@@ -219,7 +219,7 @@
   id: VendorClothingOuterVestWebSalvageMerc
   productEntity: ClothingOuterVestWebSalvageMerc
   cost:
-    SalvageTicket: 200
+    SalvageTicket: 40
   categories:
   - SalvageEquipment
   conditions:
@@ -229,7 +229,7 @@
   id: VendorClothingHandsSalvageMercGlovesCombat
   productEntity: ClothingHandsSalvageMercGlovesCombat
   cost:
-    SalvageTicket: 200
+    SalvageTicket: 40
   categories:
   - SalvageEquipment
   conditions:
@@ -239,7 +239,7 @@
   id: VendorClothingShoesBootsSalvageMerc
   productEntity: ClothingShoesBootsSalvageMerc
   cost:
-    SalvageTicket: 200
+    SalvageTicket: 40
   categories:
   - SalvageEquipment
   conditions:
@@ -249,7 +249,7 @@
   id: VendorClothingBeltSalvageMercWebbing
   productEntity: ClothingBeltSalvageMercWebbing
   cost:
-    SalvageTicket: 200
+    SalvageTicket: 40
   categories:
   - SalvageEquipment
   conditions:
@@ -259,7 +259,7 @@
   id: VendorFultonBeacon
   productEntity: FultonBeacon
   cost:
-    SalvageTicket: 200
+    SalvageTicket: 40
   categories:
   - SalvageUtilities
   conditions:
@@ -269,7 +269,7 @@
   id: VendorDefibrillatorCompact
   productEntity: DefibrillatorCompact
   cost:
-    SalvageTicket: 350
+    SalvageTicket: 70
   categories:
   - SalvageUtilities
   conditions:
@@ -279,7 +279,7 @@
   id: VendorOreBagMagnetic
   productEntity: OreBagMagnetic
   cost:
-    SalvageTicket: 500
+    SalvageTicket: 100
   categories:
   - SalvageUtilities
   conditions:
@@ -289,7 +289,7 @@
   id: VendorClothingOuterHardsuitSalvage
   productEntity: ClothingOuterHardsuitSalvage
   cost:
-    SalvageTicket: 500
+    SalvageTicket: 100
   categories:
   - SalvageEquipment
   conditions:
@@ -299,7 +299,7 @@
   id: VendorN14ShieldMetalHeavy
   productEntity: N14ShieldMetalHeavy
   cost:
-    SalvageTicket: 400
+    SalvageTicket: 80
   categories:
   - SalvageEquipment
   conditions:
@@ -309,7 +309,7 @@
   id: VendorClothingOuterHardsuitMaxim
   productEntity: ClothingOuterHardsuitMaxim
   cost:
-    SalvageTicket: 1000
+    SalvageTicket: 200
   categories:
   - SalvageEquipment
   conditions:
@@ -319,7 +319,7 @@
   id: VendorN14SledgeHammer
   productEntity: N14SledgeHammer
   cost:
-    SalvageTicket: 1000
+    SalvageTicket: 200
   categories:
   - SalvageEquipment
   conditions:
@@ -333,7 +333,7 @@
   id: VendorTesteMedkit
   productEntity: MedkitFilled
   cost:
-    SalvageTicket: 300
+    SalvageTicket: 60
   categories:
   - SalvageConsumeables
   conditions:
@@ -343,7 +343,7 @@
   id: VendorMedkitRadiationFilled
   productEntity: MedkitRadiationFilled
   cost:
-    SalvageTicket: 500
+    SalvageTicket: 100
   categories:
   - SalvageConsumeables
   conditions:
@@ -353,7 +353,7 @@
   id: VendorMedkitToxinFilled
   productEntity: MedkitToxinFilled
   cost:
-    SalvageTicket: 500
+    SalvageTicket: 100
   categories:
   - SalvageConsumeables
   conditions:
@@ -363,7 +363,7 @@
   id: VendorMedkitAdvancedFilled
   productEntity: MedkitAdvancedFilled
   cost:
-    SalvageTicket: 750
+    SalvageTicket: 150
   categories:
   - SalvageConsumeables
   conditions:
@@ -375,7 +375,7 @@
   id: VendorShellShotgunImprovised
   productEntity: ShellShotgunImprovised
   cost:
-    SalvageTicket: 20
+    SalvageTicket: 4
   categories:
   - SalvageConsumeables
   conditions:
@@ -385,7 +385,7 @@
   id: VendorMagazinePistolSubMachineGunImprovised
   productEntity: MagazinePistolSubMachineGunImprovised
   cost:
-    SalvageTicket: 200
+    SalvageTicket: 40
   categories:
   - SalvageConsumeables
   conditions:
@@ -395,18 +395,18 @@
   id: VendorMagazineShotgunEmpty
   productEntity: MagazineShotgunEmpty
   cost:
-    SalvageTicket: 250
+    SalvageTicket: 50
   categories:
   - SalvageConsumeables
   conditions:
   - !type:BuyerAccessCondition
-  
+
 
 - type: listing
   id: VendorBoxMagnum
   productEntity: MagazineBoxMagnum
   cost:
-    SalvageTicket: 350
+    SalvageTicket: 70
   categories:
   - SalvageConsumeables
   conditions:
@@ -416,7 +416,7 @@
   id: VendorBoxLightRifle
   productEntity: MagazineBoxLightRifle
   cost:
-    SalvageTicket: 450
+    SalvageTicket: 90
   categories:
   - SalvageConsumeables
   conditions:
@@ -426,7 +426,7 @@
   id: VendorMagazineBoxImprovisedPistol
   productEntity: MagazineBoxImprovisedPistol
   cost:
-    SalvageTicket: 750
+    SalvageTicket: 150
   categories:
   - SalvageConsumeables
   conditions:
@@ -438,7 +438,7 @@
   id: VendorBoxFlare
   productEntity: BoxFlare
   cost:
-    SalvageTicket: 50
+    SalvageTicket: 10
   categories:
   - SalvageUtilities
   conditions:
@@ -448,7 +448,7 @@
   id: VendorBoxMRE
   productEntity: BoxMRE
   cost:
-    SalvageTicket: 50
+    SalvageTicket: 10
   categories:
   - SalvageConsumeables
   conditions:


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
reduz o rendimento de minerios em ~5x

estou deixando em draft por que estou com sono, vou mimir, pode ter coisa faltando e ainda vou testar isso ingame. sim eu sou paranoico

## Por quê? / Balanceamento
creio que todos sabemos que o rendimento atual é ridiculo, um único minerador consegue render mais de mil de aço em menos de 30 minutos, o suficiente pra suprir uma estação lowpop inteira por um bom tempo. e isso sem ter mt dos equipamentos melhores de mineração.

## Detalhes Técnicos
yaml

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl: supernova
- tweak: minerios agora rendem cinco vezes menos materiais
