### PR TITLE
Wraith Spawn

### DIFF
--- a/Resources/Prototypes/_Trauma/Wraith/Gamerules/roundstart.yml
+++ b/Resources/Prototypes/_Trauma/Wraith/Gamerules/roundstart.yml
@@ -3,8 +3,8 @@
   id: WraithRoundstart
   components:
   - type: GameRule
-    chaosScore: 1000
-    minPlayers: 35
+    chaosScore: 500
+    minPlayers: 20
   - type: AntagSpawner
     # Dumont
     prototype: MobWraith 

--- a/Resources/Prototypes/_Trauma/Wraith/Gamerules/roundstart.yml
+++ b/Resources/Prototypes/_Trauma/Wraith/Gamerules/roundstart.yml
@@ -1,4 +1,8 @@
-﻿- type: entity
+# SPDX-FileCopyrightText: 2026 Space Station 14 Contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: entity
   parent: BaseGameRule
   id: WraithRoundstart
   components:


### PR DESCRIPTION
## Sobre a PR
Altera o spawn do Wraith, antes estava o do trauma.

## Por quê? / Balanceamento

## Detalhes Técnicos
35min de players pra > 20
chaos score 1000 pra > 500

sem changelog pois é uma mudança pequena igual o fix de salv.

## Anexos

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

