### PR TITLE
Punição de itens malignos.

### DIFF
--- a/Content.Goobstation.Shared/Religion/UnholyItemComponent.cs
+++ b/Content.Goobstation.Shared/Religion/UnholyItemComponent.cs
@@ -6,8 +6,23 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
 
 namespace Content.Goobstation.Shared.Religion;
 
-[RegisterComponent, NetworkedComponent]
-public sealed partial class UnholyItemComponent : Component;
+/// <summary>
+/// Marks an item as unholy.
+///
+/// When <see cref="Punish"/> is enabled, unauthorized entities that attempt
+/// to pick up or pull this item are punished by <see cref="UnholyItemSystem"/>.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class UnholyItemComponent : Component
+{
+    /// <summary>
+    /// Whether interacting with this item should punish entities that are
+    /// neither unholy nor capable of using bibles.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Punish = false;
+}

--- a/Content.Server/_Dumont/Religion/EntitySystems/UnholyItemSystem.cs
+++ b/Content.Server/_Dumont/Religion/EntitySystems/UnholyItemSystem.cs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Goobstation.Common.Religion;
+using Content.Goobstation.Shared.Religion;
+using Content.Server.Atmos.EntitySystems;
+using Content.Shared.Hands;
+using Content.Shared.Item;
+using Content.Shared.Popups;
+using Content.Shared.Standing;
+using Content.Shared.Stunnable;
+using Content.Shared.Temperature;
+using Content.Shared.Vampire.Components;
+
+namespace Content.Server._Dumont.Religion.EntitySystems;
+
+/// <summary>
+/// Handles attempts to pick up protected unholy items.
+/// </summary>
+public sealed partial class UnholyItemSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedStunSystem _stun = default!;
+    [Dependency] private readonly FlammableSystem _flammable = default!;
+
+    private static readonly TimeSpan HeavyStunTime = TimeSpan.FromSeconds(10);
+    private const float FireStacks = 3f;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<UnholyItemComponent, GettingPickedUpAttemptEvent>(
+            OnPickupAttempt);
+    }
+
+    private void OnPickupAttempt(
+        Entity<UnholyItemComponent> item,
+        ref GettingPickedUpAttemptEvent args)
+    {
+        if (TryPunish(item, args.User))
+            args.Cancel();
+    }
+
+    /// <summary>
+    /// Checks whether punishment is enabled and whether the user is permitted
+    /// to pick up the item.
+    /// </summary>
+    private bool TryPunish(
+    Entity<UnholyItemComponent> item,
+    EntityUid user)
+    {
+        if (!item.Comp.Punish)
+            return false;
+
+        if (HasComp<UnholyComponent>(user))
+            return false;
+
+        if (HasComp<BibleUserComponent>(user))
+        {
+            _popup.PopupEntity(
+                Loc.GetString(
+                    "unholy-item-bible-user-popup",
+                    ("item", item.Owner)),
+                item,
+                user,
+                PopupType.Medium);
+
+            return false;
+        }
+
+        _popup.PopupEntity(
+            Loc.GetString(
+                "unholy-item-punishment-popup",
+                ("item", item.Owner)),
+            item,
+            user,
+            PopupType.LargeCaution);
+
+        _stun.TryUpdateParalyzeDuration(
+            user,
+            HeavyStunTime);
+
+        _flammable.AdjustFireStacks(user, FireStacks);
+        _flammable.Ignite(user, item);
+
+        // Tells the pickup handler to cancel acquisition of the item.
+        return true;
+    }
+}

--- a/Resources/Locale/en-US/_Dumont/Religion/EntitySystems/UnholyItemSystem.ftl
+++ b/Resources/Locale/en-US/_Dumont/Religion/EntitySystems/UnholyItemSystem.ftl
@@ -1,0 +1,3 @@
+unholy-item-bible-user-popup = Your faith protects you from the evil aura contained in {$item}!
+
+unholy-item-punishment-popup = The evil aura contained in {$item} punishes you!

--- a/Resources/Locale/pt-BR/_Dumont/Religion/EntitySystems/UnholyItemSystem.ftl
+++ b/Resources/Locale/pt-BR/_Dumont/Religion/EntitySystems/UnholyItemSystem.ftl
@@ -1,0 +1,3 @@
+unholy-item-bible-user-popup = A sua fé te protege da aura maligna contida em {$item}!
+
+unholy-item-punishment-popup = A aura maligna contida em {$item} te pune!


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
Adiciona um sistema que permite que itens com o componente `UnholyItem` punam mobs que tentarem pegar o item, exceto se eles possuírem `BibleUser`(componente do capelão) ou `Unholy`.

## Por quê? / Balanceamento
O componente `UnholyItem` atualmente não possui nenhuma mecânica significativa, e essa PR cria um sistema que permite punir uma criatura não-maligna ou não-capelã de pegar o item.
O componente `UnholyItem` agora possui um campo chamado `Punish`, que por padrão é definido como `false` e não faz nada, mudar para `true` irá ativar o sistema.
Criaturas punidas recebem stun e são incendiadas, além de largar o item maligno.

## Detalhes Técnicos
Fluent & C#, shitcode is my passion.

## Anexos
https://cdn.discordapp.com/attachments/1296583941171576873/1526638603097342073/MyServer_-_Dumont_Station_2026-07-14_14-11-50.mp4?ex=6a57c07e&is=6a566efe&hm=3b7a6494b8fde36774b35e11c7e18056ba52faf601b51d3a3d3c1b431ec477f7&

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl: SrKolobanov
- add: Sistema de punição para itens malignos.
