### PR TITLE
mais cristais melhorados!

### DIFF
--- a/Resources/Prototypes/_Funkystation/Atmospherics/crystallizer.yml
+++ b/Resources/Prototypes/_Funkystation/Atmospherics/crystallizer.yml
@@ -74,8 +74,8 @@
     ProtoNitrateCrystal: 1
   dangerous: false
   minimumRequirements:
-  - 80    # oxygen
-  - 80    # nitrogen
+  - 220    # oxygen
+  - 710   # nitrogen
   - 0     # carbon dioxide
   - 0     # plasma
   - 0     # tritium
@@ -89,7 +89,7 @@
   - 0     # pluox
   - 0     # hydrogen
   - 0     # hypernob
-  - 100   # protonitrate
+  - 200   # protonitrate
   - 0     # zauker
   - 0     # halon
   - 0     # helium
@@ -99,7 +99,7 @@
   id: ammoniaCrystalRecipe
   name: Ammonia Crystal
   minimumTemperature: 200
-  maximumTemperature: 240
+  maximumTemperature: 400
   energyRelease: 950000
   products:
     AmmoniaCrystal: 2
@@ -111,14 +111,14 @@
   - 0     # plasma
   - 0     # tritium
   - 0     # vapor
-  - 0     # miasma
+  - 40     # miasma
   - 0     # n2o
   - 0     # frezon
   - 0     # bz
   - 0     # healium
   - 0     # nitrium
   - 0     # pluox
-  - 50    # hydrogen
+  - 0    # hydrogen
   - 0     # hypernob
   - 0     # protonitrate
   - 0     # zauker

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/crystals.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/crystals.yml
@@ -60,7 +60,7 @@
       - 400 # oxygen
       - 1400 # nitrogen
       temperature: 293.15
-  - type: SmokeOnTrigger #Dumont start
+  - type: SmokeOnTrigger
     duration: 8
     spreadAmount: 20
     smokePrototype: Resin

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/crystals.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/crystals.yml
@@ -52,24 +52,35 @@
   components:
   - type: Sprite
     sprite: _Funkystation/Objects/Weapons/Grenades/protonitratecrystal.rsi
-  - type: AdjustAirOnTrigger
-    gasAdjustments:
-      nitrogen: 1420
-      oxygen: 440
-    range: 5
+  - type: ReleaseGasOnTrigger
+    removeFraction: 0.25
+    air:
+      volume: 1000
+      moles: # Target is 3117.84 mols total for filling 30 tiles (goal is 101.325 kPa @ 20C)
+      - 400 # oxygen
+      - 1400 # nitrogen
+      temperature: 293.15
   - type: SmokeOnTrigger #Dumont start
     duration: 8
     spreadAmount: 20
     smokePrototype: Resin
-  - type: EmitSoundOnTrigger #Dumont end
+    keysIn:
+    - timer #Dumont end
+  - type: EmitSoundOnTrigger 
     sound:
-      path: "/Audio/Effects/spray.ogg"
+      path: /Audio/Effects/spray.ogg
+    keysIn:
+    - timer
     positional: true
   - type: DeleteOnTrigger
+    keysIn:
+    - timer
   - type: Appearance
   - type: StaticPrice
     price: 650
   - type: TimerTriggerVisuals
+    primingSound:
+      path: /Audio/Items/smoke_grenade_smoke.ogg
 
 - type: entity
   parent: GrenadeBase

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/crystals.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/crystals.yml
@@ -59,7 +59,7 @@
     range: 5
   - type: SmokeOnTrigger #Dumont start
     duration: 8
-    spreadAmount: 40
+    spreadAmount: 20
     smokePrototype: Resin
   - type: EmitSoundOnTrigger #Dumont end
     sound:

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/crystals.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/crystals.yml
@@ -56,7 +56,7 @@
     removeFraction: 0.25
     air:
       volume: 1000
-      moles: # Target is 3117.84 mols total for filling 30 tiles (goal is 101.325 kPa @ 20C)
+      moles:
       - 400 # oxygen
       - 1400 # nitrogen
       temperature: 293.15

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/crystals.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/crystals.yml
@@ -52,7 +52,7 @@
   components:
   - type: Sprite
     sprite: _Funkystation/Objects/Weapons/Grenades/protonitratecrystal.rsi
-  - type: ReleaseGasOnTrigger
+  - type: ReleaseGasOnTrigger # Dumont edit start
     removeFraction: 0.25
     air:
       volume: 1000

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/crystals.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/crystals.yml
@@ -57,8 +57,8 @@
     air:
       volume: 1000
       moles:
-      - 400 # oxygen
-      - 1400 # nitrogen
+      - 436.8 # oxygen
+      - 1643.2 # nitrogen
       temperature: 293.15
   - type: SmokeOnTrigger
     duration: 8

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/crystals.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/crystals.yml
@@ -11,7 +11,7 @@
     flavors:
     - eggplant
   - type: StaticPrice
-    price: 35
+    price: 200 #Dumont
   - type: Item
     size: Small
   - type: SolutionContainerManager
@@ -54,10 +54,14 @@
     sprite: _Funkystation/Objects/Weapons/Grenades/protonitratecrystal.rsi
   - type: AdjustAirOnTrigger
     gasAdjustments:
-      nitrogen: 80
-      oxygen: 30
+      nitrogen: 1420
+      oxygen: 440
     range: 5
-  - type: EmitSoundOnTrigger
+  - type: SmokeOnTrigger #Dumont start
+    duration: 8
+    spreadAmount: 40
+    smokePrototype: Resin
+  - type: EmitSoundOnTrigger #Dumont end
     sound:
       path: "/Audio/Effects/spray.ogg"
     positional: true
@@ -106,3 +110,4 @@
   - type: Tag
     tags:
     - NoRecharge
+  - type: EmpImmune #Dumont


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
Melhora cristal de energia, amônia e de protonitrate. 

## Por quê? / Balanceamento
Cristal de energia: Agora ele é imune EMP. 
Motivo: Não tinha sentido tu sintetizar o cristal com a maior quantidade de energia do jogo e apenas toda carga desaparecer com apenas EMP.

Cristal de amônia: Preço aumentado.
Motivo: Esse cristal não serve de nada e não pensei o que fazer de legal nele. Ao menos serve para vender agora e aprender sobre funcionamento do Cristalizador.

Cristal de ProtoNitrate: Libera mais gás atmosférico e resina atmosférica.
Motivo: Não tinha motivo para sintetizar por causa da baixa liberação de gás. Agora você pode pressurizar uma grande área e regular temperatura dela.

## Detalhes Técnicos
Mudanças yml pouco dali e de cá... Nada de mais. 

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl:

- tweak: Cristal de energia agora é imune a EMP.
- tweak: Cristal de amônia teve o valor aumentado.
- tweak: Cristal de Proto-Nitrate libera quantidade massiva de O2/N2 padrão de atmosfera e uma espuma reguladora de temperatura.

