### PR TITLE
Cristal N2O melhorado

### DIFF
--- a/Resources/Prototypes/_Funkystation/Atmospherics/crystallizer.yml
+++ b/Resources/Prototypes/_Funkystation/Atmospherics/crystallizer.yml
@@ -174,9 +174,9 @@
   - 0     # tritium
   - 0     # vapor
   - 0     # miasma
-  - 150   # n2o
+  - 400   # n2o
   - 0     # frezon
-  - 30    # bz
+  - 50    # bz
   - 0     # healium
   - 0     # nitrium
   - 0     # pluox

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/crystals.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/crystals.yml
@@ -77,7 +77,7 @@
     sprite: _Funkystation/Objects/Weapons/Grenades/nitrousoxidecrystal.rsi
   - type: AdjustAirOnTrigger
     gasAdjustments:
-      nitrousoxide: 20
+      nitrousoxide: 300
     range: 1
   - type: EmitSoundOnTrigger
     sound:


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
O cristal de N2O agora libera mais gás e exige quantidade maior de material para criar.

## Por quê? / Balanceamento
Motivo de eu ter aumentado a quantidade de mols liberado foi para justificar a criação dele. Para ter noção esse cristal apenas liberava 20 de N2O e tu gastava cerca de 150 mols para produzir(praticamente para ter efeito tu teria que ativar ele em cima do mesmo tile da pessoa). Agora com essa mudança melhora o uso dele para situação mais diversas e ambientes levemente mais aberto.

## Detalhes Técnicos
Mudanças de yml.
## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl:
- tweak: Alterado liberação de gás do cristal de N2O. Zzz...

