### PR TITLE
Desativa Hostage Ops

### DIFF
--- a/Resources/Prototypes/_DV/Objectives/nukies.yml
+++ b/Resources/Prototypes/_DV/Objectives/nukies.yml
@@ -4,7 +4,7 @@
   id: NukieOperations
   weights:
     NukieOperationDestroyStation: 1
-    NukieOperationKidnapHeads: 1
+    NukieOperationKidnapHeads: 0 # Dumont - Objetivo de hostage ops Retirado da rotação.
 
 - type: nukieOperation
   id: NukieOperationDestroyStation


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
Desativa o objetivo de Hostage Ops para nukies

## Por quê? / Balanceamento
Não combina muito bem com a ideia de nukie ops, os jogadores se confundem muito por causa disso e acabam perdendo.
Jogar de hostage ops é derrota certeira atualmente, devido a grande dificuldade que existe em encontrar heads e leva-los inteiros para a base nukie, sem contar que o objetivo sempre pede bastante heads para sequestrar.
No geral, me parece um objetivo mais de acordo com um fireteam do que os terroristas nucleares que conhecemos.

## Detalhes Técnicos

weights:
    NukieOperationDestroyStation: 1
    NukieOperationKidnapHeads: 1 -> 0

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl:
- remove: O objetivo de sequestrar heads foi desativado da rotação dos nuke ops.
