### PR TITLE
arruma server não fazendo update

### DIFF
--- a/Content.Packaging/DepsHandler.cs
+++ b/Content.Packaging/DepsHandler.cs
@@ -1,0 +1,80 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Content.Packaging;
+
+/// <summary>
+/// Helper class for working with <c>.deps.json</c> files.
+/// </summary>
+public sealed class DepsHandler
+{
+    public readonly Dictionary<string, LibraryInfo> Libraries = new();
+
+    public DepsHandler(DepsData data)
+    {
+        if (data.Targets.Count != 1)
+            throw new Exception("Expected exactly one target");
+
+        var target = data.Targets.Single().Value;
+
+        foreach (var (libNameAndVersion, libInfo) in target)
+        {
+            var split = libNameAndVersion.Split('/', 2);
+
+            Libraries.Add(split[0], libInfo);
+        }
+    }
+
+    public static DepsHandler Load(string depsFile)
+    {
+        using var f = File.OpenRead(depsFile);
+        var depsData = JsonSerializer.Deserialize<DepsData>(f) ?? throw new InvalidOperationException("Deps are null!");
+
+        return new DepsHandler(depsData);
+    }
+
+    public HashSet<string> RecursiveGetLibrariesFrom(string start)
+    {
+        var found = new HashSet<string>();
+
+        RecursiveAddLibraries(start, found);
+
+        return found;
+    }
+
+    private void RecursiveAddLibraries(string start, HashSet<string> set)
+    {
+        if (!set.Add(start))
+            return;
+
+        var lib = Libraries[start];
+        if (lib.Dependencies == null)
+            return;
+
+        foreach (var dep in lib.Dependencies.Keys)
+        {
+            RecursiveAddLibraries(dep, set);
+        }
+    }
+
+    public sealed class DepsData
+    {
+        [JsonInclude, JsonPropertyName("targets")]
+        public required Dictionary<string, Dictionary<string, LibraryInfo>> Targets;
+    }
+
+    public sealed class LibraryInfo
+    {
+        [JsonInclude, JsonPropertyName("dependencies")]
+        public Dictionary<string, string>? Dependencies;
+
+        [JsonInclude, JsonPropertyName("runtime")]
+        public Dictionary<string, object>? Runtime;
+
+        // Paths are like lib/netstandard2.0/JetBrains.Annotations.dll
+        public IEnumerable<string> GetDllNames()
+        {
+            return Runtime == null ? [] : Runtime.Keys.Select(p => p.Split('/')[^1]);
+        }
+    }
+}

--- a/Content.Packaging/ServerPackaging.cs
+++ b/Content.Packaging/ServerPackaging.cs
@@ -79,7 +79,6 @@
 
 using System.Diagnostics;
 using System.IO.Compression;
-using System.Text.Json;
 using Robust.Packaging;
 using Robust.Packaging.AssetProcessing;
 using Robust.Packaging.AssetProcessing.Passes;
@@ -114,31 +113,9 @@ public static class ServerPackaging
         .Select(o => o.Rid)
         .ToList();
 
-    private static readonly List<string> CoreServerContentAssemblies = new()
-    {
-        "Content.Server.Database",
-        "Content.Server",
-        "Content.Shared",
-        "Content.Shared.Database",
-        /*"Content.Goobstation.Server", // Gabystation - start
-        "Content.Goobstation.Client", // I don't give a shit if this is not the right way to do
-        "Content.Goobstation.Shared",
-        "Content.Goobstation.Common", // Gabystation - end*/
-        "Content.ModuleManager", // I cant be fucked to figure out how to this dynamically
-    };
-
-    private static readonly List<string> ServerExtraAssemblies = new()
-    {
-        // Python script had Npgsql. though we want Npgsql.dll as well soooo
-        "Npgsql",
-        "Microsoft",
-        "Concentus",
-        "NetCord",
-    };
-
     private static readonly List<string> ServerNotExtraAssemblies = new()
     {
-        "Microsoft.CodeAnalysis",
+        "JetBrains.Annotations",
     };
 
     private static readonly HashSet<string> BinSkipFolders = new()
@@ -318,47 +295,12 @@ public static class ServerPackaging
         var inputPassCore = graph.InputCore;
         var inputPassResources = graph.InputResources;
 
-        var contentAssemblies = FindAllServerModules();
-
         // Additional assemblies that need to be copied such as EFCore.
         var sourcePath = Path.Combine(contentDir, "bin", "Content.Server");
 
-        var serverExtraAssemblies = new List<string>(ServerExtraAssemblies);
-        var dependenciesFile = File.OpenRead(Path.Combine("bin", "Content.Server", "Content.Server.deps.json"));
-        var serverProj = await JsonDocument.ParseAsync(dependenciesFile, cancellationToken: cancel);
-        var targets = serverProj.RootElement.GetProperty("targets");
-        foreach (var target in targets.EnumerateObject())
-        {
-            foreach (var project in target.Value.EnumerateObject())
-            {
-                if (!project.Name.Contains("Content.Server"))
-                    continue;
+        var deps = DepsHandler.Load(Path.Combine(sourcePath, "Content.Server.deps.json"));
 
-                if (!project.Value.TryGetProperty("dependencies", out var dependencies))
-                    continue;
-
-                foreach (var dependency in dependencies.EnumerateObject())
-                {
-                    var dependencyName = dependency.Name;
-                    if (!serverExtraAssemblies.Contains(dependencyName))
-                        serverExtraAssemblies.Add(dependencyName);
-                }
-            }
-        }
-        Debugger.Launch();
-
-        // Should this be an asset pass?
-        // For future archaeologists I just want audio rework to work and need the audio pass so
-        // just porting this as is from python.
-        foreach (var fullPath in Directory.EnumerateFiles(sourcePath, "*.*", SearchOption.AllDirectories))
-        {
-            var fileName = Path.GetFileNameWithoutExtension(fullPath);
-
-            if (!ServerNotExtraAssemblies.Any(o => fileName.StartsWith(o)) && serverExtraAssemblies.Any(o => fileName.StartsWith(o)))
-            {
-                contentAssemblies.Add(fileName);
-            }
-        }
+        var contentAssemblies = GetContentAssemblyNamesToCopy(deps);
 
         await RobustSharedPackaging.DoResourceCopy(
             Path.Combine("RobustToolbox", "bin", "Server",
@@ -384,6 +326,22 @@ public static class ServerPackaging
 
         inputPassCore.InjectFinished();
         inputPassResources.InjectFinished();
+    }
+
+    // This returns both content assemblies (e.g. Content.Server.dll) and dependencies (e.g. Npgsql)
+    private static IEnumerable<string> GetContentAssemblyNamesToCopy(DepsHandler deps)
+    {
+        var depsContent = deps.RecursiveGetLibrariesFrom("Content.Server").SelectMany(GetLibraryNames);
+        var depsRobust = deps.RecursiveGetLibrariesFrom("Robust.Server").SelectMany(GetLibraryNames);
+
+        var depsContentExclusive = depsContent.Except(depsRobust).ToHashSet();
+
+        // Remove .dll suffix and apply filtering.
+        var names = depsContentExclusive.Select(p => p[..^4]).Where(p => !ServerNotExtraAssemblies.Any(p.StartsWith));
+
+        return names;
+
+        IEnumerable<string> GetLibraryNames(string library) => deps.Libraries[library].GetDllNames();
     }
 
     private readonly record struct PlatformReg(string Rid, string TargetOs, bool BuildByDefault);

--- a/Content.Packaging/ServerPackaging.cs
+++ b/Content.Packaging/ServerPackaging.cs
@@ -79,7 +79,7 @@
 
 using System.Diagnostics;
 using System.IO.Compression;
-using Content.ModuleManager;
+using System.Xml.Linq;
 using Robust.Packaging;
 using Robust.Packaging.AssetProcessing;
 using Robust.Packaging.AssetProcessing.Passes;
@@ -322,6 +322,23 @@ public static class ServerPackaging
 
         // Additional assemblies that need to be copied such as EFCore.
         var sourcePath = Path.Combine(contentDir, "bin", "Content.Server");
+
+        var serverExtraAssemblies = new List<string>(ServerExtraAssemblies);
+        var serverProj = XDocument.Load(Path.Combine("Content.Server", "Content.Server.csproj"));
+        if (serverProj.Root is { } root)
+        {
+            foreach (var group in root.Elements("ItemGroup"))
+            {
+                foreach (var reference in group.Elements("PackageReference"))
+                {
+                    if (reference.Attribute("Include")?.Value is not { } include)
+                        continue;
+
+                    if (!serverExtraAssemblies.Contains(include))
+                        serverExtraAssemblies.Add(include);
+                }
+            }
+        }
 
         // Should this be an asset pass?
         // For future archaeologists I just want audio rework to work and need the audio pass so

--- a/Content.Packaging/ServerPackaging.cs
+++ b/Content.Packaging/ServerPackaging.cs
@@ -347,7 +347,7 @@ public static class ServerPackaging
         {
             var fileName = Path.GetFileNameWithoutExtension(fullPath);
 
-            if (!ServerNotExtraAssemblies.Any(o => fileName.StartsWith(o)) && ServerExtraAssemblies.Any(o => fileName.StartsWith(o)))
+            if (!ServerNotExtraAssemblies.Any(o => fileName.StartsWith(o)) && serverExtraAssemblies.Any(o => fileName.StartsWith(o)))
             {
                 contentAssemblies.Add(fileName);
             }

--- a/Content.Packaging/ServerPackaging.cs
+++ b/Content.Packaging/ServerPackaging.cs
@@ -232,31 +232,6 @@ public static class ServerPackaging
         return serverModules;
     }
 
-    private static List<string> FindAllServerModules(string path = ".")
-    {
-        var modules = new List<string>(CoreServerContentAssemblies);
-        modules.AddRange(ModuleDiscovery.DiscoverModules(path)
-            .Where(m => m.Type is not ModuleType.Client)
-            .Select(m => m.Name)
-            .Distinct()
-        );
-
-        var directories = Directory.GetDirectories(path, "Content.*");
-        foreach (var dir in directories)
-        {
-            var dirName = Path.GetFileName(dir);
-
-            // Throw out anything that does not end with ".Server" or ".Shared"
-            if ((!dirName.EndsWith(".Server") && !dirName.EndsWith(".Shared")) || modules.Contains(dirName))
-                continue;
-            var projectPath = Path.Combine(dir, $"{dirName}.csproj");
-            if (File.Exists(projectPath))
-                modules.Add(dirName);
-        }
-
-        return modules;
-    }
-
     private static async Task PublishClientServer(string runtime, string targetOs, string configuration)
     {
         await ProcessHelpers.RunCheck(new ProcessStartInfo

--- a/Content.Packaging/ServerPackaging.cs
+++ b/Content.Packaging/ServerPackaging.cs
@@ -79,7 +79,7 @@
 
 using System.Diagnostics;
 using System.IO.Compression;
-using System.Xml.Linq;
+using System.Text.Json;
 using Robust.Packaging;
 using Robust.Packaging.AssetProcessing;
 using Robust.Packaging.AssetProcessing.Passes;
@@ -324,21 +324,28 @@ public static class ServerPackaging
         var sourcePath = Path.Combine(contentDir, "bin", "Content.Server");
 
         var serverExtraAssemblies = new List<string>(ServerExtraAssemblies);
-        var serverProj = XDocument.Load(Path.Combine("Content.Server", "Content.Server.csproj"));
-        if (serverProj.Root is { } root)
+        var dependenciesFile = File.OpenRead(Path.Combine("bin", "Content.Server", "Content.Server.deps.json"));
+        var serverProj = await JsonDocument.ParseAsync(dependenciesFile, cancellationToken: cancel);
+        var targets = serverProj.RootElement.GetProperty("targets");
+        foreach (var target in targets.EnumerateObject())
         {
-            foreach (var group in root.Elements("ItemGroup"))
+            foreach (var project in target.Value.EnumerateObject())
             {
-                foreach (var reference in group.Elements("PackageReference"))
-                {
-                    if (reference.Attribute("Include")?.Value is not { } include)
-                        continue;
+                if (!project.Name.Contains("Content.Server"))
+                    continue;
 
-                    if (!serverExtraAssemblies.Contains(include))
-                        serverExtraAssemblies.Add(include);
+                if (!project.Value.TryGetProperty("dependencies", out var dependencies))
+                    continue;
+
+                foreach (var dependency in dependencies.EnumerateObject())
+                {
+                    var dependencyName = dependency.Name;
+                    if (!serverExtraAssemblies.Contains(dependencyName))
+                        serverExtraAssemblies.Add(dependencyName);
                 }
             }
         }
+        Debugger.Launch();
 
         // Should this be an asset pass?
         // For future archaeologists I just want audio rework to work and need the audio pass so


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
modifica o empactotamento pra resolver o erro do update do server

## Por quê? / Balanceamento
fix pra poder fazer update

## Detalhes Técnicos
~~o problema era o empactomante que é feito no server, o codigo que listava todas as dependencias à serem adicionadas não levava em consideração o caminho de onde os .dll estavam, e assumia que todos estavam na pasta raiz do bin/Content.Server, coisa que não era verdade no .net 10~~

err, n era bem isso (perdão kyoth, acho que sua averigação estava ligeiramente errada). o fix faz com que as dependencias utilizem a feature do nuget de resolver subdependencias (pacotes transitivos), isso faz com que não haja mais necessidade de especifiar onde os arquivos (tais como Microsoft.IO.Redist.dll) estejam. Onde previamente eles utilizavam um caminho hardcoded (que precisaria ser mudado dado a mudança do .net 10) e muitas vezes duplicada

todo o credito ao kyoth que me ajudou a reproduzir, apontar a fonte do erro, e apontar a como resolver.

## Anexos
erro:

<img width="700" height="70" alt="image" src="https://github.com/user-attachments/assets/9407bfef-5455-4d9d-ab6c-86adc13f7a7b" />


## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
no cl