### PR TITLE
[FIX] Arruma certas partes do livro guia e regras não aparecendo.

### DIFF
--- a/Content.Client/Guidebook/DocumentParsingManager.static.cs
+++ b/Content.Client/Guidebook/DocumentParsingManager.static.cs
@@ -159,7 +159,7 @@ public sealed partial class DocumentParsingManager
                     }
 
                     msg.Pop();
-                    rt.SetMessage(msg);
+                    rt.SetMessage(msg, tagsAllowed: null);
                     return rt;
                 },
                 TextParser)

--- a/Content.Client/Info/InfoSection.xaml.cs
+++ b/Content.Client/Info/InfoSection.xaml.cs
@@ -27,7 +27,7 @@ public sealed partial class InfoSection : BoxContainer
     {
         TitleLabel.Text = title;
         if (markup)
-            Content.SetMessage(FormattedMessage.FromMarkupOrThrow(text.Trim()));
+            Content.SetMessage(FormattedMessage.FromMarkupOrThrow(text.Trim()), tagsAllowed: null);
         else
             Content.SetMessage(text);
     }

--- a/Content.Client/Info/ServerInfo.cs
+++ b/Content.Client/Info/ServerInfo.cs
@@ -37,7 +37,7 @@ namespace Content.Client.Info
         }
         public void SetInfoBlob(string markup)
         {
-            _richTextLabel.SetMessage(FormattedMessage.FromMarkupOrThrow(markup));
+            _richTextLabel.SetMessage(FormattedMessage.FromMarkupOrThrow(markup), tagsAllowed: null);
         }
     }
 }


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
<!-- O que ela muda? -->
Corrige o bug onde as partes do livro guia com hyperlink não apareciam. Porta a seguinte PR do wizard: https://github.com/space-wizards/space-station-14/pull/42032

## Detalhes técnicos
A Robust laçou uma atualização de segurança em questão dos textos formatados (FormattedMessages), que quebrou esses links. A PR corrige o bug D:

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl: Biel Verdadeiro
- fix: Corrigido bug onde certas partes do livro guia não apareciam.
