### PR TITLE
[Feature] Adiciona cvar de trocar os prontos por pessoas online

### DIFF
--- a/Content.Goobstation.Common/CCVar/CCVars.Goob.cs
+++ b/Content.Goobstation.Common/CCVar/CCVars.Goob.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Goob Station Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Robust.Shared.Configuration;
 
 namespace Content.Goobstation.Common.CCVar;

--- a/Content.Goobstation.Common/CCVar/CCVars.Goob.cs
+++ b/Content.Goobstation.Common/CCVar/CCVars.Goob.cs
@@ -637,4 +637,7 @@ public sealed partial class GoobCVars
         CVarDef.Create("particles.global_budget", 8000, CVar.CLIENTONLY | CVar.ARCHIVE);
 
     #endregion
+
+    public static readonly CVarDef<bool> SecretUseOnlinePlayerCount =
+        CVarDef.Create("game.secret_use_online_count", false, CVar.SERVER | CVar.REPLICATED | CVar.ARCHIVE);
 }

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -445,6 +445,11 @@ namespace Content.Server.GameTicking
             return total;
         }
 
+        public int OnlinePlayerCount()
+        {
+            return _playerManager.PlayerCount;
+        }
+
         public void StartRound(bool force = false)
         {
 #if EXCEPTION_TOLERANCE

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.cs
@@ -17,12 +17,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Goobstation.Common.CCVar;
 using Content.Server._Gabystation;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Chat.Managers;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Tag;
 using Robust.Server.GameObjects;
+using Robust.Shared.Configuration;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -34,6 +36,7 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
     [Dependency] protected readonly IChatManager ChatManager = default!;
     [Dependency] protected readonly GameTicker GameTicker = default!;
     [Dependency] protected readonly IGameTiming Timing = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
 
     // Not protected, just to be used in utility methods
     [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
@@ -56,11 +59,15 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
         if (args.Forced || args.Cancelled)
             return;
 
+        var playerCount = _cfg.GetCVar(GoobCVars.SecretUseOnlinePlayerCount)
+            ? GameTicker.OnlinePlayerCount()
+            : args.Players.Length;
+
         var query = QueryAllRules();
         while (query.MoveNext(out var uid, out _, out var gameRule))
         {
             var minPlayers = gameRule.MinPlayers;
-            if (args.Players.Length >= minPlayers)
+            if (playerCount >= minPlayers)
                 continue;
 
             if (gameRule.CancelPresetOnTooFewPlayers)
@@ -69,7 +76,7 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
                 {
                     // GabyStation
                     ChatManager.SendAdminAnnouncement(Loc.GetString("preset-not-enough-ready-players-end-rule",
-                        ("readyPlayersCount", args.Players.Length),
+                        ("readyPlayersCount", playerCount),
                         ("minimumPlayers", minPlayers),
                         ("presetName", ToPrettyString(uid))));
 
@@ -78,7 +85,7 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
                 else
                 {
                     ChatManager.SendAdminAnnouncement(Loc.GetString("preset-not-enough-ready-players",
-                        ("readyPlayersCount", args.Players.Length),
+                        ("readyPlayersCount", playerCount),
                         ("minimumPlayers", minPlayers),
                         ("presetName", ToPrettyString(uid))));
                     args.Cancel();

--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -28,6 +28,7 @@ using Content.Server.GameTicking.Presets;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Random;
+using Content.Goobstation.Common.CCVar;
 using Content.Shared.CCVar;
 using Content.Shared.Database;
 using Robust.Shared.Prototypes;
@@ -93,10 +94,17 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
         }
     }
 
+    private int GetPlayerCountForPresetSelection()
+    {
+        return _configurationManager.GetCVar(GoobCVars.SecretUseOnlinePlayerCount)
+            ? GameTicker.OnlinePlayerCount()
+            : GameTicker.ReadyPlayerCount();
+    }
+
     private bool TryPickPreset(ProtoId<WeightedRandomPrototype> weights, [NotNullWhen(true)] out GamePresetPrototype? preset)
     {
         var options = _prototypeManager.Index(weights).Weights.ShallowClone();
-        var players = GameTicker.ReadyPlayerCount();
+        var players = GetPlayerCountForPresetSelection();
 
         GamePresetPrototype? selectedPreset = null;
         var sum = options.Values.Sum();
@@ -154,7 +162,7 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     /// </summary>
     public bool CanPickAny(IEnumerable<ProtoId<GamePresetPrototype>> protos)
     {
-        var players = GameTicker.ReadyPlayerCount();
+        var players = GetPlayerCountForPresetSelection();
         foreach (var id in protos)
         {
             if (!_prototypeManager.TryIndex(id, out var selectedPreset))

--- a/Content.Server/GameTicking/Rules/SubGamemodesSystem.cs
+++ b/Content.Server/GameTicking/Rules/SubGamemodesSystem.cs
@@ -5,21 +5,56 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using System.Linq;
+using Content.Goobstation.Common.CCVar;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Storage;
+using Robust.Shared.Configuration;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.GameTicking.Rules;
 
 public sealed class SubGamemodesSystem : GameRuleSystem<SubGamemodesComponent>
 {
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+
+    private string _ruleCompName = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _ruleCompName = Factory.GetComponentName<GameRuleComponent>();
+    }
+
     protected override void Added(EntityUid uid, SubGamemodesComponent comp, GameRuleComponent rule, GameRuleAddedEvent args)
     {
-        var picked = EntitySpawnCollection.GetSpawns(comp.Rules, RobustRandom);
+        var candidates = comp.Rules;
+
+        if (_cfg.GetCVar(GoobCVars.SecretUseOnlinePlayerCount))
+        {
+            var players = GameTicker.OnlinePlayerCount();
+            candidates = comp.Rules.Where(entry => CanRun(entry, players)).ToList();
+        }
+
+        var picked = EntitySpawnCollection.GetSpawns(candidates, RobustRandom);
         foreach (var id in picked)
         {
             Log.Info($"Starting gamerule {id} as a subgamemode of {ToPrettyString(uid):rule}");
             GameTicker.AddGameRule(id);
         }
+    }
+
+    private bool CanRun(EntitySpawnEntry entry, int players)
+    {
+        if (entry.PrototypeId is not { } protoId)
+            return true;
+
+        if (!_proto.TryIndex(protoId, out EntityPrototype? ruleProto)
+            || !ruleProto.TryGetComponent(_ruleCompName, out GameRuleComponent? ruleComp))
+            return true;
+
+        return ruleComp.MinPlayers <= players || !ruleComp.CancelPresetOnTooFewPlayers;
     }
 }

--- a/Resources/Locale/en-US/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-ticker.ftl
@@ -65,6 +65,7 @@ latejoin-arrivals-dumped-from-shuttle = A mysterious force prevents you from lea
 latejoin-arrivals-teleport-to-spawn = A mysterious force teleports you off the arrivals shuttle. Have a safe shift!
 
 preset-not-enough-ready-players = Can't start {$presetName}. Requires {$minimumPlayers} players but we have {$readyPlayersCount}.
+preset-not-enough-ready-players-end-rule = Ending {$presetName}. Requires {$minimumPlayers} players but we have {$readyPlayersCount}.
 preset-no-one-ready = Can't start {$presetName}. No players are ready.
 
 game-run-level-PreRoundLobby = Pre-round lobby

--- a/Resources/Locale/pt-BR/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/pt-BR/game-ticking/game-ticker.ftl
@@ -39,7 +39,8 @@ latejoin-arrivals-direction-time = Uma nave que o transferirá para sua estaçã
 latejoin-arrivals-dumped-from-shuttle = Uma força misteriosa impede você de sair com a nave de chegadas.
 latejoin-arrivals-teleport-to-spawn = Uma força misteriosa teletransporta você para fora da nave de chegadas. Tenha um turno seguro!
 
-preset-not-enough-ready-players = A rodada será cancelado pois não é possível iniciar {$presetName}. São necessários {$minimumPlayers} jogadores prontos, mas temos apenas {$readyPlayersCount}.
+preset-not-enough-ready-players = A rodada será cancelada pois não é possível iniciar {$presetName}. São necessários {$minimumPlayers} jogadores, mas temos apenas {$readyPlayersCount}.
+preset-not-enough-ready-players-end-rule = Encerrando {$presetName}: são necessários {$minimumPlayers} jogadores, mas temos apenas {$readyPlayersCount}.
 preset-no-one-ready = Não é possível iniciar {$presetName}. Nenhum jogador está pronto.
 
 game-run-level-PreRoundLobby = Lobby pré-rodada


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
 ela Adiciona uma cvar  "game.secret_use_online_count" ela troca a necessidade dos prontos no lobby, assim o game escolhe o gamemode de acordo com a quantidade de players no lobby
[eu não consegui testar direito porque no local porque só tem eu, e eu não consigo rodar um local server (dotnet run --project Content.Server) por muito tempo porque meu pc é uma batata]


## Por quê? / Balanceamento
  Sempre foi um perrengue não ter round bons porque as pessoas não dão pronto e as vezes elas só não sabem qual departamento ir ainda, assim afetando a escolha do gamemode para os outros


## Anexos

<img width="406" height="106" alt="image" src="https://github.com/user-attachments/assets/c7f12771-e8a9-440c-b743-1ca5da206406" />
  

## Requerimentos
 Confirme colocando X entre os colchetes [X]: 
- [x ] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x ] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.


Changelog

🆑 Crono209

add: Adiciona um cvar para contar pessoas online no lobby
