### PR TITLE
fix erros de console do duo emote system 

### DIFF
--- a/Content.Client/_Funkystation/Emoting/DuoEmoteSystem.cs
+++ b/Content.Client/_Funkystation/Emoting/DuoEmoteSystem.cs
@@ -100,6 +100,9 @@ public sealed partial class DuoEmoteSystem : SharedDuoEmoteSystem
         var initiator = GetEntity(ev.Initiator);
         var partner = GetEntity(ev.Partner);
 
+        if (!initiator.IsValid() || !partner.IsValid())
+            return;
+
         // Base lunge animation
         PlayLunge(initiator, partner);
         PlayLunge(partner, initiator);


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
resolve o erro onde ele n consegue dar resolve em entityuid = 0;

## Por quê? / Balanceamento
remoção de erro

## Detalhes Técnicos
checa se a entitade adquirida via net entity é valida antes de utilizar o getmap coordinates (Id > 0), meio que um erro bandage mas é valido, sinto como se isso fosse parte de um problema maior

## Anexos
<img width="1081" height="193" alt="image" src="https://github.com/user-attachments/assets/4c44b8aa-aa90-4176-a733-5b85bfe2de78" />


## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
no