### PR TITLE
add: traduz a ação de hail, usada pela máscara de segurança, ciborgue de sec, etc

### DIFF
--- a/Resources/Locale/pt-BR/_Goobstation/actions/clothing.ftl
+++ b/Resources/Locale/pt-BR/_Goobstation/actions/clothing.ftl
@@ -1,0 +1,2 @@
+ent-ActionHailer = Autofalante
+    .desc = Grita ordens para a tripulação por perto. Útil para dar ordens rápidas.

--- a/Resources/Locale/pt-BR/_Goobstation/hailer/hails.ftl
+++ b/Resources/Locale/pt-BR/_Goobstation/hailer/hails.ftl
@@ -1,0 +1,10 @@
+hail-0 = Pare de quebrar a lei, cuzão!!
+hail-1 = Pare ou vai levar cassetada!!
+hail-2 = Pare em nome da lei!!
+hail-3 = Cooperar é do seu melhor interesse!!
+hail-4 = Não se mexa, verme!!
+hail-5 = EU SOU A LEI!!
+hail-6 = No chão, verme!!
+hail-7 = Parado aí, vagabundo!!
+hail-8 = ALTO LÁ! ALTO LÁ! ALTO LÁ!!
+hail-death-to-nt = Morte à NanoTrasen!!


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR

as falas de hail (as chaves hail-*) só existiam em en-US, então quem usa o hailer saía gritando tudo em inglês. isso vale pra máscara de gás da segurança, a da swat, o capacete dreadnought da cybersun e o ciborgue de segurança

traduzido mantendo o tom robocop das originais, EU SOU A LEI incluso, e a fala de emag também. a ação em si também não tinha nome em português, virou Proclamar

## Por quê? / Balanceamento

servidor brasileiro com o borg de sec gritando freeze scumbag não dá. sem mudança de mecânica nenhuma, só texto

## Detalhes Técnicos

o hails.ftl novo em pt-BR/_Goobstation/hailer e a entrada da ação num clothing.ftl novo em pt-BR/_Goobstation/actions, que é onde o prototype dela mora (_Goobstation/Actions/clothing.yml), seguindo o espelhamento que a pasta já usa

o áudio dos ogg continua com a voz em inglês, isso é asset de som e fica pra outro momento, aqui é o texto do chat

## Anexos

<!-- tradução, sem imagem -->

## Requerimentos

- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl:
- add: as falas de hail agora estão em português
