### PR TITLE
Aumenta o preço do Sandevistan

### DIFF
--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -1131,7 +1131,7 @@
   icon: { sprite: _Goobstation/Objects/Misc/sandevistan.rsi, state: icon }
   productEntity: AutosurgeonSandevistan
   cost:
-    Telecrystal: 124
+    Telecrystal: 324
   categories:
   - UplinkImplants
   conditions:


### PR DESCRIPTION
## Sobre a PR
Aumenta o preço em 200 TC a mais para usar o Sandevistan

## Por quê? / Balanceamento
Originalmente era pra ser uma remoção, mas, decidi aumentar o preço.

O Sandevistan é um item problematico por inumeors motivos, pois combando ele com qualquer arma meele, te faz vencer de qualquer coisa normal do jogo, o que inclui mechas e esquadrões ERT, sozinho, desde que tenha cura pra se manter.

Além disso, ele torna a gameplay tóxica, visto que o nuke pode arma a bomba e simplesmente ficar batendo e correndo em quem tenta desarmar a bomba.

No geral, o Sandevistan por si só, é um item coringa. Ele estava garatindo a vitória facilmente, por um preço baixo, coisa que não acontencia com outras builds para nukes.

## Detalhes Técnicos
só yaml e apenas no de nuke, preço pra traidor fica normal.

## Anexos
<img width="301" height="294" alt="image" src="https://github.com/user-attachments/assets/275fa1f6-09a3-4ebf-b5cf-05a2b0929682" />

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl: Struater
- tweak: Altera o preço do Sandevistan

