### PR TITLE
[Fix] Acesso Virologia

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/books.yml
@@ -392,7 +392,7 @@
     # - RatKing no exist also?
     - SpaceNinja
     - Bingle
-    - Xenos
+    # - Xenos nonono
     - Wizard
 
 

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -730,7 +730,7 @@
   components:
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsMedical ]
+      board: [ DoorElectronicsVirology ]
 
 - type: entity
   parent: AirlockScienceGlass

--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -89,10 +89,10 @@
   access:
   - Cargo
   - Maintenance
+  - Mail # Dumont
   extendedAccess:
   - Salvage
   - External # goobstation
-  - Mail # Dumont
   - Mining # Dumont
   - Bitrun # Dumont
   special:


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
<!-- O que ela muda? -->
Arruma acesso de virologia para airlock de vidro subdepartamental, também concede acesso temporário de correio para técnicos de carga até que o trabalho em si seja introduzido.

## Por quê? / Balanceamento
<!-- Discuta do por que da existencia da PR. (opcional | recomendado) -->
Fixes #862 
## Detalhes Técnicos
<!-- Mudanças do codigo para uma review mais facil (opcional). -->
Edição básica YML.
## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl:
- tweak: Acesso de correio concedido a técnicos de carga até que o trabalho separado seja introduzido.
- fix: Airlock de vidro da virologia possui acesso adequado agora.
