### PR TITLE
modifica livros de guidebook pra seguir metashield

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
+++ b/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
@@ -96,7 +96,7 @@
     - id: BookMedicalReferenceBook
     - id: BookScientistsGuidebook
     - id: BookSecurity
-    - id: BookSpaceEncyclopedia
+    # - id: BookSpaceEncyclopedia Dumont
     - id: BookSpaceLaw
     - id: BookTheBookOfControl
 

--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -268,7 +268,7 @@
   components:
     - type: StorageFill
       contents:
-      - id: BookSpaceEncyclopedia
+      # - id: BookSpaceEncyclopedia
       - id: BookTheBookOfControl
       - id: BookBartendersManual
       - id: BookHowToCookForFortySpaceman
@@ -456,4 +456,3 @@
     contents:
     - id: BoxLightbulbColorfulMixed
     - id: BoxLighttubeColorfulMixed
-

--- a/Resources/Prototypes/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/books.yml
@@ -223,26 +223,27 @@
     - Fiber
   # Goobstation Edit End
 
-- type: entity
-  id: BookSpaceEncyclopedia
-  parent: BaseGuidebook
-  name: space encyclopedia
-  description: An encyclopedia containing all the knowledge. The author of this encyclopedia is unknown.
-  components:
-  - type: Sprite
-    layers:
-    - state: paper
-    - state: cover_base
-      color: "#0a2a6b"
-    - state: decor_wingette
-      color: "#082561"
-    - state: icon_text
-      color: gold
-    - state: icon_planet
-      color: "#42b6f5"
-  - type: GuideHelp
-    guides:
-    - SS14
+# Dumont - deactivated since it breaks metashield
+# - type: entity
+#   id: BookSpaceEncyclopedia
+#   parent: BaseGuidebook
+#   name: space encyclopedia
+#   description: An encyclopedia containing all the knowledge. The author of this encyclopedia is unknown.
+#   components:
+#   - type: Sprite
+#     layers:
+#     - state: paper
+#     - state: cover_base
+#       color: "#0a2a6b"
+#     - state: decor_wingette
+#       color: "#082561"
+#     - state: icon_text
+#       color: gold
+#     - state: icon_planet
+#       color: "#42b6f5"
+#   - type: GuideHelp
+#     guides:
+#     - SS14
 
 - type: entity
   id: BookTheBookOfControl

--- a/Resources/Prototypes/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/books.yml
@@ -223,27 +223,26 @@
     - Fiber
   # Goobstation Edit End
 
-# Dumont - deactivated since it breaks metashield
-# - type: entity
-#   id: BookSpaceEncyclopedia
-#   parent: BaseGuidebook
-#   name: space encyclopedia
-#   description: An encyclopedia containing all the knowledge. The author of this encyclopedia is unknown.
-#   components:
-#   - type: Sprite
-#     layers:
-#     - state: paper
-#     - state: cover_base
-#       color: "#0a2a6b"
-#     - state: decor_wingette
-#       color: "#082561"
-#     - state: icon_text
-#       color: gold
-#     - state: icon_planet
-#       color: "#42b6f5"
-#   - type: GuideHelp
-#     guides:
-#     - SS14
+- type: entity
+  id: BookSpaceEncyclopedia
+  parent: BaseGuidebook
+  name: space encyclopedia
+  description: An encyclopedia containing all the knowledge. The author of this encyclopedia is unknown.
+  components:
+  - type: Sprite
+    layers:
+    - state: paper
+    - state: cover_base
+      color: "#0a2a6b"
+    - state: decor_wingette
+      color: "#082561"
+    - state: icon_text
+      color: gold
+    - state: icon_planet
+      color: "#42b6f5"
+  - type: GuideHelp
+    guides:
+    - SS14
 
 - type: entity
   id: BookTheBookOfControl
@@ -384,7 +383,18 @@
   - type: GuideHelp
     guides:
     - Security
-    - Antagonists
+    - Traitors
+    - Thieves
+    - NuclearOperatives
+    # - Dragon Doesn't exist?
+    - Morph
+    - Blob
+    # - RatKing no exist also?
+    - SpaceNinja
+    - Bingle
+    - Xenos
+    - Wizard
+
 
 - type: entity
   id: BookHowToKeepStationClean

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mail/mail_service.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mail/mail_service.yml
@@ -11,9 +11,9 @@
   components:
   - type: Mail
     contents:
-    - id: BookSpaceEncyclopedia
-      prob: 0.2
-      orGroup: bookguide
+    # - id: BookSpaceEncyclopedia Dumont
+    #   prob: 0.2
+    #   orGroup: bookguide
     - id: BookTheBookOfControl
       prob: 0.2
       orGroup: bookguide


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
desativa completamente o BookSpaceEncyclopedia, que ao interagir, mostrava a pagina do guia de todos os antags

## Por quê? / Balanceamento
quebra metashield, e pedido do criso

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl: supernova
- remove: livro de enciclopedia
- tweak: livro security 101 agora apenas mostra os antagonistas que são conhecimento comum via metashield