### PR TITLE
feat: arpia agora pode usar sapatos num geral.

### DIFF
--- a/Resources/Prototypes/InventoryTemplates/digitigrade_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/digitigrade_inventory_template.yml
@@ -31,6 +31,16 @@
 - type: inventoryTemplate
   id: digitigrade
   slots:
+    # Dumont-Arpia-Sapato: o DeltaV tirou o slot de sapato do corpo digitígrado inteiro.
+    # aqui a arpia calça, mesmo sabendo que os sprites de sapato não foram desenhados
+    # pra garra e podem desalinhar
+    - name: shoes
+      slotTexture: shoes
+      slotFlags: FEET
+      stripTime: 3
+      uiWindowPos: 1,0
+      strippingWindowPos: 1,3
+      displayName: Shoes
     - name: jumpsuit
       slotTexture: uniform
       slotFlags: INNERCLOTHING


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR

arpia não conseguia calçar sapato nenhum. investigando, não era whitelist nem bloqueio.. o template de inventário digitígrado que o DeltaV deu pra ela simplesmente não tem o slot de sapato, o slot não existia no corpo

devolvido o slot, idêntico ao do template humano, na posição que estava livre no layout

## Por quê? / Balanceamento

decisão de servidor: aqui a arpia calça. o design original do DeltaV é as garras ficarem descalças, e o custo assumido dessa mudança é visual.. os sprites de sapato do jogo não foram desenhados pra perna de garra e podem desalinhar um pouco. testado em jogo e ficou aceitável

sem mudança de mecânica além do slot existir

## Detalhes Técnicos

8 linhas no digitigrade_inventory_template.yml, marcadas com comentário explicando a divergência do DeltaV pra quem for resolver conflito de merge no futuro. só a arpia usa esse template

## Anexos

<!-- se quiser, print da arpia calçada -->

## Requerimentos

- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl:
- fix: arpias agora conseguem calçar sapatos
