### PR TITLE
remover  Loadout Helldivers

### DIFF
--- a/Resources/Prototypes/_Dumont/Loadouts/Jobs/Cargo/leadsalvage.yml
+++ b/Resources/Prototypes/_Dumont/Loadouts/Jobs/Cargo/leadsalvage.yml
@@ -16,21 +16,11 @@
 # Neck
 
 - type: loadout
-  id: ClothingNeckCloakHelldiver
-  equipment:
-    neck: ClothingNeckCloakHelldiver
-
-- type: loadout
   id: ClothingNeckMantleDecoratedSalvager
   equipment:
     neck: ClothingNeckMantleDecoratedSalvager
 
 # PDA
-
-- type: loadout
-  id: HelldiverPDA
-  equipment:
-    id: HelldiverPDA
 
 - type: loadout
   id: SalvageLeadPDA

--- a/Resources/Prototypes/_Dumont/Loadouts/Jobs/Cargo/leadsalvage.yml
+++ b/Resources/Prototypes/_Dumont/Loadouts/Jobs/Cargo/leadsalvage.yml
@@ -15,12 +15,22 @@
 
 # Neck
 
+# - type: loadout
+#   id: ClothingNeckCloakHelldiver
+#   equipment:
+#     neck: ClothingNeckCloakHelldiver
+
 - type: loadout
   id: ClothingNeckMantleDecoratedSalvager
   equipment:
     neck: ClothingNeckMantleDecoratedSalvager
 
 # PDA
+
+# - type: loadout
+#   id: HelldiverPDA
+#   equipment:
+#     id: HelldiverPDA
 
 - type: loadout
   id: SalvageLeadPDA

--- a/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
@@ -11,7 +11,6 @@
   id: SalvageLeadNeck
   name: loadout-group-salvage-lead-mantle
   loadouts:
-    - ClothingNeckCloakHelldiver
     - ClothingNeckMantleDecoratedSalvager
 
 - type: loadoutGroup
@@ -19,4 +18,3 @@
   name: loadout-group-salvagelead-id
   loadouts:
     - SalvageLeadPDA
-    - HelldiverPDA

--- a/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
@@ -11,6 +11,7 @@
   id: SalvageLeadNeck
   name: loadout-group-salvage-lead-mantle
   loadouts:
+#    - ClothingNeckCloakHelldiver
     - ClothingNeckMantleDecoratedSalvager
 
 - type: loadoutGroup
@@ -18,3 +19,5 @@
   name: loadout-group-salvagelead-id
   loadouts:
     - SalvageLeadPDA
+#    - HelldiverPDA
+


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
Como foi pedido pelo CRISO, decidi fazer essa modificação no loadout do lider de expedição

## Por quê? / Balanceamento
Acredito que os itens tematizados com Helldivers não se encaixem com a atmosfera do servidor

## Detalhes Técnicos
Apenas foram removidas as linhas que continham menções do helldivers

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [ ] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl: SukitaBR
- remove: Loadout do Helldivers do Lider de expedição

