### PR TITLE
hotfix: arruma o motd do lobby e a listagem de crimes da space law

### DIFF
--- a/Content.Client/Info/RulesControl.xaml
+++ b/Content.Client/Info/RulesControl.xaml
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 <BoxContainer xmlns="https://spacestation14.io" Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True">
     <Control HorizontalExpand="True" VerticalExpand="True" HorizontalAlignment="Stretch">
         <ScrollContainer Name="Scroll" HScrollEnabled="False" HorizontalExpand="True" VerticalExpand="True">
-            <BoxContainer Name="RulesContainer" VerticalExpand="True" Margin="0 0 5 0"/>
+            <BoxContainer Name="RulesContainer" Orientation="Vertical" VerticalExpand="True" Margin="0 0 5 0"/>
         </ScrollContainer>
         <BoxContainer Margin="0 0 15 0" HorizontalExpand="True" HorizontalAlignment="Right">
             <Button Name="BackButton"

--- a/Content.Client/Info/RulesControl.xaml.cs
+++ b/Content.Client/Info/RulesControl.xaml.cs
@@ -54,16 +54,22 @@ public sealed partial class RulesControl : BoxContainer, ILinkClickHandler
         var coreEntry = UserInterfaceManager.GetUIController<InfoUIController>().GetCoreRuleEntry();
         entry ??= coreEntry;
 
+        var target = entry.Value;
+
         Scroll.SetScrollValue(default);
         RulesContainer.Children.Clear();
-        if (!_parsingMan.TryAddMarkup(RulesContainer, entry.Value))
-            return;
+
+        if (!_parsingMan.TryAddMarkup(RulesContainer, target) && RulesContainer.ChildCount == 0) // Gabystation - regras
+        {
+            target = coreEntry.Id;
+            _parsingMan.TryAddMarkup(RulesContainer, target);
+        }
 
         if (addToPrior && _currentEntry != null)
             _priorEntries.Push(_currentEntry);
-        _currentEntry = entry.Value;
+        _currentEntry = target;
 
-        HomeButton.Visible = entry.Value != coreEntry.Id;
-        BackButton.Visible = _priorEntries.Count != 0 && _priorEntries.Peek() != entry.Value;
+        HomeButton.Visible = target != coreEntry.Id;
+        BackButton.Visible = _priorEntries.Count != 0 && _priorEntries.Peek() != target;
     }
 }

--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -167,6 +167,8 @@ namespace Content.Client.Lobby
 
             UpdateLobbyUi();
 
+            Lobby.MOTDBuletin.RequestMOTD(); // Gabystation - motd
+
             Lobby.CharacterPreview.CharacterSetupButton.OnPressed += OnSetupPressed;
             Lobby.CharacterPreview.PatronPerks.OnPressed += OnPatronPerksPressed;
             Lobby.ManifestButton.OnPressed += OnManifestPressed; // Harmony
@@ -327,7 +329,6 @@ namespace Content.Client.Lobby
 
 
             UpdatePlayerBalance(); // Goobstation - Goob Coin
-            Lobby!.MOTDBuletin.RequestMOTD();
 
             var minutesToday = _playtimeTracking.PlaytimeMinutesToday;
             if (minutesToday > 60)

--- a/Content.Client/Lobby/LobbyUIController.cs
+++ b/Content.Client/Lobby/LobbyUIController.cs
@@ -186,10 +186,11 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
     {
         if (_stateManager.CurrentState is LobbyState lobby)
         {
-            var enabled = _configurationManager.GetCVar(CCVars.MOTDBuletinEnable);
-            lobby.Lobby!.MOTDBuletin.Visible = enabled;
-            if (!enabled)
-                lobby.Lobby!.ShowMOTD.Visible = enabled;
+            if (_configurationManager.GetCVar(CCVars.MOTDBuletinEnable)) // Gabystation - motd
+                return;
+
+            lobby.Lobby!.MOTDBuletin.Visible = false;
+            lobby.Lobby!.ShowMOTD.Visible = false;
         }
     }
 

--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -91,7 +91,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                     <BoxContainer Orientation="Vertical" HorizontalAlignment="Left" VerticalAlignment="Bottom">
                             <Button Name="ShowMOTD" Margin="5 5 5 5" Visible="False" Text="{Loc 'lobby-buletin-motd-title'}"
                                 HorizontalExpand="True" VerticalExpand="True" MinWidth="50" Access="Public" />
-                        <lobbyUi:LobbyBuletin Name="MOTDBuletin" Margin="3 3 3 3" Access="Public"/>
+                        <lobbyUi:LobbyBuletin Name="MOTDBuletin" Margin="3 3 3 3" Visible="False" Access="Public"/>
                         <!-- Gabystation end -->
                         <PanelContainer VerticalAlignment="Bottom" HorizontalAlignment="Left"
                                     Margin="0 75" StyleClasses="AngleRect">

--- a/Content.Server/Motd/MOTDSystem.cs
+++ b/Content.Server/Motd/MOTDSystem.cs
@@ -126,6 +126,9 @@ public sealed class MOTDSystem : EntitySystem
 
     public void ReplyMOTDBuletinRequest(MsgMOTDRequest msg)
     {
+        if (string.IsNullOrEmpty(_messageOfTheDay)) // Gabystation - motd
+            return;
+
         var motdMsg = new MsgMOTD
         {
             MOTD = _messageOfTheDay

--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml
@@ -470,7 +470,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     </ColorBox>
     <ColorBox>
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2" Background="#222222">
-        [textlink="Desacato" link="desacato"]
+        [textlink="Desacato" link="desrespeitoAutoridade"]
       </Box>
     </ColorBox>
     <ColorBox>


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR

o boletim de mensagem do dia aparecia vazio no lobby e voltava sozinho toda vez que eu fechava. e a listagem de crimes da space law tava com o texto todo sobreposto, o desacato nem abria, dava tela branca

## Detalhes Técnicos

o `ReplyMOTDBuletinRequest` respondia mesmo com a mensagem vazia, os outros `TrySendMOTD` do arquivo já tem a guarda de `IsNullOrEmpty`. o voltar sozinho era o `RequestMOTD()` estar dentro do `UpdateLobbyUi()`, que roda a cada pronto/entrada/saida, movi pro `Startup()`

o link do desacato apontava pra um id que não existe, o certo é `desrespeitoAutoridade`. quando arrumei vi que o texto abria torto: os 49 arquivos de crime estão sem `<Document>` e o `RulesContainer` não tinha `Orientation`, e o default do BoxContainer é horizontal. botei vertical no container ao inves de mexer nos 49 arquivos

## Requerimentos
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl:
- fix: Corrigido o boletim de mensagem do dia, que aparecia vazio no lobby e voltava sozinho depois de fechado.
- fix: Corrigida a listagem de crimes da Space Law, que aparecia com o texto sobreposto.
- fix: Corrigido o link do Desacato na Space Law, que abria uma tela em branco.
