### PR TITLE
Interface fantasma - Ajustes e etc

### DIFF
--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
@@ -440,7 +440,7 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
 
         private void PlayersAllocation()
         {
-            _alivePlayers = _playerWarps.Where(warp => warp.IsAlive).ToList();
+            _alivePlayers = _playerWarps.Where(warp => warp.IsAlive && !warp.IsLeft).ToList();
             _deadPlayers = _playerWarps.Where(warp => warp.IsDead).ToList();
             _leftPlayers = _playerWarps.Where(warp => warp.IsLeft).ToList();
             _ghostPlayers = _playerWarps.Where(warp => warp.IsGhost).ToList();


### PR DESCRIPTION
## Sobre a PR
Agora catatônicos não aparecem na lista de vivos da interface fantasma.

## Por quê? / Balanceamento
Menos poluição, eles já tem uma aba própria e confundia muito qual bitrunner era o ativo.

## Anexos
"-"

## Requerimentos
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl:
- tweak: Agora catatônicos não aparecem na lista de vivos da interface fantasma.
